### PR TITLE
Fix for template issue to fix build error on macOS with clang

### DIFF
--- a/quantum/gate/utils/JsonVisitor.cpp
+++ b/quantum/gate/utils/JsonVisitor.cpp
@@ -81,13 +81,13 @@ template <class W, class B> std::string JsonVisitor<W, B>::write() {
       auto p = kv.second;
       switch (p.which()) {
     case 0:
-      writer->Int(p.as<int>());
+      writer->Int(p.template as<int>());
       break;
     case 1:
-      writer->Double(p.as<double>());
+      writer->Double(p.template as<double>());
       break;
     case 2:
-      writer->String(p.as<std::string>());
+      writer->String(p.template as<std::string>());
       break;
     default:
       writer->String(p.toString());


### PR DESCRIPTION
Trying to build master on macOS Mojave with clang (Apple LLVM version 10.0.1 (clang-1001.0.46.4)). Using configure command

```
cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DXACC_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DCMAKE_C_COMPILER=/usr/bin/cc ../
```

Gives error `error: use 'template' keyword to treat 'as' as a dependent`  on lines 84, 87 and 90 of JsonVisitor.cpp.

This patch allows xacc to be built successfully. However a number of the tests are failing (see output below), but believe this could be unrelated.

```
The following tests FAILED:
          7 - xacc_PauliOperatorTester (Child aborted)
          8 - xacc_FermionOperatorTester (Child aborted)
          9 - xacc_JWTester (Child aborted)
         32 - xacc_ImprovedSamplingDecoratorTester (SEGFAULT)
         34 - xacc_ROErrorDecoratorTester (Child aborted)
         39 - xacc_OQASMCompilerTester (Child aborted)
         40 - xacc_QObjectCompilerTester (Child aborted)
         41 - xacc_QObjectTester (Child aborted)
         42 - xacc_QVMAcceleratorTester (Child aborted)
         43 - xacc_QuilCompilerTester (Child aborted)
         44 - xacc_QuilVisitorTester (Child aborted)
         45 - xacc_DWAcceleratorTester (Child aborted)
         46 - xacc_DWQMICompilerTester (Child aborted)
         47 - xacc_AnnealScheduleGeneratorTester (Child aborted)
```

Signed-off-by: Niall Moran <niall.moran@ichec.ie>