### PR TITLE
Fix some compatibility  issues

### DIFF
--- a/quantum/plugins/algorithms/qpt/qpt.hpp
+++ b/quantum/plugins/algorithms/qpt/qpt.hpp
@@ -21,7 +21,7 @@ class QPT : public Algorithm {
   CompositeInstruction *circuit;
   Accelerator *qpu;
   std::vector<int> qubit_map;
-  
+  bool optimizeCircuit;
 public:
   bool initialize(const HeterogeneousMap &parameters) override;
   const std::vector<std::string> requiredParameters() const override;

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -99,5 +99,6 @@ public:
   virtual ~Accelerator() {}
 };
 
+template Accelerator* HeterogeneousMap::getPointerLike<Accelerator>(const std::string key) const;
 } // namespace xacc
 #endif

--- a/xacc/ir/CompositeInstruction.hpp
+++ b/xacc/ir/CompositeInstruction.hpp
@@ -131,5 +131,6 @@ public:
   virtual ~CompositeInstruction() {}
 };
 
+template CompositeInstruction* HeterogeneousMap::getPointerLike<CompositeInstruction>(const std::string key) const;
 } // namespace xacc
 #endif

--- a/xacc/utils/heterogeneous.hpp
+++ b/xacc/utils/heterogeneous.hpp
@@ -250,6 +250,11 @@ template <class T>
 std::unordered_map<const HeterogeneousMap *, std::map<std::string, T>>
     HeterogeneousMap::items;
 
+// Make sure these basic types are always instantiatied for HeterogeneousMap
+template const bool& HeterogeneousMap::get<bool>(const std::string key) const;
+template const int& HeterogeneousMap::get<int>(const std::string key) const;
+template const double& HeterogeneousMap::get<double>(const std::string key) const;
+
 template <typename... Types> class Variant : public mpark::variant<Types...> {
 
 private:


### PR DESCRIPTION
Testing QPT with QuaC, I was puzzled by the fact that `getPointerLike<Accelerator>` and `getPointerLike<CompositeInstruction>` were failing although I *did* send on those two parameters and the heterogenous map *does* contain those params, just that the templated functions are mismatched (possibly between the QuaC side and XACC side)

My theory was that because these are all implicit instantiations, somehow, they can become mismatched (the order in which the compiler sees those instantiations), especially with external linkage (like QuaC).

Anyway, by explicitly instantiating those (Accelerator and Composite), the issue is fixed.

Also, fix a bug in QPT where the imaginary chi vector is always uninitialized (all zeros)

Lastly, add an option to QPT to disable circuit optimization. When the circuit contains pulse instructions, the circuit optimizer doesn’t work correctly (looks like it may skip the pulse instruction and merge gates)

Tested by: running XACC tests and QuaC QPT tests.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>