### PR TITLE
adding initialization check for getService and hasService

### DIFF
--- a/xacc/XACC.hpp
+++ b/xacc/XACC.hpp
@@ -233,6 +233,11 @@ bool hasCompiler(const std::string& name);
 
 template<typename Service>
 std::shared_ptr<Service> getService(const std::string& serviceName) {
+	if (!xacc::xaccFrameworkInitialized) {
+		error(
+				"XACC not initialized before use. Please execute "
+				"xacc::Initialize() before using API.");
+	}
 	auto service = serviceRegistry->getService<Service>(
 			serviceName);
 	if (!service) {
@@ -245,6 +250,11 @@ std::shared_ptr<Service> getService(const std::string& serviceName) {
 
 template<typename Service>
 bool hasService(const std::string& serviceName) {
+	if (!xacc::xaccFrameworkInitialized) {
+		error(
+				"XACC not initialized before use. Please execute "
+				"xacc::Initialize() before using API.");
+	}
 	return serviceRegistry->hasService<Service>(
 			serviceName);
 }


### PR DESCRIPTION
Now, attempting to use the XACC Python API without XACC initialization will cause an XACC Error message.
Signed-off-by: Zachary Parks <1zp@ornl.gov>