### PR TITLE
Fixed CPhase gate def

### DIFF
--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -387,7 +387,7 @@ public:
       : Gate("CPhase", qbits,
              std::vector<InstructionParameter>{InstructionParameter(0.0)}) {}
 
-  const int nRequiredBits() const override { return 1; }
+  const int nRequiredBits() const override { return 2; }
 
   DEFINE_CLONE(CPhase)
   DEFINE_VISITABLE()


### PR DESCRIPTION
nRequiredBits should be 2. This cause the XASM compiler to reject valid expressions, e.g. CPhase(q[0], q[1], 3.14).

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>