### PR TITLE
Added file logging and util timer

### DIFF
--- a/xacc/utils/Utils.cpp
+++ b/xacc/utils/Utils.cpp
@@ -270,6 +270,17 @@ void XACCLogger::setLoggingLevel(int level) {
   }
 }
 
+int XACCLogger::getLoggingLevel() {
+  const auto spdLevel = getLogger()->level();
+  switch (spdLevel) {
+  case spdlog::level::trace:
+  case spdlog::level::debug: return 2;
+  case spdlog::level::info: return 1;
+  default:
+    return 0;
+  }
+}
+
 void XACCLogger::info(const std::string &msg, MessagePredicate predicate) {
   if (useCout) {
     if (predicate() && globalPredicate()) {

--- a/xacc/utils/Utils.cpp
+++ b/xacc/utils/Utils.cpp
@@ -310,4 +310,25 @@ void XACCLogger::error(const std::string &msg, MessagePredicate predicate) {
   }
 }
 
+ScopeTimer::ScopeTimer(const std::string& scopeName, bool shouldLog):
+  m_startTime(std::chrono::system_clock::now()),
+  m_shouldLog(shouldLog),
+  m_scopeName(scopeName)
+  {
+    if (m_shouldLog) {
+      XACCLogger::instance()->info("'" + scopeName + "' started.");
+    }
+  }
+
+double ScopeTimer::getDurationMs() const {
+  return static_cast<double>(
+    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - m_startTime).count()/1000.0);
+}
+
+ScopeTimer::~ScopeTimer() {
+  const double elapsedTime = getDurationMs();
+  if (m_shouldLog) {
+    XACCLogger::instance()->info("'" + m_scopeName + "' finished [" + std::to_string(elapsedTime) + " ms].");
+  }
+}
 } // namespace xacc

--- a/xacc/utils/Utils.hpp
+++ b/xacc/utils/Utils.hpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <algorithm>
 #include <map>
+#include <chrono>
 
 namespace spdlog {
 class logger;
@@ -232,6 +233,40 @@ template <typename T> std::vector<T> linspace(T a, T b, size_t N) {
     *x = val;
   return xs;
 }
+
+// Util timer to log execution elapsed time of a scope block.
+// Example usage:
+// (1) Time a function body:
+/* 
+void slowFunc {
+  // Use __FUNCTION__ macro to get the function name 
+  // Can use a custom string as well
+  ScopeTimer timer(__FUNCTION__);
+  .... code
+}
+*/
+// The above timer will log when the function starts and ends (with elapsed time).
+// (2) Time a code block, including function calls
+/* 
+ ... irrelevant code
+ // Create a scope block:
+ {
+  ScopeTimer timer("human readable name of this block");
+  .... code
+ }
+  ... irrelevant code
+*/
+// This will log the timing data of that specific code block.
+class ScopeTimer {
+public:
+  ScopeTimer(const std::string& scopeName, bool shouldLog = true);
+  double getDurationMs() const;
+  ~ScopeTimer();
+private:
+  std::chrono::time_point<std::chrono::system_clock> m_startTime;
+  bool m_shouldLog;
+  std::string m_scopeName;
+};
 
 // container helper
 namespace container {

--- a/xacc/utils/Utils.hpp
+++ b/xacc/utils/Utils.hpp
@@ -201,7 +201,8 @@ public:
   // 2: Debug and above
   // Note: this will only take effect when xacc::verbose is set.
   void setLoggingLevel(int level);
-
+  int getLoggingLevel();
+  
   void subscribeLoggingLevel(LoggingLevelNotification onLevelChangeFn) { 
     loggingLevelSubscribers.emplace_back(onLevelChangeFn);
   }

--- a/xacc/utils/Utils.hpp
+++ b/xacc/utils/Utils.hpp
@@ -167,7 +167,19 @@ protected:
 
   XACCLogger();
   
-  std::shared_ptr<spdlog::logger> getLogger() { return useFile ? fileLogger : stdOutLogger; }
+  std::shared_ptr<spdlog::logger> getLogger() { 
+    static bool fileLoggerUsed = false;
+    if (!fileLoggerUsed && useFile) {
+      createFileLogger();
+      fileLoggerUsed = true;
+    }
+
+    return useFile ? fileLogger : stdOutLogger; 
+  }
+
+  // On-demand create a file logger:
+  // We don't want to create one if not being used.
+  void createFileLogger();
 
 public:
   // Overriding here so we can have a custom constructor

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -111,6 +111,18 @@ void setGlobalLoggerPredicate(MessagePredicate predicate) {
   XACCLogger::instance()->dumpQueue();
 }
 
+void logToFile(bool enable) {
+  XACCLogger::instance()->logToFile(enable);
+}
+
+void setLoggingLevel(int level) {
+  XACCLogger::instance()->setLoggingLevel(level);
+}
+
+void subscribeLoggingLevel(LoggingLevelNotification callback) {
+  XACCLogger::instance()->subscribeLoggingLevel(callback);
+}
+
 void info(const std::string &msg, MessagePredicate predicate) {
   if (verbose) XACCLogger::instance()->info(msg, predicate);
 }

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -119,6 +119,10 @@ void setLoggingLevel(int level) {
   XACCLogger::instance()->setLoggingLevel(level);
 }
 
+int getLoggingLevel() {
+  return XACCLogger::instance()->getLoggingLevel();
+}
+
 void subscribeLoggingLevel(LoggingLevelNotification callback) {
   XACCLogger::instance()->subscribeLoggingLevel(callback);
 }

--- a/xacc/xacc.hpp
+++ b/xacc/xacc.hpp
@@ -95,6 +95,10 @@ void addCommandLineOptions(const std::string &category,
 void addCommandLineOptions(const std::map<std::string, std::string> &options);
 
 void setGlobalLoggerPredicate(MessagePredicate predicate);
+void logToFile(bool enable);
+void setLoggingLevel(int level);
+void subscribeLoggingLevel(LoggingLevelNotification callback);
+
 void info(const std::string &msg,
           MessagePredicate predicate = std::function<bool(void)>([]() {
             return true;

--- a/xacc/xacc.hpp
+++ b/xacc/xacc.hpp
@@ -97,6 +97,7 @@ void addCommandLineOptions(const std::map<std::string, std::string> &options);
 void setGlobalLoggerPredicate(MessagePredicate predicate);
 void logToFile(bool enable);
 void setLoggingLevel(int level);
+int getLoggingLevel();
 void subscribeLoggingLevel(LoggingLevelNotification callback);
 
 void info(const std::string &msg,


### PR DESCRIPTION
- Users can switch to file logging from the default stdout logging.
- The (`verbose = true`) predicate still applies.
- Log files (timestamped) are saved to `~/.xacc/logs` folder.
- Also added a simple timer class to be used in TNQVM.