### PR TITLE
Expose Accelerator::contributeInstructions method to Python

### DIFF
--- a/python/py_accelerator.cpp
+++ b/python/py_accelerator.cpp
@@ -49,7 +49,8 @@ void bind_accelerator(py::module &m) {
                xacc::Accelerator::updateConfiguration,
            "")
       .def("getConnectivity", &xacc::Accelerator::getConnectivity, "")
-      .def("configurationKeys", &xacc::Accelerator::configurationKeys, "");
+      .def("configurationKeys", &xacc::Accelerator::configurationKeys, "")
+      .def("contributeInstructions", &xacc::Accelerator::contributeInstructions, "");
 
   py::class_<xacc::AcceleratorDecorator, xacc::Accelerator,
              std::shared_ptr<xacc::AcceleratorDecorator>>

--- a/python/py_accelerator.hpp
+++ b/python/py_accelerator.hpp
@@ -68,7 +68,9 @@ public:
                            configurationKeys)
   }
 
-
+  void contributeInstructions(const std::string& custom_json_config) override {
+    PYBIND11_OVERLOAD(void, xacc::Accelerator, contributeInstructions, custom_json_config);
+  }
 
 };
 


### PR DESCRIPTION
This allows users to load pulse and cmd-def JSON from the Python shell.

Tested by: using the binding from Python (with QuaC Python)

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>