### PR TITLE
Fixed exp-val-z calculation for the Qpp Accelerator

### DIFF
--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -72,7 +72,7 @@ namespace quantum {
         return m_buffer->size() - in_idx - 1;
     }
 
-    double QppVisitor::calcExpectationValueZ() const
+    double QppVisitor::calcExpectationValueZ(const KetVectorType& in_stateVec, const std::vector<qpp::idx>& in_bits)
     {
         const auto hasEvenParity = [](size_t x, const std::vector<size_t>& in_qubitIndices) -> bool {
             size_t count = 0;
@@ -88,9 +88,9 @@ namespace quantum {
 
 
         double result = 0.0;
-        for(uint64_t i = 0; i < m_stateVec.size(); ++i)
+        for(uint64_t i = 0; i < in_stateVec.size(); ++i)
         {
-            result += (hasEvenParity(i, m_measureBits) ? 1.0 : -1.0) * std::norm(m_stateVec[i]);
+            result += (hasEvenParity(i, in_bits) ? 1.0 : -1.0) * std::norm(in_stateVec[i]);
         }
 
         return result;
@@ -270,7 +270,7 @@ namespace quantum {
         if (!m_shotsMode)
         {
             // Not running a shot simulation, calculate the expectation value.
-            const double expectedValueZ = calcExpectationValueZ();
+            const double expectedValueZ = calcExpectationValueZ(m_stateVec, m_measureBits);
             m_buffer->addExtraInfo("exp-val-z", expectedValueZ);
         }
         else

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -55,9 +55,9 @@ public:
   
   virtual std::shared_ptr<QppVisitor> clone() { return std::make_shared<QppVisitor>(); }
   const KetVectorType& getStateVec() const { return m_stateVec; }
+  static double calcExpectationValueZ(const KetVectorType& in_stateVec, const std::vector<qpp::idx>& in_bits);
 private:
   qpp::idx xaccIdxToQppIdx(size_t in_idx) const;
-  double calcExpectationValueZ() const;
 private:
   std::shared_ptr<AcceleratorBuffer> m_buffer;  
   std::vector<qpp::idx> m_dims;


### PR DESCRIPTION
Swapping the order of conditional check so that in we can further optimize for the case where there is no If statements in the circuit nor shots; in that case, calculate expectation analytically.

Also, fixed a potential bug whereby the shots count may not be reset if using the accelerator multiple times.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>