### PR TITLE
Changes to the benchmark suite

### DIFF
--- a/python/benchmark/chemistry/chemistry_benchmark.py
+++ b/python/benchmark/chemistry/chemistry_benchmark.py
@@ -28,7 +28,7 @@ class Chemistry(Benchmark):
 
         if 'Ansatz' not in inputParams:
             xacc.error('Invalid benchmark input - must have Ansatz circuit description')
-            
+
         H = None
         if inputParams['Observable']['name'] == 'pauli':
             obs_str = inputParams['Observable']['obs_str']
@@ -36,14 +36,12 @@ class Chemistry(Benchmark):
         elif inputParams['Observable']['name'] == 'fermion':
             obs_str = inputParams['Observable']['obs_str']
             H = xacc.getObservable('fermion', obs_str)
-
         elif inputParams['Observable']['name'] == 'psi4':
             opts = {'basis':inputParams['Observable']['basis'], 'geometry':inputParams['Observable']['geometry']}
             if 'fo' in inputParams['Observable'] and 'ao' in inputParams['Observable']:
                 opts['frozen-spin-orbitals'] = ast.literal_eval(inputParams['Observable']['fo'])
                 opts['active-spin-orbitals'] = ast.literal_eval(inputParams['Observable']['ao'])
             H = xacc.getObservable('psi4', opts)
-            
         elif inputParams['Observable']['name'] == 'pyscf':
             opts = {'basis':inputParams['Observable']['basis'], 'geometry':inputParams['Observable']['geometry']}
             if 'fo' in inputParams['Observable'] and 'ao' in inputParams['Observable']:
@@ -80,11 +78,8 @@ class Chemistry(Benchmark):
             optimizer = xacc.getOptimizer('nlopt')
 
         provider = xacc.getIRProvider('quantum')
-        
-        
-        # Added adapt-vqe with new keywords
+
         if inputParams['Benchmark']['algorithm'] == 'adapt-vqe':
-            
             alg = xacc.getAlgorithm(inputParams['Benchmark']['algorithm'], {
                                     'pool' : inputParams['Ansatz']['pool'],
                                     'nElectrons' : int(inputParams['Ansatz']['electrons']),
@@ -95,8 +90,9 @@ class Chemistry(Benchmark):
 
             alg.execute(buffer)
             return buffer
+        
+        else: 
             
-        else:
             if 'source' in inputParams['Ansatz']:
                 # here assume this is xasm always
                 src = inputParams['Ansatz']['source']
@@ -119,8 +115,7 @@ class Chemistry(Benchmark):
                                     })
 
             alg.execute(buffer)
-            return (buffer)
-
+            return buffer
 
     def analyze(self, buffer, inputParams):
 
@@ -143,7 +138,6 @@ class Chemistry(Benchmark):
             buffer.addExtraInfo('readout-corrected-energy', ro_energies[int(min_index)])
             print('Readout Energy = ', ro_energies[int(min_index)])
             print('Optimal Parameters =', uniqueParams[int(min_index)])
-        
-            print('Energy = ', buffer['opt-val'])
-            print('Opt Params = ', buffer['opt-params'])
 
+        print('Energy = ', buffer['opt-val'])
+        print('Opt Params = ', buffer['opt-params'])

--- a/python/plugins/observables/pyscf_observable.py
+++ b/python/plugins/observables/pyscf_observable.py
@@ -35,6 +35,7 @@ class PySCFObservable(xacc.Observable):
         mol = gto.mole.Mole()
         mol.atom = inputParams['geometry']
         mol.basis = inputParams['basis']
+        mol.build()
         scf_wfn = scf.RHF(mol) # needs to be changed for open-shells
         scf_wfn.conv_tol = 1e-8
         scf_wfn.kernel() # runs RHF calculations

--- a/python/xacc.py
+++ b/python/xacc.py
@@ -406,10 +406,19 @@ def benchmark(xacc_settings):
 
     results_name = "%s_%s_out" % (os.path.splitext(
         tail)[0], timestr)
-    f = open(results_name+".ab", 'w')
-    f.write(str(buffer))
-    f.close()
+    
+    if 'output_logs' not in xacc_settings['Benchmark']:
+            xacc_settings['Benchmark']['output_logs'] = False
+            
+    if xacc_settings['Benchmark']['output_logs'] == True:
+        f = open(results_name+".ab", 'w')
+        f.write(str(buffer))
+        f.close()
+    
+    else:
+        pass
 
+    return buffer
 def benchmark_from_cmd_line(opts):
     if opts.benchmark is not None:
         inputfile = opts.benchmark


### PR DESCRIPTION
Added a toggle to the output logs generated by the benchmark suite. The default is no output log. Also added a return statement for the buffer, so you can interact with the data after running the suite. (xacc.py)

Fixed an initialization issue with the pyscf observable (pyscf_observable.py)

Added pyscf and adapt-vqe and its keywords to the benchmark suite (chemistry_benchmark.py)