### PR TITLE
Changes to the Benchmark Suite #2 

### DIFF
--- a/python/benchmark/chemistry/chemistry_benchmark.py
+++ b/python/benchmark/chemistry/chemistry_benchmark.py
@@ -36,18 +36,12 @@ class Chemistry(Benchmark):
         elif inputParams['Observable']['name'] == 'fermion':
             obs_str = inputParams['Observable']['obs_str']
             H = xacc.getObservable('fermion', obs_str)
-        elif inputParams['Observable']['name'] == 'psi4':
+        elif inputParams['Observable']['name'] in ['pyscf','psi4']:
             opts = {'basis':inputParams['Observable']['basis'], 'geometry':inputParams['Observable']['geometry']}
             if 'fo' in inputParams['Observable'] and 'ao' in inputParams['Observable']:
                 opts['frozen-spin-orbitals'] = ast.literal_eval(inputParams['Observable']['fo'])
                 opts['active-spin-orbitals'] = ast.literal_eval(inputParams['Observable']['ao'])
-            H = xacc.getObservable('psi4', opts)
-        elif inputParams['Observable']['name'] == 'pyscf':
-            opts = {'basis':inputParams['Observable']['basis'], 'geometry':inputParams['Observable']['geometry']}
-            if 'fo' in inputParams['Observable'] and 'ao' in inputParams['Observable']:
-                opts['frozen-spin-orbitals'] = ast.literal_eval(inputParams['Observable']['fo'])
-                opts['active-spin-orbitals'] = ast.literal_eval(inputParams['Observable']['ao'])
-            H = xacc.getObservable('pyscf', opts)
+            H = xacc.getObservable(inputParams['Observable']['name'], opts)
 
         #print('Ham: ', H.toString())
         qpu = xacc.getAccelerator(acc_name, xacc_opts)

--- a/python/plugins/observables/pyscf_observable.py
+++ b/python/plugins/observables/pyscf_observable.py
@@ -35,6 +35,7 @@ class PySCFObservable(xacc.Observable):
         mol = gto.mole.Mole()
         mol.atom = inputParams['geometry']
         mol.basis = inputParams['basis']
+        mol.build()
         scf_wfn = scf.RHF(mol) # needs to be changed for open-shells
         scf_wfn.conv_tol = 1e-8
         scf_wfn.kernel() # runs RHF calculations

--- a/python/xacc.py
+++ b/python/xacc.py
@@ -406,9 +406,19 @@ def benchmark(xacc_settings):
 
     results_name = "%s_%s_out" % (os.path.splitext(
         tail)[0], timestr)
-    f = open(results_name+".ab", 'w')
-    f.write(str(buffer))
-    f.close()
+    
+    if 'output_logs' not in xacc_settings['Benchmark']:
+            xacc_settings['Benchmark']['output_logs'] = False
+            
+    if xacc_settings['Benchmark']['output_logs'] == True:
+        f = open(results_name+".ab", 'w')
+        f.write(str(buffer))
+        f.close()
+    
+    else:
+        pass
+
+    return buffer
 
 def benchmark_from_cmd_line(opts):
     if opts.benchmark is not None:

--- a/python/xacc.py
+++ b/python/xacc.py
@@ -408,7 +408,7 @@ def benchmark(xacc_settings):
         tail)[0], timestr)
     
     if 'output_logs' not in xacc_settings['Benchmark']:
-            xacc_settings['Benchmark']['output_logs'] = False
+            xacc_settings['Benchmark']['output_logs'] = True
             
     if xacc_settings['Benchmark']['output_logs'] == True:
         f = open(results_name+".ab", 'w')


### PR DESCRIPTION
Signed-off-by: Jerimiah <Jerimiah.wright@utexas.edu>

Added a toggle to the output logs generated by the benchmark suite. The default is no output log. Also added a return statement for the buffer, so you can interact with the data after running the suite. (xacc.py)

Fixed an initialization issue with the pyscf observable (pyscf_observable.py)

Added pyscf and adapt-vqe and its keywords to the benchmark suite (chemistry_benchmark.py)