### PR TITLE
Added a *safe* import of QuaC python plugin

### DIFF
--- a/python/xacc.py
+++ b/python/xacc.py
@@ -447,6 +447,12 @@ def main(argv=None):
 
 initialize()
 
+try:
+    from _pyquaC import *
+except ImportError:
+    # Nothing, QuaC is not available
+    pass
+
 loaded_from_cpp_dont_finalize = False
 
 def _finalize():


### PR DESCRIPTION
If it exists (build and install QuaC) then import, otherwise, skip.
Those functions that _pyquaC exports will be available in the XACC namespace as regular _pyxacc

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>