### PR TITLE
Support Gradients in QFAST

### DIFF
--- a/python/examples/qfast_circuit_synthesis.py
+++ b/python/examples/qfast_circuit_synthesis.py
@@ -10,6 +10,12 @@ ccnotMat[7][7] = 0.0
 ccnotMat[6][7] = 1.0
 ccnotMat[7][6] = 1.0
 
-composite = xacc.createCompositeInstruction('QFAST', { 'unitary' : ccnotMat })
+# Get the MLPack Optimizer, default is Adam
+optimizer = xacc.getOptimizer('mlpack')
+composite = xacc.createCompositeInstruction('QFAST', { 
+    'unitary' : ccnotMat,
+    'optimizer': optimizer 
+})
+
 print(composite)
 

--- a/quantum/plugins/circuits/qfast/qfast.hpp
+++ b/quantum/plugins/circuits/qfast/qfast.hpp
@@ -152,7 +152,7 @@ private:
     };
 
     // Differentiation Functor for the *EXPLORE* stage,
-    // i.e. where we have fixed the gate location.
+    // i.e. where we have *not* fixed the gate location.
     struct ExploreDiffFunctor: public Functor<double>
     {
         ExploreDiffFunctor(const QFAST* const parent, const std::vector<QFAST::PauliReps>& in_genericLayers, int in_nbInputs, int in_nbValues = 1):

--- a/quantum/plugins/circuits/qfast/qfast.hpp
+++ b/quantum/plugins/circuits/qfast/qfast.hpp
@@ -126,6 +126,51 @@ private:
         std::pair<TopologyPaulis, TopologyPaulis> bucketPaulis;
     };
 
+    // Base functor for Auto-diff
+    template<typename _Scalar, int NX = Eigen::Dynamic, int NY = Eigen::Dynamic>
+    struct Functor
+    {
+        typedef _Scalar Scalar;
+        enum 
+        {
+            InputsAtCompileTime = NX,
+            ValuesAtCompileTime = NY
+        };
+        
+        typedef Eigen::Matrix<Scalar,InputsAtCompileTime,1> InputType;
+        typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,1> ValueType;
+        typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
+        
+        int m_inputs, m_values;
+        
+        Functor() : m_inputs(InputsAtCompileTime), m_values(ValuesAtCompileTime) {}
+        Functor(int inputs, int values) : m_inputs(inputs), m_values(values) {}
+        
+        int inputs() const { return m_inputs; }
+        int values() const { return m_values; }
+    };
+
+    // Differentiation Functor for the REFINE stage,
+    // i.e. where we have fixed the gate location.
+    struct RefineDiffFunctor: public Functor<double>
+    {
+        RefineDiffFunctor(const QFAST* const parent, const std::vector<QFAST::PauliReps>& in_fixedLayers, int in_nbInputs, int in_nbValues = 1):
+            Functor(in_nbInputs, in_nbValues),
+            m_parent(parent),
+            m_layerConfigs(in_fixedLayers)
+        {}
+
+        // Compute the cost function given the input
+        int operator()(const InputType& in_x, ValueType& out_fvec) const;
+
+    private:
+        // The QFAST algorithm parent.
+        const QFAST* m_parent;
+        // The layer configuration to refine:
+        // i.e. fixed locations, just need to optimize the Pauli coefficients.
+        std::vector<QFAST::PauliReps> m_layerConfigs;
+    };
+
     // Returns decomposed Blocks
     std::vector<Block> decompose();
     // Algorithm #3

--- a/quantum/plugins/circuits/qfast/qfast.hpp
+++ b/quantum/plugins/circuits/qfast/qfast.hpp
@@ -18,6 +18,7 @@
 #include <Eigen/Dense>
 
 namespace xacc {
+class Optimizer;    
 namespace circuits {
 
 class QFAST : public xacc::quantum::Circuit 
@@ -210,7 +211,7 @@ private:
     double m_exploreTraceDistanceLimit;
     std::shared_ptr<LocationModel> m_locationModel;
     DecomposedResultCache m_cache;
+    std::shared_ptr<Optimizer> m_optimizer;
 };
-
 } // namespace circuits
 } // namespace xacc

--- a/quantum/plugins/circuits/qfast/qfast.hpp
+++ b/quantum/plugins/circuits/qfast/qfast.hpp
@@ -151,6 +151,28 @@ private:
         int values() const { return m_values; }
     };
 
+    // Differentiation Functor for the *EXPLORE* stage,
+    // i.e. where we have fixed the gate location.
+    struct ExploreDiffFunctor: public Functor<double>
+    {
+        ExploreDiffFunctor(const QFAST* const parent, const std::vector<QFAST::PauliReps>& in_genericLayers, int in_nbInputs, int in_nbValues = 1):
+            Functor(in_nbInputs, in_nbValues),
+            m_parent(parent),
+            m_layerConfigs(in_genericLayers)
+        {}
+
+        // Compute the cost function given the input
+        int operator()(const InputType& in_x, ValueType& out_fvec) const;
+
+    private:
+        // The QFAST algorithm parent.
+        const QFAST* m_parent;
+        // The layer configuration to explore.
+        // Note: these layers haven't been fixed, 
+        // i.e. locations are opt params.
+        std::vector<QFAST::PauliReps> m_layerConfigs;
+    };
+
     // Differentiation Functor for the REFINE stage,
     // i.e. where we have fixed the gate location.
     struct RefineDiffFunctor: public Functor<double>

--- a/quantum/plugins/circuits/qfast/tests/QfastTester.cpp
+++ b/quantum/plugins/circuits/qfast/tests/QfastTester.cpp
@@ -22,6 +22,15 @@ using namespace xacc;
 
 TEST(QFastTester, checkSimple) 
 {
+  srand(time(0));
+  // Pick 0 or 1
+  const int randPick = rand() % 2;
+  const std::string optimizerName = (randPick == 0) ? "nlopt" : "mlpack";
+  // Randomly pick an optimizer:
+  // To save test time, we don't want to run many long tests.
+  auto optimizer = xacc::getOptimizer(optimizerName);
+  std::cout << "Use '" << optimizer->name() << "' optimizer\n";
+
   auto acc = xacc::getAccelerator("qpp", { std::make_pair("shots", 8192)});
   auto gateRegistry = xacc::getService<IRProvider>("quantum");
   auto xGate0 = gateRegistry->createInstruction("X", { 0 });
@@ -45,7 +54,8 @@ TEST(QFastTester, checkSimple)
     ccnotMat(7, 6) = 1.0;
   
     const bool expandOk = qfast->expand({ 
-      std::make_pair("unitary", ccnotMat)
+      std::make_pair("unitary", ccnotMat),
+      std::make_pair("optimizer", optimizer)
     });
     EXPECT_TRUE(expandOk);
     

--- a/xacc/optimizer/nlopt-optimizers/nlopt_optimizer.cpp
+++ b/xacc/optimizer/nlopt-optimizers/nlopt_optimizer.cpp
@@ -93,8 +93,20 @@ OptResult NLOptimizer::optimize(OptFunction &function) {
 
   nlopt::opt _opt(algo, dim);
   _opt.set_min_objective(c_wrapper, d);
-  _opt.set_lower_bounds(std::vector<double>(dim, -3.1415926));
-  _opt.set_upper_bounds(std::vector<double>(dim, 3.1415926));
+  // Default lower bounds
+  std::vector<double> lowerBounds(dim, -3.1415926);
+  if (options.keyExists<std::vector<double>>("nlopt-lower-bounds")) {
+    lowerBounds = options.get<std::vector<double>>("nlopt-lower-bounds");
+  }
+
+  // Default upper bounds
+  std::vector<double> upperBounds(dim, 3.1415926);
+  if (options.keyExists<std::vector<double>>("nlopt-upper-bounds")) {
+    upperBounds = options.get<std::vector<double>>("nlopt-upper-bounds");
+  }
+
+  _opt.set_lower_bounds(lowerBounds);
+  _opt.set_upper_bounds(upperBounds);
   _opt.set_maxeval(maxeval);
   _opt.set_ftol_rel(tol);
 


### PR DESCRIPTION
QFAST to calculate gradients automatically if the optimizer is gradient-based:

- Refactored `explore` and `refine` optimization functions into Eigen functors.

- Used softmax function for localization during `explore` phase (rather than max element).

- Added ability to specify parameter bounds for `nlopt`. This is to prevent overflow when using soft-max on location parameters.