### PR TITLE
Implemented QFAST Cache

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -1811,6 +1811,9 @@ Optionally, we can provide additional configurations as listed below.
 |  initial-depth         | The initial number of circuit layers.                                  | int (default = 1)                    |
 +------------------------+------------------------------------------------------------------------+--------------------------------------+
 
+By default, after each unitary matrix decomposition, the QFAST plugin will save the result (in terms of smaller block matrices) into a cache file located at ``$XACC_INSTALL_DIR/tmp``. If a cache entry is found, the QFAST plugin will re-use the result automatically.
+
+Users can modify the cache filename via the configuration key ``cache-file-name``.
 
 Example:
 

--- a/quantum/plugins/circuits/qfast/qfast.hpp
+++ b/quantum/plugins/circuits/qfast/qfast.hpp
@@ -69,11 +69,8 @@ private:
         // If in_shouldSync, this will also update the cache file.
         bool addCacheEntry(const Eigen::MatrixXcd& in_unitary, const std::vector<Block>& in_decomposedBlocks, bool in_shouldSync = true);
         
-        // Returns true if this unitary has a cached result.
-        bool hasCache(const Eigen::MatrixXcd& in_unitary) const;
-        
-        // Returns the cached result.
-        // Assert that this hasCache() is true.   
+        // Returns the cached result if found.
+        // If not found, returns an empty vector.  
         std::vector<Block> getCache(const Eigen::MatrixXcd& in_unitary) const;
         
         // Json serialization:
@@ -90,6 +87,7 @@ private:
             bool fromJsonString(const std::string& in_jsonString);
         };
         std::vector<CacheEntry> cache;
+        std::string fileName;
     };
 
     struct PauliReps 
@@ -144,8 +142,11 @@ private:
     // This is the set of matrices that we can use to decompose the target unitary
     // into two-qubit blocks (constrained by the topology)
     static std::vector<std::vector<Eigen::MatrixXcd>>  generateAllPaulis(size_t in_nbQubits, const Topology& in_topology);
+    
+    // Computes the Hilbert-Smith trace distance between two matrix 
+    static double computeTraceDistance(const Eigen::MatrixXcd& in_mat1, const Eigen::MatrixXcd& in_mat2);
     // Evaluate cost function for the input unitary against the target unitary
-    double evaluateCostFunc(const Eigen::MatrixXcd in_U) const;
+    double evaluateCostFunc(const Eigen::MatrixXcd& in_U) const;
     
     // Returns true if the target trace distance can be met.
     // The depth is determined by the io_repsToOpt vector,
@@ -163,6 +164,7 @@ private:
     // Explore phase distance limit:
     double m_exploreTraceDistanceLimit;
     std::shared_ptr<LocationModel> m_locationModel;
+    DecomposedResultCache m_cache;
 };
 
 } // namespace circuits

--- a/quantum/plugins/circuits/qfast/qfast.hpp
+++ b/quantum/plugins/circuits/qfast/qfast.hpp
@@ -49,6 +49,47 @@ private:
         // Convert this local block (acting on two qubits)
         // to the full matrix representation (total system).
         Eigen::MatrixXcd toFullMat(size_t in_totalDim) const;
+        // Json serialization:
+        std::string toJson() const; 
+        bool fromJsonString(const std::string& in_jsonString);
+    };
+
+    // We cache the decomposition (in terms of smaller blocks)
+    // rather than the final quantum circuit because:
+    // (1) In case we want to change the final instantiation step,
+    // e.g. changing the gate set,
+    // this cache can be reused directly.
+    // (2) The instantiation is just direct linear algebra calculation
+    // and hence is super fast.  
+    struct DecomposedResultCache
+    {
+        // Initialize this cache with a file.
+        bool initialize(const std::string& in_filePath);
+        // Add a QFAST decomposed result to the cache.
+        // If in_shouldSync, this will also update the cache file.
+        bool addCacheEntry(const Eigen::MatrixXcd& in_unitary, const std::vector<Block>& in_decomposedBlocks, bool in_shouldSync = true);
+        
+        // Returns true if this unitary has a cached result.
+        bool hasCache(const Eigen::MatrixXcd& in_unitary) const;
+        
+        // Returns the cached result.
+        // Assert that this hasCache() is true.   
+        std::vector<Block> getCache(const Eigen::MatrixXcd& in_unitary) const;
+        
+        // Json serialization:
+        std::string toJson() const; 
+    private:
+        bool fromJsonString(const std::string& in_jsonString);
+    
+    private:
+        struct CacheEntry
+        {
+            Eigen::MatrixXcd uMat;
+            std::vector<Block> blocks;
+            std::string toJson() const; 
+            bool fromJsonString(const std::string& in_jsonString);
+        };
+        std::vector<CacheEntry> cache;
     };
 
     struct PauliReps 


### PR DESCRIPTION
The cache is saved in terms of decomposed blocks so that we can re-use the results if we need to use a different circuit generator (e.g. rather than KAK.)

