### PR TITLE
Enables getObservable to access Observable as Service

### DIFF
--- a/quantum/gate/xacc_quantum_gate_api.cpp
+++ b/quantum/gate/xacc_quantum_gate_api.cpp
@@ -29,10 +29,13 @@ std::shared_ptr<Observable> getObservable(const std::string type,
     return representation.empty()
                ? std::make_shared<FermionOperator>()
                : std::make_shared<FermionOperator>(representation);
+  } else if (xacc::hasService<Observable>(type)) {
+    auto obs = xacc::getService<Observable>(type);
+    return obs;
   } else {
     if (xacc::hasContributedService<Observable>(type)) {
-        auto obs = xacc::getContributedService<Observable>(type);
-        return obs;
+      auto obs = xacc::getContributedService<Observable>(type);
+      return obs;
     }
     xacc::error("[xacc::getObservable()] Invalid observable type: " + type);
     return std::make_shared<PauliOperator>();


### PR DESCRIPTION
Checks if the ServiceRegistry constains Service of type Observable with given name before checking for ContributedService of the same name.

Signed-off-by: Daniel Claudino <6d3@ornl.gov>