### PR TITLE
Tnguyen/qpp new gates

### DIFF
--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -31,7 +31,7 @@ namespace {
     {
         qpp::cmat gateMat(4, 4);  
         gateMat << 
-        1.0, 0.0, 0.0 , 0.0 ,
+        1.0, 0.0, 0.0, 0.0,
         0.0, std::cos(in_theta), std::complex<double>(0, -std::sin(in_theta)), 0.0,
         0.0, std::complex<double>(0, -std::sin(in_theta)), std::cos(in_theta), 0.0,
         0.0, 0.0, 0.0, std::exp(std::complex<double>(0, -in_phi));
@@ -245,7 +245,6 @@ namespace quantum {
         const auto phi = InstructionParameterToDouble(in_fsimGate.getParameter(1));
         m_stateVec = qpp::apply(m_stateVec, fSimGateMat(theta, phi), { qIdx1, qIdx2 });
     }
-
 
     void QppVisitor::visit(Measure& measure)
     {

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -14,6 +14,32 @@
 #include "QppVisitor.hpp"
 #include "xacc.hpp"
 
+namespace {
+    // Add gate matrix for iSwap and fSim gates
+    qpp::cmat iSwapGateMat()
+    {
+        qpp::cmat gateMat(4, 4);  
+        gateMat << 1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, std::complex<double>(0, 1.0), 0.0,
+        0.0, std::complex<double>(0, 1.0), 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0;
+        
+        return gateMat; 
+    }
+
+    qpp::cmat fSimGateMat(double in_theta, double in_phi)
+    {
+        qpp::cmat gateMat(4, 4);  
+        gateMat << 
+        1.0, 0.0, 0.0 , 0.0 ,
+        0.0, std::cos(in_theta), std::complex<double>(0, -std::sin(in_theta)), 0.0,
+        0.0, std::complex<double>(0, -std::sin(in_theta)), std::cos(in_theta), 0.0,
+        0.0, 0.0, 0.0, std::exp(std::complex<double>(0, -in_phi));
+        
+        return gateMat; 
+    }
+}
+
 namespace xacc {
 namespace quantum {
     void QppVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, bool shotsMode)
@@ -202,6 +228,24 @@ namespace quantum {
         const auto uMat =  qpp::Gates::get_instance().RZ(lambda) * qpp::Gates::get_instance().RY(phi) * qpp::Gates::get_instance().RZ(theta);
         m_stateVec = qpp::apply(m_stateVec, uMat, { qubitIdx });
     }
+
+    void QppVisitor::visit(iSwap& in_iSwapGate) 
+    {
+        const auto qIdx1 = xaccIdxToQppIdx(in_iSwapGate.bits()[0]);
+        const auto qIdx2 = xaccIdxToQppIdx(in_iSwapGate.bits()[1]);
+
+        m_stateVec = qpp::apply(m_stateVec, iSwapGateMat(), { qIdx1, qIdx2 });
+    }
+
+    void QppVisitor::visit(fSim& in_fsimGate) 
+    {
+        const auto qIdx1 = xaccIdxToQppIdx(in_fsimGate.bits()[0]);
+        const auto qIdx2 = xaccIdxToQppIdx(in_fsimGate.bits()[1]);
+        const auto theta = InstructionParameterToDouble(in_fsimGate.getParameter(0));
+        const auto phi = InstructionParameterToDouble(in_fsimGate.getParameter(1));
+        m_stateVec = qpp::apply(m_stateVec, fSimGateMat(theta, phi), { qIdx1, qIdx2 });
+    }
+
 
     void QppVisitor::visit(Measure& measure)
     {

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -50,7 +50,9 @@ public:
   void visit(Identity& i) override;
   void visit(U& u) override;
   void visit(IfStmt& ifStmt) override;
-
+  void visit(iSwap& in_iSwapGate) override;
+  void visit(fSim& in_fsimGate) override;
+  
   virtual std::shared_ptr<QppVisitor> clone() { return std::make_shared<QppVisitor>(); }
 
 private:


### PR DESCRIPTION
Added `fSim(theta,phi)` and `iSwap` gates to the visitor implementation of the Qpp Accelerator plugin.