### PR TITLE
Implementation of finite difference gradients

### DIFF
--- a/quantum/plugins/algorithms/adapt/adapt.cpp
+++ b/quantum/plugins/algorithms/adapt/adapt.cpp
@@ -297,7 +297,7 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       xacc::info(ss.str());
       ss.str(std::string());
 
-      xacc::info("Final ADAPT- " + subAlgo + " circuit\n" + ansatzInstructions->toString());
+      xacc::info("Final ADAPT-" + subAlgo + " circuit\n" + ansatzInstructions->toString());
 
       return; 
 
@@ -331,8 +331,7 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
 
         gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(gradStrategyName);
         gradientStrategy->optionalParameters({std::make_pair("observable", observable),
-                                            std::make_pair("commutator", commutators[maxCommutatorIdx]),
-                                            std::make_pair("jw", true)
+                                            std::make_pair("commutator", commutators[maxCommutatorIdx])
                                             });
         x.insert(x.begin(), 0.0);
         newOptimizer = xacc::getOptimizer(optimizer->name(),

--- a/quantum/plugins/algorithms/adapt/adapt.cpp
+++ b/quantum/plugins/algorithms/adapt/adapt.cpp
@@ -41,19 +41,19 @@ bool ADAPT::initialize(const HeterogeneousMap &parameters) {
   if (!parameters.pointerLikeExists<Observable>("observable")) {
     xacc::info("Obs was false\n");
     return false;
-  } 
-  
+  }
+
   if (!parameters.pointerLikeExists<Accelerator>("accelerator")) {
     xacc::info("Acc was false\n");
     return false;
-  } 
-  
-  if (!parameters.stringExists("pool")){
+  }
+
+  if (!parameters.stringExists("pool")) {
     xacc::info("Pool was false\n");
     return false;
   }
 
-  if (!parameters.stringExists("sub-algorithm")){
+  if (!parameters.stringExists("sub-algorithm")) {
     xacc::info("Sub algorithm was false\n");
     return false;
   }
@@ -66,7 +66,7 @@ bool ADAPT::initialize(const HeterogeneousMap &parameters) {
 
   if (parameters.keyExists<int>("maxiter")) {
     _maxIter = parameters.get<int>("maxiter");
-  } 
+  }
 
   if (parameters.keyExists<double>("adapt-threshold")) {
     _adaptThreshold = parameters.get<double>("adapt-threshold");
@@ -82,51 +82,55 @@ bool ADAPT::initialize(const HeterogeneousMap &parameters) {
 
   if (parameters.stringExists("gradient_strategy")) {
     gradStrategyName = parameters.getString("gradient_strategy");
-  } 
+  }
 
   if (parameters.pointerLikeExists<CompositeInstruction>("initial-state")) {
-    initialState = parameters.get<std::shared_ptr<CompositeInstruction>>("initial-state");
+    initialState =
+        parameters.get<std::shared_ptr<CompositeInstruction>>("initial-state");
   }
 
   if (parameters.keyExists<int>("n-electrons")) {
     _nElectrons = parameters.get<int>("n-electrons");
   }
 
-  if ((subAlgo == "vqe" && !initialState) && 
-     (subAlgo == "vqe" && !parameters.keyExists<int>("n-electrons"))){
+  if ((subAlgo == "vqe" && !initialState) &&
+      (subAlgo == "vqe" && !parameters.keyExists<int>("n-electrons"))) {
 
-      xacc::info("VQE requires number of electrons or initial state.");
+    xacc::info("VQE requires number of electrons or initial state.");
   }
 
-  if (parameters.getString("pool") == "singlet-adapted-uccsd" && 
-      parameters.keyExists<int>("n-electrons")){
+  if (parameters.getString("pool") == "singlet-adapted-uccsd" &&
+      parameters.keyExists<int>("n-electrons")) {
 
-      pool->optionalParameters({std::make_pair("n-electrons", _nElectrons)});
+    pool->optionalParameters({std::make_pair("n-electrons", _nElectrons)});
   }
 
   // Check if Observable is Fermion or Pauli and manipulate accordingly
   //
   // if string has ^, it's FermionOperator
-  if (observable->toString().find("^") != std::string::npos){
+  if (observable->toString().find("^") != std::string::npos) {
 
     auto jw = xacc::getService<ObservableTransform>("jw");
     if (std::dynamic_pointer_cast<FermionOperator>(observable)) {
       observable = jw->transform(observable);
     } else {
-      auto fermionObservable = xacc::quantum::getObservable("fermion", observable->toString());
-      observable = jw->transform(std::dynamic_pointer_cast<Observable>(fermionObservable));      
+      auto fermionObservable =
+          xacc::quantum::getObservable("fermion", observable->toString());
+      observable = jw->transform(
+          std::dynamic_pointer_cast<Observable>(fermionObservable));
     }
 
-  // observable is PauliOperator, but does not cast down to it
-  // Not sure about the likelihood of this happening, but want to cover all bases
-  } else if (observable->toString().find("X") != std::string::npos
-            || observable->toString().find("Y") != std::string::npos
-            || observable->toString().find("Z") != std::string::npos
-            && !std::dynamic_pointer_cast<PauliOperator>(observable)){
+    // observable is PauliOperator, but does not cast down to it
+    // Not sure about the likelihood of this happening, but want to cover all
+    // bases
+  } else if (observable->toString().find("X") != std::string::npos ||
+             observable->toString().find("Y") != std::string::npos ||
+             observable->toString().find("Z") != std::string::npos &&
+                 !std::dynamic_pointer_cast<PauliOperator>(observable)) {
 
-    auto pauliObservable = xacc::quantum::getObservable("pauli", observable->toString());
+    auto pauliObservable =
+        xacc::quantum::getObservable("pauli", observable->toString());
     observable = std::dynamic_pointer_cast<Observable>(pauliObservable);
-
   }
 
   return true;
@@ -146,36 +150,38 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
   auto ansatzRegistry = xacc::getIRProvider("quantum");
   auto ansatzInstructions = ansatzRegistry->createComposite("ansatzCircuit");
 
-  if(initialState){
+  if (initialState) {
 
-    for(auto& inst : initialState->getInstructions()){
+    for (auto &inst : initialState->getInstructions()) {
       ansatzInstructions->addInstruction(inst);
     }
 
   } else {
 
-    if(subAlgo == "vqe"){
+    if (subAlgo == "vqe") {
       // Define the initial state, usually HF for chemistry problems
       std::size_t j;
-      for (int i = 0; i < _nElectrons/2; i++) {
-        j = (std::size_t) i;
-        auto alphaXGate = ansatzRegistry->createInstruction("X", std::vector<std::size_t>{j});
+      for (int i = 0; i < _nElectrons / 2; i++) {
+        j = (std::size_t)i;
+        auto alphaXGate =
+            ansatzRegistry->createInstruction("X", std::vector<std::size_t>{j});
         ansatzInstructions->addInstruction(alphaXGate);
-        j = (std::size_t) (i + buffer->size()/2);
-        auto betaXGate = ansatzRegistry->createInstruction("X", std::vector<std::size_t>{j});
+        j = (std::size_t)(i + buffer->size() / 2);
+        auto betaXGate =
+            ansatzRegistry->createInstruction("X", std::vector<std::size_t>{j});
         ansatzInstructions->addInstruction(betaXGate);
       }
     }
 
-    if(subAlgo == "QAOA"){
+    if (subAlgo == "QAOA") {
       std::size_t j;
       for (int i = 0; i < buffer->size(); i++) {
-        j = (std::size_t) i;
-        auto H = ansatzRegistry->createInstruction("H", std::vector<std::size_t>{j});
+        j = (std::size_t)i;
+        auto H =
+            ansatzRegistry->createInstruction("H", std::vector<std::size_t>{j});
         ansatzInstructions->addInstruction(H);
       }
     }
-
   }
 
   // Generate operators in the pool
@@ -184,87 +190,95 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
 
   // Vector of commutators, need to compute them only once
   std::vector<std::shared_ptr<Observable>> commutators;
-  if(subAlgo == "QAOA"){
+  if (subAlgo == "QAOA") {
 
     std::complex<double> i(0, 1);
-    for (auto op : operators){
+    for (auto op : operators) {
       auto comm = observable->commutator(op);
-      auto& tmp = *std::dynamic_pointer_cast<PauliOperator>(comm);
+      auto &tmp = *std::dynamic_pointer_cast<PauliOperator>(comm);
       tmp = tmp * i;
-      auto ptr = std::dynamic_pointer_cast<Observable>(std::make_shared<PauliOperator>(tmp));
+      auto ptr = std::dynamic_pointer_cast<Observable>(
+          std::make_shared<PauliOperator>(tmp));
       commutators.push_back(ptr);
     }
 
   } else {
 
-    for (auto op : operators){
+    for (auto op : operators) {
       commutators.push_back(observable->commutator(op));
     }
-
   }
 
   xacc::info("Operator pool: " + pool->name());
-  xacc::info("Number of operators in the pool: " + std::to_string(operators.size()));
+  xacc::info("Number of operators in the pool: " +
+             std::to_string(operators.size()));
   double oldEnergy = 0.0;
   std::vector<double> x; // these are the variational parameters
 
   // start ADAPT loop
-  for (int iter = 0; iter < _maxIter; iter++){
+  for (int iter = 0; iter < _maxIter; iter++) {
 
     xacc::info("Iteration: " + std::to_string(iter + 1));
     xacc::info("Computing [H, A]");
-    xacc::info("Printing commutators with absolute value above " + std::to_string(_printThreshold));
+    xacc::info("Printing commutators with absolute value above " +
+               std::to_string(_printThreshold));
 
-    if(subAlgo == "QAOA"){
+    if (subAlgo == "QAOA") {
 
       auto costHamiltonianGates = std::dynamic_pointer_cast<quantum::Circuit>(
-      xacc::getService<Instruction>("exp_i_theta"));
+          xacc::getService<Instruction>("exp_i_theta"));
 
       // Create instruction for new operator
       costHamiltonianGates->expand(
-        {std::make_pair("pauli", observable->toString()),
-        std::make_pair("param_id", "x" + std::to_string(ansatzInstructions->nVariables()))
-        });
+          {std::make_pair("pauli", observable->toString()),
+           std::make_pair(
+               "param_id",
+               "x" + std::to_string(ansatzInstructions->nVariables()))});
 
-      ansatzInstructions->addVariable("x" + std::to_string(ansatzInstructions->nVariables()));
-      for(auto& inst : costHamiltonianGates->getInstructions()){
+      ansatzInstructions->addVariable(
+          "x" + std::to_string(ansatzInstructions->nVariables()));
+      for (auto &inst : costHamiltonianGates->getInstructions()) {
         ansatzInstructions->addInstruction(inst);
       }
       x.insert(x.begin(), 0.01);
-
     }
 
     int maxCommutatorIdx = 0;
     double maxCommutator = 0.0;
     double gradientNorm = 0.0;
 
-    // Loop over non-vanishing commutators and select the one with largest magnitude
-    for (int operatorIdx = 0; operatorIdx < commutators.size(); operatorIdx++){
+    // Loop over non-vanishing commutators and select the one with largest
+    // magnitude
+    for (int operatorIdx = 0; operatorIdx < commutators.size(); operatorIdx++) {
 
       // only compute commutators if they aren't zero
-      int nTermsCommutator = std::dynamic_pointer_cast<PauliOperator>(commutators[operatorIdx])->getTerms().size();
-      if(nTermsCommutator != 0){
+      int nTermsCommutator =
+          std::dynamic_pointer_cast<PauliOperator>(commutators[operatorIdx])
+              ->getTerms()
+              .size();
+      if (nTermsCommutator != 0) {
 
         // Print number of instructions for computing <observable>
-        xacc::info("Number of instructions for commutator calculation: " 
-                    + std::to_string(nTermsCommutator));
+        xacc::info("Number of instructions for commutator calculation: " +
+                   std::to_string(nTermsCommutator));
         // observe the commutators with the updated circuit ansatz
         auto grad_algo = xacc::getAlgorithm(
             subAlgo, {std::make_pair("observable", commutators[operatorIdx]),
-                    std::make_pair("optimizer", optimizer),
-                    std::make_pair("accelerator", accelerator),
-                    std::make_pair("ansatz", ansatzInstructions)});
+                      std::make_pair("optimizer", optimizer),
+                      std::make_pair("accelerator", accelerator),
+                      std::make_pair("ansatz", ansatzInstructions)});
         auto tmp_buffer = xacc::qalloc(buffer->size());
         auto commutatorValue = std::real(grad_algo->execute(tmp_buffer, x)[0]);
 
-        if(abs(commutatorValue) > _printThreshold){
-          ss << std::setprecision(12) << "[H," << operatorIdx << "] = " << commutatorValue;
+        if (abs(commutatorValue) > _printThreshold) {
+          ss << std::setprecision(12) << "[H," << operatorIdx
+             << "] = " << commutatorValue;
           xacc::info(ss.str());
           ss.str(std::string());
         }
 
         // update maxCommutator
-        if(abs(commutatorValue) > abs(maxCommutator)){
+        if (abs(commutatorValue) > abs(maxCommutator)) {
           maxCommutatorIdx = operatorIdx;
           maxCommutator = commutatorValue;
         }
@@ -272,36 +286,40 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
         gradientNorm += commutatorValue * commutatorValue;
       }
     }
-    
-    ss << std::setprecision(12) << "Max gradient component: [H, " 
-        << maxCommutatorIdx << "] = " << maxCommutator << " a.u.";
+
+    ss << std::setprecision(12) << "Max gradient component: [H, "
+       << maxCommutatorIdx << "] = " << maxCommutator << " a.u.";
     xacc::info(ss.str());
     ss.str(std::string());
 
     gradientNorm = std::sqrt(gradientNorm);
-    ss << std::setprecision(12) << "Norm of gradient vector: " << gradientNorm << " a.u.";
+    ss << std::setprecision(12) << "Norm of gradient vector: " << gradientNorm
+       << " a.u.";
     xacc::info(ss.str());
     ss.str(std::string());
 
     if (gradientNorm < _adaptThreshold) { // ADAPT converged
 
-      xacc::info("ADAPT-" + subAlgo + " converged in " + std::to_string(iter) + " iterations.");
-      ss << std::setprecision(12) << "ADAPT-" << subAlgo << " energy: " << oldEnergy << " a.u.";
+      xacc::info("ADAPT-" + subAlgo + " converged in " + std::to_string(iter) +
+                 " iterations.");
+      ss << std::setprecision(12) << "ADAPT-" << subAlgo
+         << " energy: " << oldEnergy << " a.u.";
       xacc::info(ss.str());
       ss.str(std::string());
 
       ss << "Optimal parameters: ";
-      for (auto param : x){
+      for (auto param : x) {
         ss << std::setprecision(12) << param << " ";
       }
       xacc::info(ss.str());
       ss.str(std::string());
 
-      xacc::info("Final ADAPT-" + subAlgo + " circuit\n" + ansatzInstructions->toString());
+      xacc::info("Final ADAPT-" + subAlgo + " circuit\n" +
+                 ansatzInstructions->toString());
 
-      return; 
+      return;
 
-    } else if (iter < _maxIter) { // Add operator and reoptimize 
+    } else if (iter < _maxIter) { // Add operator and reoptimize
 
       xacc::info(subAlgo + " optimization of current ansatz.");
 
@@ -309,85 +327,96 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       ansatzOps.push_back(maxCommutatorIdx);
 
       // Instruction service for the operator to be added to the ansatz
-      auto maxCommutatorGate = pool->getOperatorInstructions(maxCommutatorIdx, 
-                                      ansatzInstructions->nVariables());
+      auto maxCommutatorGate = pool->getOperatorInstructions(
+          maxCommutatorIdx, ansatzInstructions->nVariables());
 
       // Label for new variable and add it to the circuit
-      ansatzInstructions->addVariable("x" + std::to_string(ansatzInstructions->nVariables()));
+      ansatzInstructions->addVariable(
+          "x" + std::to_string(ansatzInstructions->nVariables()));
 
       // Append new instructions to current circuit
-      for (auto& inst : maxCommutatorGate->getInstructions()){  
+      for (auto &inst : maxCommutatorGate->getInstructions()) {
         ansatzInstructions->addInstruction(inst);
       }
 
       // Convergence is improved if passing initial parameters to optimizer
       // so we create a new instance of Optimizer with them
       // insert 0.0 for VQE and pi/2 for QAOA
- 
+
       // Instantiate gradient class
       std::shared_ptr<AlgorithmGradientStrategy> gradientStrategy;
       std::shared_ptr<Optimizer> newOptimizer;
-      if(!gradStrategyName.empty() && subAlgo == "vqe" && optimizer->isGradientBased()){
+      if (!gradStrategyName.empty() && subAlgo == "vqe" &&
+          optimizer->isGradientBased()) {
 
-        gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(gradStrategyName);
-        gradientStrategy->optionalParameters({std::make_pair("observable", observable),
-                                            std::make_pair("commutator", commutators[maxCommutatorIdx])
-                                            });
+        gradientStrategy =
+            xacc::getService<AlgorithmGradientStrategy>(gradStrategyName);
+        gradientStrategy->initialize(
+            {std::make_pair("observable", observable),
+             std::make_pair("commutator", commutators[maxCommutatorIdx])});
         x.insert(x.begin(), 0.0);
-        newOptimizer = xacc::getOptimizer(optimizer->name(),
-                    {std::make_pair(optimizer->name() + "-optimizer", optimizer->get_algorithm()),
-                    std::make_pair("initial-parameters", x)}); 
+        newOptimizer = xacc::getOptimizer(
+            optimizer->name(), {std::make_pair(optimizer->name() + "-optimizer",
+                                               optimizer->get_algorithm()),
+                                std::make_pair("initial-parameters", x)});
 
-      } else if (!gradStrategyName.empty() && subAlgo == "QAOA" && optimizer->isGradientBased()) {
+      } else if (!gradStrategyName.empty() && subAlgo == "QAOA" &&
+                 optimizer->isGradientBased()) {
 
-        gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(gradStrategyName);
-        gradientStrategy->optionalParameters({std::make_pair("observable", observable)});
+        gradientStrategy =
+            xacc::getService<AlgorithmGradientStrategy>(gradStrategyName);
+        gradientStrategy->initialize(
+            {std::make_pair("observable", observable)});
         x.insert(x.begin(), xacc::constants::pi / 2.0);
-        newOptimizer = xacc::getOptimizer(optimizer->name(),
-              {std::make_pair(optimizer->name() + "-optimizer", optimizer->get_algorithm()),
-              std::make_pair("initial-parameters", x)});     
+        newOptimizer = xacc::getOptimizer(
+            optimizer->name(), {std::make_pair(optimizer->name() + "-optimizer",
+                                               optimizer->get_algorithm()),
+                                std::make_pair("initial-parameters", x)});
 
       } else {
         gradientStrategy = nullptr;
-        newOptimizer = xacc::getOptimizer(optimizer->name(),
-            {std::make_pair(optimizer->name() + "-optimizer", optimizer->get_algorithm())});      
+        newOptimizer = xacc::getOptimizer(
+            optimizer->name(), {std::make_pair(optimizer->name() + "-optimizer",
+                                               optimizer->get_algorithm())});
       }
 
-      // Start subAlgo optimization 
+      // Start subAlgo optimization
       auto sub_opt = xacc::getAlgorithm(
           subAlgo, {std::make_pair("observable", observable),
-                  std::make_pair("optimizer", newOptimizer),
-                  std::make_pair("accelerator", accelerator),
-                  std::make_pair("gradient_strategy", gradientStrategy),
-                  std::make_pair("ansatz", ansatzInstructions)
-                  });
+                    std::make_pair("optimizer", newOptimizer),
+                    std::make_pair("accelerator", accelerator),
+                    std::make_pair("gradient_strategy", gradientStrategy),
+                    std::make_pair("ansatz", ansatzInstructions)});
       sub_opt->execute(buffer);
 
       auto newEnergy = (*buffer)["opt-val"].as<double>();
       x = (*buffer)["opt-params"].as<std::vector<double>>();
       oldEnergy = newEnergy;
 
-      ss << std::setprecision(12) << "Energy at ADAPT iteration " << iter + 1 << ": " << newEnergy;
+      ss << std::setprecision(12) << "Energy at ADAPT iteration " << iter + 1
+         << ": " << newEnergy;
       xacc::info(ss.str());
       ss.str(std::string());
 
-      ss << std::setprecision(12) << "Parameters at ADAPT iteration " << iter + 1 << ": ";
-      for (auto param : x){
+      ss << std::setprecision(12) << "Parameters at ADAPT iteration "
+         << iter + 1 << ": ";
+      for (auto param : x) {
         ss << param << " ";
       }
       xacc::info(ss.str());
       ss.str(std::string());
 
       ss << "Ansatz at ADAPT iteration " << std::to_string(iter + 1) << ": ";
-      for (auto op : ansatzOps){
+      for (auto op : ansatzOps) {
         ss << op << " ";
       }
       xacc::info(ss.str());
       ss.str(std::string());
 
-      if(_printOps){
-        xacc::info("Printing operators at ADAPT iteration " + std::to_string(iter + 1));
-        for(auto op : ansatzOps){
+      if (_printOps) {
+        xacc::info("Printing operators at ADAPT iteration " +
+                   std::to_string(iter + 1));
+        for (auto op : ansatzOps) {
           xacc::info("Operator index: " + std::to_string(op));
           xacc::info(pool->operatorString(op));
         }
@@ -398,12 +427,12 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       buffer->addExtraInfo("opt-ansatz", ExtraInfo(ansatzOps));
 
     } else {
-      xacc::info("ADAPT-" + subAlgo + " did not converge in " + std::to_string(_maxIter) + " iterations.");
+      xacc::info("ADAPT-" + subAlgo + " did not converge in " +
+                 std::to_string(_maxIter) + " iterations.");
       return;
     }
-
   }
 }
 
-} // namespace adapt
+} // namespace algorithm
 } // namespace xacc

--- a/quantum/plugins/algorithms/gradient_strategies/BackwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/BackwardDifferenceGradient.hpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2020 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Daniel Claudino - initial API and implementation
+ *******************************************************************************/
+#ifndef XACC_BACKWARD_DIFFERENCE_GRADIENT_HPP_
+#define XACC_BACKWARD_DIFFERENCE_GRADIENT_HPP_
+
+#include "CompositeInstruction.hpp"
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "AlgorithmGradientStrategy.hpp"
+#include <iomanip>
+
+using namespace xacc;
+
+namespace xacc {
+namespace algorithm {
+
+class BackwardDifferenceGradient : public AlgorithmGradientStrategy {
+
+protected:
+
+  std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
+  double step = 1.0e-7;
+  double obsExpValue;
+
+public:
+
+  bool isNumerical() const override {
+    return true;
+  }
+
+  void passObsExpValue(double expValue) override {
+    obsExpValue = expValue;
+    return;
+  }
+
+  // passes the Hamiltonian and current ansatz operators to the gradient class
+  bool optionalParameters(const HeterogeneousMap parameters) override {
+
+    if (parameters.keyExists<double>("step")) {
+      step = parameters.get<double>("step");
+    } 
+    return true;
+
+  }
+
+  void passObservable(const std::shared_ptr<Observable> observable) override {
+    obs = observable;
+    return;
+  }
+
+  std::vector<std::shared_ptr<CompositeInstruction>>
+  getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
+                        const std::vector<double> &x) override {
+
+    std::stringstream ss;
+    ss << std::setprecision(5) << "Input parameters: ";
+    for(auto param : x){
+      ss << param << " ";
+    }
+    xacc::info(ss.str());
+    ss.str(std::string());
+
+    std::vector<std::shared_ptr<CompositeInstruction>> gradientInstructions;
+    for (int op = 0; op < x.size(); op++){ // loop over operators
+
+        // shift the parameter by step and observe
+        auto tmpX = x;
+        tmpX[op] -= step;
+        auto kernels = obs->observe(circuit);
+
+        // loop over circuit instructions
+        // and gather coefficients/instructions
+        for (auto &f : kernels) {
+          auto evaled = f->operator()(tmpX);
+          coefficients.push_back(std::real(f->getCoefficient()));
+          gradientInstructions.push_back(evaled);
+        }
+
+        nInstructionsElement.push_back(kernels.size());
+        
+      }
+
+    return gradientInstructions;
+
+  }
+
+  void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
+
+    int shift = 0;
+    // loop over the remaining number of entries in the gradient vector
+    for (int gradTerm = 0; gradTerm < dx.size(); gradTerm++){ 
+
+      double gradElement = 0.0;
+
+      // loop over instructions for a given term, compute <+> and <->
+      for (int instElement = 0; instElement < nInstructionsElement[gradTerm]; instElement++) {
+
+        auto expval = std::real(results[instElement + shift]->getExpectationValueZ());
+        gradElement += expval * coefficients[instElement + shift];
+      }
+
+      // gradient is (<+> - <->)/2
+      dx[gradTerm] = std::real(obsExpValue - gradElement) / step;
+      shift += nInstructionsElement[gradTerm];
+    }
+
+    coefficients.clear();
+    nInstructionsElement.clear();
+    std::stringstream ss;
+    ss << std::setprecision(12) << "Computed gradient: ";
+    for(auto param : dx){
+      ss << param << " ";
+    }
+    xacc::info(ss.str());
+    ss.str(std::string());
+
+    return;
+  }
+
+  const std::string name() const override { return "backward-difference-gradient"; }
+  const std::string description() const override { return ""; }
+
+};
+
+
+}
+}
+
+#endif

--- a/quantum/plugins/algorithms/gradient_strategies/BackwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/BackwardDifferenceGradient.hpp
@@ -29,21 +29,23 @@ class BackwardDifferenceGradient : public AlgorithmGradientStrategy {
 protected:
 
   std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
-  double step = 1.0e-7;
-  double obsExpValue;
+  double step = 1.0e-7; // step size
+  double obsExpValue; // <H> expectation value of the observable
 
 public:
 
+  // this is a numerical gradient
   bool isNumerical() const override {
     return true;
   }
 
+  // Pass the expectation value of the observable
   void passObsExpValue(double expValue) override {
     obsExpValue = expValue;
     return;
   }
 
-  // passes the Hamiltonian and current ansatz operators to the gradient class
+  // Change step size if need be
   bool optionalParameters(const HeterogeneousMap parameters) override {
 
     if (parameters.keyExists<double>("step")) {
@@ -53,11 +55,13 @@ public:
 
   }
 
+  // Get observable to compute gradients of
   void passObservable(const std::shared_ptr<Observable> observable) override {
     obs = observable;
     return;
   }
 
+ // Get the circuit instructions necessary to compute gradients
   std::vector<std::shared_ptr<CompositeInstruction>>
   getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
                         const std::vector<double> &x) override {
@@ -94,6 +98,7 @@ public:
 
   }
 
+ // Compute gradients from executed instructions
   void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
 
     int shift = 0;

--- a/quantum/plugins/algorithms/gradient_strategies/CentralDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/CentralDifferenceGradient.hpp
@@ -29,8 +29,8 @@ class CentralDifferenceGradient : public AlgorithmGradientStrategy {
 protected:
 
   std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
-  double step = 1.0e-7;
-  double obsExpValue;
+  double step = 1.0e-7; // step size
+  double obsExpValue; // <H> expectation value of the observable
 
 public:
 

--- a/quantum/plugins/algorithms/gradient_strategies/CentralDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/CentralDifferenceGradient.hpp
@@ -27,40 +27,36 @@ namespace algorithm {
 class CentralDifferenceGradient : public AlgorithmGradientStrategy {
 
 protected:
-
   std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
-  double step = 1.0e-7; // step size
-  double obsExpValue; // <H> expectation value of the observable
+  double step = 1.0e-7;            // step size
+  double obsExpValue;              // <H> expectation value of the observable
 
 public:
-
   // Set this to true to get energy, but see comment on passObsExpValue below
-  bool isNumerical() const override {
-    return true;
-  }
+  bool isNumerical() const override { return true; }
 
   // We won't use it for now, but this may come in handy if we need the Hessian
-  void passObsExpValue(const double expValue) override {
+  void setFunctionValue(const double expValue) override {
     obsExpValue = expValue;
     return;
   }
 
-  // Change step size if need be
-  bool optionalParameters(const HeterogeneousMap parameters) override {
+  bool initialize(const HeterogeneousMap parameters) override {
 
-    if (parameters.keyExists<double>("step")){
+    if (!parameters.keyExists<std::shared_ptr<Observable>>("observable")) {
+      xacc::error("Gradient strategy needs observable");
+      return false;
+    }
+
+    obs = parameters.get<std::shared_ptr<Observable>>("observable");
+
+    // Change step size if need be
+    if (parameters.keyExists<double>("step")) {
       step = parameters.get<double>("step");
-    } 
+    }
+
     return true;
-
   }
-
-  // Get observable to compute gradients of
-  void passObservable(const std::shared_ptr<Observable> observable) override {
-    obs = observable;
-    return;
-  }
-
 
   // Get the circuit instructions necessary to compute gradients
   // This is very similar to ParameterShift
@@ -70,15 +66,15 @@ public:
 
     std::stringstream ss;
     ss << std::setprecision(5) << "Input parameters: ";
-    for(auto param : x){
+    for (auto param : x) {
       ss << param << " ";
     }
     xacc::info(ss.str());
     ss.str(std::string());
 
     std::vector<std::shared_ptr<CompositeInstruction>> gradientInstructions;
-    for (int op = 0; op < x.size(); op++){ // loop over operators
-      for (double sign : {1.0, -1.0}){ // change sign 
+    for (int op = 0; op < x.size(); op++) { // loop over operators
+      for (double sign : {1.0, -1.0}) {     // change sign
 
         // shift the parameter by step and observe
         auto tmpX = x;
@@ -91,45 +87,50 @@ public:
           auto evaled = f->operator()(tmpX);
           coefficients.push_back(std::real(f->getCoefficient()));
           gradientInstructions.push_back(evaled);
-          //std::cout << evaled->toString() << "\n";
+          // std::cout << evaled->toString() << "\n";
         }
 
         // the number of instructions for a given element of x is the same
         // regardless of the parameter sign, so we need only one of this
-        if(sign == 1.0){
+        if (sign == 1.0) {
           nInstructionsElement.push_back(kernels.size());
         }
-
       }
-        
-      }
+    }
 
     return gradientInstructions;
-
   }
 
   // Compute gradients from executed instructions
-  void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
+  void
+  compute(std::vector<double> &dx,
+          std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
 
     int shift = 0;
     // loop over the terms in the gradient vector
-    for (int gradTerm = 0; gradTerm < dx.size(); gradTerm++){ 
+    for (int gradTerm = 0; gradTerm < dx.size(); gradTerm++) {
 
-      double plusGradElement = 0.0; // <+>
+      double plusGradElement = 0.0;  // <+>
       double minusGradElement = 0.0; // <->
 
       // loop over instructions for a given term, compute <+> and <->
-      for (int instElement = 0; instElement < nInstructionsElement[gradTerm]; instElement++) {
+      for (int instElement = 0; instElement < nInstructionsElement[gradTerm];
+           instElement++) {
 
-        auto plus_expval = std::real(results[instElement + shift]->getExpectationValueZ());
-        auto minus_expval = std::real(results[instElement + nInstructionsElement[gradTerm] + shift]->getExpectationValueZ());
+        auto plus_expval =
+            std::real(results[instElement + shift]->getExpectationValueZ());
+        auto minus_expval = std::real(
+            results[instElement + nInstructionsElement[gradTerm] + shift]
+                ->getExpectationValueZ());
         plusGradElement += plus_expval * coefficients[instElement + shift];
-        minusGradElement += minus_expval * coefficients[instElement + nInstructionsElement[gradTerm] + shift];
-
+        minusGradElement +=
+            minus_expval *
+            coefficients[instElement + nInstructionsElement[gradTerm] + shift];
       }
 
       // gradient is (<+> - <->) / 2 *step
-      dx[gradTerm] = std::real(plusGradElement - minusGradElement) / (2.0 * step);
+      dx[gradTerm] =
+          std::real(plusGradElement - minusGradElement) / (2.0 * step);
       shift += 2 * nInstructionsElement[gradTerm];
     }
 
@@ -137,7 +138,7 @@ public:
     nInstructionsElement.clear();
     std::stringstream ss;
     ss << std::setprecision(5) << "Computed gradient: ";
-    for(auto param : dx){
+    for (auto param : dx) {
       ss << param << " ";
     }
     xacc::info(ss.str());
@@ -146,13 +147,13 @@ public:
     return;
   }
 
-  const std::string name() const override { return "central-difference-gradient"; }
+  const std::string name() const override {
+    return "central-difference-gradient";
+  }
   const std::string description() const override { return ""; }
-
 };
 
-
-}
-}
+} // namespace algorithm
+} // namespace xacc
 
 #endif

--- a/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
@@ -27,38 +27,35 @@ namespace algorithm {
 class ForwardDifferenceGradient : public AlgorithmGradientStrategy {
 
 protected:
-
   std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
-  double step = 1.0e-7; // step size
-  double obsExpValue; // <H> expectation value of the observable
+  double step = 1.0e-7;            // step size
+  double obsExpValue;              // <H> expectation value of the observable
 
 public:
-
   // this is a numerical gradient
-  bool isNumerical() const override {
-    return true;
-  }
+  bool isNumerical() const override { return true; }
 
   // Pass the expectation value of the observable
-  void passObsExpValue(double expValue) override {
+  void setFunctionValue(const double expValue) override {
     obsExpValue = expValue;
     return;
   }
 
-  // Change step size if need be
-  bool optionalParameters(const HeterogeneousMap parameters) override {
+  bool initialize(const HeterogeneousMap parameters) override {
 
+    if (!parameters.keyExists<std::shared_ptr<Observable>>("observable")) {
+      xacc::error("Gradient strategy needs observable");
+      return false;
+    }
+
+    obs = parameters.get<std::shared_ptr<Observable>>("observable");
+
+    // Change step size if need be
     if (parameters.keyExists<double>("step")) {
       step = parameters.get<double>("step");
-    } 
+    }
+
     return true;
-
-  }
-
-  // Get observable to compute gradients of
-  void passObservable(const std::shared_ptr<Observable> observable) override {
-    obs = observable;
-    return;
   }
 
   // Get the circuit instructions necessary to compute gradients
@@ -68,49 +65,51 @@ public:
 
     std::stringstream ss;
     ss << std::setprecision(5) << "Input parameters: ";
-    for(auto param : x){
+    for (auto param : x) {
       ss << param << " ";
     }
     xacc::info(ss.str());
     ss.str(std::string());
 
     std::vector<std::shared_ptr<CompositeInstruction>> gradientInstructions;
-    for (int op = 0; op < x.size(); op++){ // loop over operators
+    for (int op = 0; op < x.size(); op++) { // loop over operators
 
-        // shift the parameter by step and observe
-        auto tmpX = x;
-        tmpX[op] += step;
-        auto kernels = obs->observe(circuit);
+      // shift the parameter by step and observe
+      auto tmpX = x;
+      tmpX[op] += step;
+      auto kernels = obs->observe(circuit);
 
-        // loop over circuit instructions
-        // and gather coefficients/instructions
-        for (auto &f : kernels) {
-          auto evaled = f->operator()(tmpX);
-          coefficients.push_back(std::real(f->getCoefficient()));
-          gradientInstructions.push_back(evaled);
-        }
-
-        nInstructionsElement.push_back(kernels.size());
-        
+      // loop over circuit instructions
+      // and gather coefficients/instructions
+      for (auto &f : kernels) {
+        auto evaled = f->operator()(tmpX);
+        coefficients.push_back(std::real(f->getCoefficient()));
+        gradientInstructions.push_back(evaled);
       }
 
-    return gradientInstructions;
+      nInstructionsElement.push_back(kernels.size());
+    }
 
+    return gradientInstructions;
   }
 
   // Compute gradients from executed instructions
-  void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
+  void
+  compute(std::vector<double> &dx,
+          std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
 
     int shift = 0;
     // loop over the remaining number of entries in the gradient vector
-    for (int gradTerm = 0; gradTerm < dx.size(); gradTerm++){ 
+    for (int gradTerm = 0; gradTerm < dx.size(); gradTerm++) {
 
       double gradElement = 0.0;
 
       // loop over instructions for a given term, compute <+> and <->
-      for (int instElement = 0; instElement < nInstructionsElement[gradTerm]; instElement++) {
+      for (int instElement = 0; instElement < nInstructionsElement[gradTerm];
+           instElement++) {
 
-        auto expval = std::real(results[instElement + shift]->getExpectationValueZ());
+        auto expval =
+            std::real(results[instElement + shift]->getExpectationValueZ());
         gradElement += expval * coefficients[instElement + shift];
       }
 
@@ -122,8 +121,8 @@ public:
     coefficients.clear();
     nInstructionsElement.clear();
     std::stringstream ss;
-    ss << std::setprecision(12) << "Computed gradient: ";
-    for(auto param : dx){
+    ss << std::setprecision(5) << "Computed gradient: ";
+    for (auto param : dx) {
       ss << param << " ";
     }
     xacc::info(ss.str());
@@ -132,13 +131,13 @@ public:
     return;
   }
 
-  const std::string name() const override { return "forward-difference-gradient"; }
+  const std::string name() const override {
+    return "forward-difference-gradient";
+  }
   const std::string description() const override { return ""; }
-
 };
 
-
-}
-}
+} // namespace algorithm
+} // namespace xacc
 
 #endif

--- a/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2020 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Daniel Claudino - initial API and implementation
+ *******************************************************************************/
+#ifndef XACC_FORWARD_DIFFERENCE_GRADIENT_HPP_
+#define XACC_FORWARD_DIFFERENCE_GRADIENT_HPP_
+
+#include "CompositeInstruction.hpp"
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "AlgorithmGradientStrategy.hpp"
+#include <iomanip>
+
+using namespace xacc;
+
+namespace xacc {
+namespace algorithm {
+
+class ForwardDifferenceGradient : public AlgorithmGradientStrategy {
+
+protected:
+
+  std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
+  double step = 1.0e-7;
+  double obsExpValue;
+
+public:
+
+  bool isNumerical() const override {
+    return true;
+  }
+
+  void passObsExpValue(double expValue) override {
+    obsExpValue = expValue;
+    return;
+  }
+
+  // passes the Hamiltonian and current ansatz operators to the gradient class
+  bool optionalParameters(const HeterogeneousMap parameters) override {
+
+    if (parameters.keyExists<double>("step")) {
+      step = parameters.get<double>("step");
+    } 
+    return true;
+
+  }
+
+  void passObservable(const std::shared_ptr<Observable> observable) override {
+    obs = observable;
+    return;
+  }
+
+  std::vector<std::shared_ptr<CompositeInstruction>>
+  getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
+                        const std::vector<double> &x) override {
+
+    std::stringstream ss;
+    ss << std::setprecision(5) << "Input parameters: ";
+    for(auto param : x){
+      ss << param << " ";
+    }
+    xacc::info(ss.str());
+    ss.str(std::string());
+
+    std::vector<std::shared_ptr<CompositeInstruction>> gradientInstructions;
+    for (int op = 0; op < x.size(); op++){ // loop over operators
+
+        // shift the parameter by step and observe
+        auto tmpX = x;
+        tmpX[op] += step;
+        auto kernels = obs->observe(circuit);
+
+        // loop over circuit instructions
+        // and gather coefficients/instructions
+        for (auto &f : kernels) {
+          auto evaled = f->operator()(tmpX);
+          coefficients.push_back(std::real(f->getCoefficient()));
+          gradientInstructions.push_back(evaled);
+        }
+
+        nInstructionsElement.push_back(kernels.size());
+        
+      }
+
+    return gradientInstructions;
+
+  }
+
+  void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
+
+    int shift = 0;
+    // loop over the remaining number of entries in the gradient vector
+    for (int gradTerm = 0; gradTerm < dx.size(); gradTerm++){ 
+
+      double gradElement = 0.0;
+
+      // loop over instructions for a given term, compute <+> and <->
+      for (int instElement = 0; instElement < nInstructionsElement[gradTerm]; instElement++) {
+
+        auto expval = std::real(results[instElement + shift]->getExpectationValueZ());
+        gradElement += expval * coefficients[instElement + shift];
+      }
+
+      // gradient is (<+> - <->)/2
+      dx[gradTerm] = std::real(gradElement - obsExpValue) / step;
+      shift += nInstructionsElement[gradTerm];
+    }
+
+    coefficients.clear();
+    nInstructionsElement.clear();
+    std::stringstream ss;
+    ss << std::setprecision(12) << "Computed gradient: ";
+    for(auto param : dx){
+      ss << param << " ";
+    }
+    xacc::info(ss.str());
+    ss.str(std::string());
+
+    return;
+  }
+
+  const std::string name() const override { return "forward-difference-gradient"; }
+  const std::string description() const override { return ""; }
+
+};
+
+
+}
+}
+
+#endif

--- a/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
@@ -29,21 +29,23 @@ class ForwardDifferenceGradient : public AlgorithmGradientStrategy {
 protected:
 
   std::shared_ptr<Observable> obs; // Hamiltonian (or any) observable
-  double step = 1.0e-7;
-  double obsExpValue;
+  double step = 1.0e-7; // step size
+  double obsExpValue; // <H> expectation value of the observable
 
 public:
 
+  // this is a numerical gradient
   bool isNumerical() const override {
     return true;
   }
 
+  // Pass the expectation value of the observable
   void passObsExpValue(double expValue) override {
     obsExpValue = expValue;
     return;
   }
 
-  // passes the Hamiltonian and current ansatz operators to the gradient class
+  // Change step size if need be
   bool optionalParameters(const HeterogeneousMap parameters) override {
 
     if (parameters.keyExists<double>("step")) {
@@ -53,11 +55,13 @@ public:
 
   }
 
+  // Get observable to compute gradients of
   void passObservable(const std::shared_ptr<Observable> observable) override {
     obs = observable;
     return;
   }
 
+  // Get the circuit instructions necessary to compute gradients
   std::vector<std::shared_ptr<CompositeInstruction>>
   getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
                         const std::vector<double> &x) override {
@@ -94,6 +98,7 @@ public:
 
   }
 
+  // Compute gradients from executed instructions
   void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
 
     int shift = 0;

--- a/quantum/plugins/algorithms/gradient_strategies/GradientStrategyActivator.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/GradientStrategyActivator.cpp
@@ -11,6 +11,9 @@
  *   Daniel Claudino - initial API and implementation
  *******************************************************************************/
 #include "ParameterShiftGradient.hpp"
+#include "CentralDifferenceGradient.hpp"
+#include "ForwardDifferenceGradient.hpp"
+#include "BackwardDifferenceGradient.hpp"
 
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
@@ -31,6 +34,15 @@ public:
 
     auto ps = std::make_shared<xacc::algorithm::ParameterShiftGradient>();
     context.RegisterService<xacc::AlgorithmGradientStrategy>(ps);
+
+    auto cd = std::make_shared<xacc::algorithm::CentralDifferenceGradient>();
+    context.RegisterService<xacc::AlgorithmGradientStrategy>(cd);
+
+    auto fd = std::make_shared<xacc::algorithm::ForwardDifferenceGradient>();
+    context.RegisterService<xacc::AlgorithmGradientStrategy>(fd);
+
+    auto bd = std::make_shared<xacc::algorithm::BackwardDifferenceGradient>();
+    context.RegisterService<xacc::AlgorithmGradientStrategy>(bd);
 
   }
 

--- a/quantum/plugins/algorithms/gradient_strategies/ParameterShiftGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/ParameterShiftGradient.hpp
@@ -17,7 +17,6 @@
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 #include "AlgorithmGradientStrategy.hpp"
-#include <complex>
 #include <iomanip>
 
 using namespace xacc;
@@ -50,11 +49,13 @@ public:
     return false;
   }
 
+  // Get observable to compute gradients of
   void passObservable(const std::shared_ptr<Observable> observable) override {
     obs = observable;
     return;
   }
 
+  // Get the circuit instructions necessary to compute gradients
   std::vector<std::shared_ptr<CompositeInstruction>>
   getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
                         const std::vector<double> &x) override {
@@ -116,6 +117,7 @@ public:
 
   }
 
+  // Compute gradients from executed instructions
   void compute(std::vector<double> &dx,
               std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
 

--- a/quantum/plugins/algorithms/gradient_strategies/ParameterShiftGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/ParameterShiftGradient.hpp
@@ -27,33 +27,29 @@ namespace algorithm {
 class ParameterShiftGradient : public AlgorithmGradientStrategy {
 
 protected:
-
-  std::shared_ptr<Observable> obs, commutator; // Hamiltonian (or any) observable
+  std::shared_ptr<Observable> obs,
+      commutator; // Hamiltonian (or any) observable
 
 public:
+  bool initialize(const HeterogeneousMap parameters) override {
 
-  // passes commutator for ADAPT-VQE
-  bool optionalParameters(const HeterogeneousMap parameters) override {
+    if (!parameters.keyExists<std::shared_ptr<Observable>>("observable")) {
+      xacc::error("Gradient strategy needs observable");
+      return false;
+    }
+
+    obs = parameters.get<std::shared_ptr<Observable>>("observable");
 
     // this is specific to ADAPT-VQE
-    if (parameters.keyExists<std::shared_ptr<Observable>>("commutator")){
+    if (parameters.keyExists<std::shared_ptr<Observable>>("commutator")) {
       commutator = parameters.get<std::shared_ptr<Observable>>("commutator");
     }
 
     return true;
-
   }
 
   // Not numerical
-  bool isNumerical() const override {
-    return false;
-  }
-
-  // Get observable to compute gradients of
-  void passObservable(const std::shared_ptr<Observable> observable) override {
-    obs = observable;
-    return;
-  }
+  bool isNumerical() const override { return false; }
 
   // Get the circuit instructions necessary to compute gradients
   std::vector<std::shared_ptr<CompositeInstruction>>
@@ -62,7 +58,7 @@ public:
 
     std::stringstream ss;
     ss << std::setprecision(5) << "Input parameters: ";
-    for(auto param : x){
+    for (auto param : x) {
       ss << param << " ";
     }
     xacc::info(ss.str());
@@ -73,9 +69,9 @@ public:
     // The gradient of the operator added in the current ADAPT-VQE cycle
     // is simply its commutator with the Hamiltonian. This improves convergence
     // over parameter shift
-    
+
     int start = 0;
-    if(commutator){
+    if (commutator) {
       auto kernels = commutator->observe(circuit);
 
       for (auto &f : kernels) {
@@ -87,8 +83,9 @@ public:
       start = 1;
     }
 
-    for (int op = start; op < x.size(); op++){// loop over the remainder of operators
-      for (double sign : {1.0, -1.0}){ // change sign 
+    for (int op = start; op < x.size();
+         op++) {                        // loop over the remainder of operators
+      for (double sign : {1.0, -1.0}) { // change sign
 
         // parameter shift and observe
         auto tmpX = x;
@@ -105,27 +102,26 @@ public:
 
         // the number of instructions for a given element of x is the same
         // regardless of the parameter sign, so we need only one of this
-        if(sign == 1.0){
+        if (sign == 1.0) {
           nInstructionsElement.push_back(kernels.size());
         }
-
       }
-     
     }
 
     return gradientInstructions;
-
   }
 
   // Compute gradients from executed instructions
-  void compute(std::vector<double> &dx,
-              std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
+  void
+  compute(std::vector<double> &dx,
+          std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
 
     // if commutator is provided
     int shift = 0, start = 0;
-    if(commutator){
+    if (commutator) {
       double gradElement = 0.0;
-      for (int instElement = 0; instElement < nInstructionsElement[0]; instElement++){
+      for (int instElement = 0; instElement < nInstructionsElement[0];
+           instElement++) {
         auto expval = std::real(results[instElement]->getExpectationValueZ());
         gradElement += expval * coefficients[instElement];
       }
@@ -137,18 +133,24 @@ public:
     }
 
     // loop over the remaining number of entries in the gradient vector
-    for (int gradTerm = start; gradTerm < dx.size(); gradTerm++){ 
+    for (int gradTerm = start; gradTerm < dx.size(); gradTerm++) {
 
-      double plusGradElement = 0.0; // <+>
+      double plusGradElement = 0.0;  // <+>
       double minusGradElement = 0.0; // <->
 
       // loop over instructions for a given term, compute <+> and <->
-      for (int instElement = 0; instElement < nInstructionsElement[gradTerm]; instElement++) {
+      for (int instElement = 0; instElement < nInstructionsElement[gradTerm];
+           instElement++) {
 
-        auto plus_expval = std::real(results[instElement + shift]->getExpectationValueZ());
-        auto minus_expval = std::real(results[instElement + nInstructionsElement[gradTerm] + shift]->getExpectationValueZ());
+        auto plus_expval =
+            std::real(results[instElement + shift]->getExpectationValueZ());
+        auto minus_expval = std::real(
+            results[instElement + nInstructionsElement[gradTerm] + shift]
+                ->getExpectationValueZ());
         plusGradElement += plus_expval * coefficients[instElement + shift];
-        minusGradElement += minus_expval * coefficients[instElement + nInstructionsElement[gradTerm] + shift];
+        minusGradElement +=
+            minus_expval *
+            coefficients[instElement + nInstructionsElement[gradTerm] + shift];
       }
 
       // gradient is (<+> - <->)/2
@@ -160,7 +162,7 @@ public:
     nInstructionsElement.clear();
     std::stringstream ss;
     ss << std::setprecision(5) << "Computed gradient: ";
-    for(auto param : dx){
+    for (auto param : dx) {
       ss << param << " ";
     }
     xacc::info(ss.str());
@@ -171,11 +173,9 @@ public:
 
   const std::string name() const override { return "parameter-shift-gradient"; }
   const std::string description() const override { return ""; }
-
 };
 
-
-}
-}
+} // namespace algorithm
+} // namespace xacc
 
 #endif

--- a/quantum/plugins/algorithms/gradient_strategies/tests/GradientStrategiesTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/GradientStrategiesTester.cpp
@@ -39,13 +39,88 @@ TEST(GradientStrategiesTester, checkParameterShift)
                         {InstructionParameter("x0")}));
 
   auto parameterShift = xacc::getService<AlgorithmGradientStrategy>("parameter-shift-gradient");
-  parameterShift->optionalParameters({std::make_pair("observable", observable)});
+  parameterShift->passObservable(observable);
   auto gradientInstructions = parameterShift->getGradientExecutions(ansatz, {0.0});
   accelerator->execute(buffer, gradientInstructions);
 
   std::vector<double> dx(1);
   parameterShift->compute(dx, buffer->getChildren());
   EXPECT_NEAR(dx[0], -1.0, 1e-4);
+}
+
+TEST(GradientStrategiesTester, checkCentralDifference) 
+{
+  auto accelerator2 = xacc::getAccelerator("qpp");
+  auto buffer2 = xacc::qalloc(2);
+
+  std::shared_ptr<Observable> observable2 = std::make_shared<xacc::quantum::PauliOperator>();
+  observable2->fromString("X0");
+
+  auto provider2 = xacc::getIRProvider("quantum");
+  auto ansatz2 = provider2->createComposite("testCircuit");
+  ansatz2->addVariable("x0");
+  ansatz2->addInstruction(provider2->createInstruction("Ry", 
+                        std::vector<std::size_t>{0}, 
+                        {InstructionParameter("x0")}));
+
+  auto centralDifference = xacc::getService<AlgorithmGradientStrategy>("central-difference-gradient");
+  centralDifference->passObservable(observable2);
+  auto gradientInstructions = centralDifference->getGradientExecutions(ansatz2, {0.0});
+  accelerator2->execute(buffer2, gradientInstructions);
+
+  std::vector<double> dx(1);
+  centralDifference->compute(dx, buffer2->getChildren());
+  EXPECT_NEAR(dx[0], 1.0, 1e-4);
+}
+
+TEST(GradientStrategiesTester, checkForwardDifference) 
+{
+  auto accelerator3 = xacc::getAccelerator("qpp");
+  auto buffer3 = xacc::qalloc(2);
+
+  std::shared_ptr<Observable> observable3 = std::make_shared<xacc::quantum::PauliOperator>();
+  observable3->fromString("X0");
+
+  auto provider3 = xacc::getIRProvider("quantum");
+  auto ansatz3 = provider3->createComposite("testCircuit");
+  ansatz3->addVariable("x0");
+  ansatz3->addInstruction(provider3->createInstruction("Ry", 
+                        std::vector<std::size_t>{0}, 
+                        {InstructionParameter("x0")}));
+
+  auto forwardDifference = xacc::getService<AlgorithmGradientStrategy>("forward-difference-gradient");
+  forwardDifference->passObservable(observable3);
+  auto gradientInstructions = forwardDifference->getGradientExecutions(ansatz3, {0.0});
+  accelerator3->execute(buffer3, gradientInstructions);
+
+  std::vector<double> dx(1);
+  forwardDifference->compute(dx, buffer3->getChildren());
+  EXPECT_NEAR(dx[0], 1.0, 1e-4);
+}
+
+TEST(GradientStrategiesTester, checkBackwardDifference) 
+{
+  auto accelerator4 = xacc::getAccelerator("qpp");
+  auto buffer4 = xacc::qalloc(2);
+
+  std::shared_ptr<Observable> observable4 = std::make_shared<xacc::quantum::PauliOperator>();
+  observable4->fromString("X0");
+
+  auto provider4 = xacc::getIRProvider("quantum");
+  auto ansatz4 = provider4->createComposite("testCircuit");
+  ansatz4->addVariable("x0");
+  ansatz4->addInstruction(provider4->createInstruction("Ry", 
+                        std::vector<std::size_t>{0}, 
+                        {InstructionParameter("x0")}));
+
+  auto backwardDifference = xacc::getService<AlgorithmGradientStrategy>("backward-difference-gradient");
+  backwardDifference->passObservable(observable4);
+  auto gradientInstructions = backwardDifference->getGradientExecutions(ansatz4, {0.0});
+  accelerator4->execute(buffer4, gradientInstructions);
+
+  std::vector<double> dx(1);
+  backwardDifference->compute(dx, buffer4->getChildren());
+  EXPECT_NEAR(dx[0], 1.0, 1e-4);
 }
 
 int main(int argc, char **argv) 

--- a/quantum/plugins/algorithms/gradient_strategies/tests/GradientStrategiesTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/GradientStrategiesTester.cpp
@@ -23,24 +23,25 @@
 using namespace xacc;
 using namespace xacc::quantum;
 
-TEST(GradientStrategiesTester, checkParameterShift) 
-{
+TEST(GradientStrategiesTester, checkParameterShift) {
   auto accelerator = xacc::getAccelerator("qpp");
   auto buffer = xacc::qalloc(2);
 
-  std::shared_ptr<Observable> observable = std::make_shared<xacc::quantum::PauliOperator>();
+  std::shared_ptr<Observable> observable =
+      std::make_shared<xacc::quantum::PauliOperator>();
   observable->fromString("X0");
 
   auto provider = xacc::getIRProvider("quantum");
   auto ansatz = provider->createComposite("testCircuit");
   ansatz->addVariable("x0");
-  ansatz->addInstruction(provider->createInstruction("Ry", 
-                        std::vector<std::size_t>{0}, 
-                        {InstructionParameter("x0")}));
+  ansatz->addInstruction(provider->createInstruction(
+      "Ry", std::vector<std::size_t>{0}, {InstructionParameter("x0")}));
 
-  auto parameterShift = xacc::getService<AlgorithmGradientStrategy>("parameter-shift-gradient");
-  parameterShift->passObservable(observable);
-  auto gradientInstructions = parameterShift->getGradientExecutions(ansatz, {0.0});
+  auto parameterShift =
+      xacc::getService<AlgorithmGradientStrategy>("parameter-shift-gradient");
+  parameterShift->initialize({std::make_pair("observable", observable)});
+  auto gradientInstructions =
+      parameterShift->getGradientExecutions(ansatz, {0.0});
   accelerator->execute(buffer, gradientInstructions);
 
   std::vector<double> dx(1);
@@ -48,24 +49,25 @@ TEST(GradientStrategiesTester, checkParameterShift)
   EXPECT_NEAR(dx[0], -1.0, 1e-4);
 }
 
-TEST(GradientStrategiesTester, checkCentralDifference) 
-{
+TEST(GradientStrategiesTester, checkCentralDifference) {
   auto accelerator2 = xacc::getAccelerator("qpp");
   auto buffer2 = xacc::qalloc(2);
 
-  std::shared_ptr<Observable> observable2 = std::make_shared<xacc::quantum::PauliOperator>();
+  std::shared_ptr<Observable> observable2 =
+      std::make_shared<xacc::quantum::PauliOperator>();
   observable2->fromString("X0");
 
   auto provider2 = xacc::getIRProvider("quantum");
   auto ansatz2 = provider2->createComposite("testCircuit");
   ansatz2->addVariable("x0");
-  ansatz2->addInstruction(provider2->createInstruction("Ry", 
-                        std::vector<std::size_t>{0}, 
-                        {InstructionParameter("x0")}));
+  ansatz2->addInstruction(provider2->createInstruction(
+      "Ry", std::vector<std::size_t>{0}, {InstructionParameter("x0")}));
 
-  auto centralDifference = xacc::getService<AlgorithmGradientStrategy>("central-difference-gradient");
-  centralDifference->passObservable(observable2);
-  auto gradientInstructions = centralDifference->getGradientExecutions(ansatz2, {0.0});
+  auto centralDifference = xacc::getService<AlgorithmGradientStrategy>(
+      "central-difference-gradient");
+  centralDifference->initialize({std::make_pair("observable", observable2)});
+  auto gradientInstructions =
+      centralDifference->getGradientExecutions(ansatz2, {0.0});
   accelerator2->execute(buffer2, gradientInstructions);
 
   std::vector<double> dx(1);
@@ -73,24 +75,25 @@ TEST(GradientStrategiesTester, checkCentralDifference)
   EXPECT_NEAR(dx[0], 1.0, 1e-4);
 }
 
-TEST(GradientStrategiesTester, checkForwardDifference) 
-{
+TEST(GradientStrategiesTester, checkForwardDifference) {
   auto accelerator3 = xacc::getAccelerator("qpp");
   auto buffer3 = xacc::qalloc(2);
 
-  std::shared_ptr<Observable> observable3 = std::make_shared<xacc::quantum::PauliOperator>();
+  std::shared_ptr<Observable> observable3 =
+      std::make_shared<xacc::quantum::PauliOperator>();
   observable3->fromString("X0");
 
   auto provider3 = xacc::getIRProvider("quantum");
   auto ansatz3 = provider3->createComposite("testCircuit");
   ansatz3->addVariable("x0");
-  ansatz3->addInstruction(provider3->createInstruction("Ry", 
-                        std::vector<std::size_t>{0}, 
-                        {InstructionParameter("x0")}));
+  ansatz3->addInstruction(provider3->createInstruction(
+      "Ry", std::vector<std::size_t>{0}, {InstructionParameter("x0")}));
 
-  auto forwardDifference = xacc::getService<AlgorithmGradientStrategy>("forward-difference-gradient");
-  forwardDifference->passObservable(observable3);
-  auto gradientInstructions = forwardDifference->getGradientExecutions(ansatz3, {0.0});
+  auto forwardDifference = xacc::getService<AlgorithmGradientStrategy>(
+      "forward-difference-gradient");
+  forwardDifference->initialize({std::make_pair("observable", observable3)});
+  auto gradientInstructions =
+      forwardDifference->getGradientExecutions(ansatz3, {0.0});
   accelerator3->execute(buffer3, gradientInstructions);
 
   std::vector<double> dx(1);
@@ -98,24 +101,25 @@ TEST(GradientStrategiesTester, checkForwardDifference)
   EXPECT_NEAR(dx[0], 1.0, 1e-4);
 }
 
-TEST(GradientStrategiesTester, checkBackwardDifference) 
-{
+TEST(GradientStrategiesTester, checkBackwardDifference) {
   auto accelerator4 = xacc::getAccelerator("qpp");
   auto buffer4 = xacc::qalloc(2);
 
-  std::shared_ptr<Observable> observable4 = std::make_shared<xacc::quantum::PauliOperator>();
+  std::shared_ptr<Observable> observable4 =
+      std::make_shared<xacc::quantum::PauliOperator>();
   observable4->fromString("X0");
 
   auto provider4 = xacc::getIRProvider("quantum");
   auto ansatz4 = provider4->createComposite("testCircuit");
   ansatz4->addVariable("x0");
-  ansatz4->addInstruction(provider4->createInstruction("Ry", 
-                        std::vector<std::size_t>{0}, 
-                        {InstructionParameter("x0")}));
+  ansatz4->addInstruction(provider4->createInstruction(
+      "Ry", std::vector<std::size_t>{0}, {InstructionParameter("x0")}));
 
-  auto backwardDifference = xacc::getService<AlgorithmGradientStrategy>("backward-difference-gradient");
-  backwardDifference->passObservable(observable4);
-  auto gradientInstructions = backwardDifference->getGradientExecutions(ansatz4, {0.0});
+  auto backwardDifference = xacc::getService<AlgorithmGradientStrategy>(
+      "backward-difference-gradient");
+  backwardDifference->initialize({std::make_pair("observable", observable4)});
+  auto gradientInstructions =
+      backwardDifference->getGradientExecutions(ansatz4, {0.0});
   accelerator4->execute(buffer4, gradientInstructions);
 
   std::vector<double> dx(1);
@@ -123,8 +127,7 @@ TEST(GradientStrategiesTester, checkBackwardDifference)
   EXPECT_NEAR(dx[0], 1.0, 1e-4);
 }
 
-int main(int argc, char **argv) 
-{
+int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   auto ret = RUN_ALL_TESTS();

--- a/quantum/plugins/algorithms/qaoa/qaoa.cpp
+++ b/quantum/plugins/algorithms/qaoa/qaoa.cpp
@@ -22,314 +22,296 @@
 
 namespace xacc {
 namespace algorithm {
-bool QAOA::initialize(const HeterogeneousMap& parameters) 
-{
-    bool initializeOk = true;
-    // Hyper-parameters for QAOA:
-    // (1) Accelerator (QPU)
-    if (!parameters.pointerLikeExists<Accelerator>("accelerator")) 
-    {
-        std::cout << "'accelerator' is required.\n";
-        // We check all required params; hence don't early return on failure.
-        initializeOk = false;
-    }
-    
-    // (2) Classical optimizer
-    if (!parameters.pointerLikeExists<Optimizer>("optimizer"))
-    {
-        std::cout << "'optimizer' is required.\n";
-        initializeOk = false;
-    }
-    
-    // (3) Number of mixing and cost function steps to use (default = 1)
-    m_nbSteps = 1;
-    if (parameters.keyExists<int>("steps"))
-    {
-        m_nbSteps =  parameters.get<int>("steps");
-    }
-    
-    // (4) Cost Hamiltonian
-    if (!parameters.pointerLikeExists<Observable>("observable")) 
-    {
-        std::cout << "'observable' is required.\n";
-        initializeOk = false;
-    }
+bool QAOA::initialize(const HeterogeneousMap &parameters) {
+  bool initializeOk = true;
+  // Hyper-parameters for QAOA:
+  // (1) Accelerator (QPU)
+  if (!parameters.pointerLikeExists<Accelerator>("accelerator")) {
+    std::cout << "'accelerator' is required.\n";
+    // We check all required params; hence don't early return on failure.
+    initializeOk = false;
+  }
 
-    if (initializeOk)
-    {
-        m_costHamObs = parameters.getPointerLike<Observable>("observable");
-        m_qpu = parameters.getPointerLike<Accelerator>("accelerator");
-        m_optimizer = parameters.getPointerLike<Optimizer>("optimizer");
-        // Optional ref-hamiltonian
-        m_refHamObs = nullptr;
-        if (parameters.pointerLikeExists<Observable>("ref-ham")) 
-        {
-            m_refHamObs = parameters.getPointerLike<Observable>("ref-ham");
-        }
-    }
+  // (2) Classical optimizer
+  if (!parameters.pointerLikeExists<Optimizer>("optimizer")) {
+    std::cout << "'optimizer' is required.\n";
+    initializeOk = false;
+  }
 
-    // we need this for ADAPT-QAOA (Daniel)
-    if (parameters.pointerLikeExists<CompositeInstruction>("ansatz")){
-      externalAnsatz = parameters.get<std::shared_ptr<CompositeInstruction>>("ansatz");
-    }
+  // (3) Number of mixing and cost function steps to use (default = 1)
+  m_nbSteps = 1;
+  if (parameters.keyExists<int>("steps")) {
+    m_nbSteps = parameters.get<int>("steps");
+  }
 
-    if (parameters.pointerLikeExists<AlgorithmGradientStrategy>(
-        "gradient_strategy")){
-      gradientStrategy = parameters.get<std::shared_ptr<AlgorithmGradientStrategy>>("gradient_strategy");
-      gradientStrategy->passObservable(xacc::as_shared_ptr(m_costHamObs));
-    }
+  // (4) Cost Hamiltonian
+  if (!parameters.pointerLikeExists<Observable>("observable")) {
+    std::cout << "'observable' is required.\n";
+    initializeOk = false;
+  }
 
-    if (parameters.stringExists("gradient_strategy") && 
-        !parameters.pointerLikeExists<AlgorithmGradientStrategy>("gradient_strategy") &&
-        m_optimizer->isGradientBased()){
-      gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(parameters.getString("gradient_strategy"));
-      gradientStrategy->passObservable(xacc::as_shared_ptr(m_costHamObs));
+  if (initializeOk) {
+    m_costHamObs = parameters.getPointerLike<Observable>("observable");
+    m_qpu = parameters.getPointerLike<Accelerator>("accelerator");
+    m_optimizer = parameters.getPointerLike<Optimizer>("optimizer");
+    // Optional ref-hamiltonian
+    m_refHamObs = nullptr;
+    if (parameters.pointerLikeExists<Observable>("ref-ham")) {
+      m_refHamObs = parameters.getPointerLike<Observable>("ref-ham");
     }
+  }
 
-    if ((parameters.stringExists("gradient_strategy") || 
-        parameters.pointerLikeExists<AlgorithmGradientStrategy>("gradient_strategy")) &&
-        !m_optimizer->isGradientBased()){
-      xacc::warning("Chosen optimizer does not support gradients. Using default.");
-    }
+  // we need this for ADAPT-QAOA (Daniel)
+  if (parameters.pointerLikeExists<CompositeInstruction>("ansatz")) {
+    externalAnsatz =
+        parameters.get<std::shared_ptr<CompositeInstruction>>("ansatz");
+  }
 
-    return initializeOk;
+  if (parameters.pointerLikeExists<AlgorithmGradientStrategy>(
+          "gradient_strategy")) {
+    gradientStrategy =
+        parameters.get<std::shared_ptr<AlgorithmGradientStrategy>>(
+            "gradient_strategy");
+  }
+
+  if (parameters.stringExists("gradient_strategy") &&
+      !parameters.pointerLikeExists<AlgorithmGradientStrategy>(
+          "gradient_strategy") &&
+      m_optimizer->isGradientBased()) {
+    gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(
+        parameters.getString("gradient_strategy"));
+    gradientStrategy->initialize(
+        {std::make_pair("observable", xacc::as_shared_ptr(m_costHamObs))});
+  }
+
+  if ((parameters.stringExists("gradient_strategy") ||
+       parameters.pointerLikeExists<AlgorithmGradientStrategy>(
+           "gradient_strategy")) &&
+      !m_optimizer->isGradientBased()) {
+    xacc::warning(
+        "Chosen optimizer does not support gradients. Using default.");
+  }
+
+  return initializeOk;
 }
 
-const std::vector<std::string> QAOA::requiredParameters() const 
-{
-    return { "accelerator", "optimizer", "observable" };
+const std::vector<std::string> QAOA::requiredParameters() const {
+  return {"accelerator", "optimizer", "observable"};
 }
 
-void QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const 
-{
-    const int nbQubits = buffer->size();
+void QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
+  const int nbQubits = buffer->size();
 
-    // we need this for ADAPT-QAOA (Daniel)
-    std::shared_ptr<CompositeInstruction> kernel;
-    if(externalAnsatz){
-      kernel = externalAnsatz;
-    } else {
-      kernel = std::dynamic_pointer_cast<CompositeInstruction>(xacc::getService<Instruction>("qaoa"));
-      kernel->expand({
-          std::make_pair("nbQubits", nbQubits),
-          std::make_pair("nbSteps", m_nbSteps),
-          std::make_pair("cost-ham", m_costHamObs),
-          std::make_pair("ref-ham", m_refHamObs)
-      });
-    }
+  // we need this for ADAPT-QAOA (Daniel)
+  std::shared_ptr<CompositeInstruction> kernel;
+  if (externalAnsatz) {
+    kernel = externalAnsatz;
+  } else {
+    kernel = std::dynamic_pointer_cast<CompositeInstruction>(
+        xacc::getService<Instruction>("qaoa"));
+    kernel->expand({std::make_pair("nbQubits", nbQubits),
+                    std::make_pair("nbSteps", m_nbSteps),
+                    std::make_pair("cost-ham", m_costHamObs),
+                    std::make_pair("ref-ham", m_refHamObs)});
+  }
 
-    // Observe the cost Hamiltonian:
-    auto kernels = m_costHamObs->observe(kernel);
+  // Observe the cost Hamiltonian:
+  auto kernels = m_costHamObs->observe(kernel);
 
-    int iterCount = 0;
-    // Construct the optimizer/minimizer:
-    OptFunction f(
-        [&, this](const std::vector<double>& x, std::vector<double>& dx) {
-            std::vector<double> coefficients;
-            std::vector<std::string> kernelNames;
-            std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
+  int iterCount = 0;
+  // Construct the optimizer/minimizer:
+  OptFunction f(
+      [&, this](const std::vector<double> &x, std::vector<double> &dx) {
+        std::vector<double> coefficients;
+        std::vector<std::string> kernelNames;
+        std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
 
-            double identityCoeff = 0.0;
-            int nInstructionsEnergy = 0, nInstructionsGradient = 0;
-            for (auto& f : kernels) 
-            {
-                kernelNames.push_back(f->name());
-                std::complex<double> coeff = f->getCoefficient();
+        double identityCoeff = 0.0;
+        int nInstructionsEnergy = 0, nInstructionsGradient = 0;
+        for (auto &f : kernels) {
+          kernelNames.push_back(f->name());
+          std::complex<double> coeff = f->getCoefficient();
 
-                int nFunctionInstructions = 0;
-                if (f->getInstruction(0)->isComposite()) 
-                {
-                    nFunctionInstructions = kernel->nInstructions() + f->nInstructions() - 1;
-                } 
-                else 
-                {
-                    nFunctionInstructions = f->nInstructions();
-                }
-
-                if (nFunctionInstructions > kernel->nInstructions()) 
-                {
-                    auto evaled = f->operator()(x);
-                    fsToExec.push_back(evaled);
-                    coefficients.push_back(std::real(coeff));
-                } 
-                else 
-                {
-                    identityCoeff += std::real(coeff);
-                }
-            }
-
-            // enables gradients (Daniel)
-            if (gradientStrategy){
-
-              auto gradFsToExec = gradientStrategy->getGradientExecutions(kernel, x);
-              // Add gradient instructions to be sent to the qpu
-              nInstructionsEnergy = fsToExec.size();
-              nInstructionsGradient = gradFsToExec.size();
-              for (auto inst: gradFsToExec){
-                fsToExec.push_back(inst);
-              }
-              xacc::info("Number of instructions for energy calculation: " 
-                          + std::to_string(nInstructionsEnergy));
-              xacc::info("Number of instructions for gradient calculation: "
-                          + std::to_string(nInstructionsGradient));
-
-            }
-
-            auto tmpBuffer = xacc::qalloc(buffer->size());
-            m_qpu->execute(tmpBuffer, fsToExec);
-            auto buffers = tmpBuffer->getChildren();
-
-            double energy = identityCoeff;
-            auto idBuffer = xacc::qalloc(buffer->size());
-            idBuffer->addExtraInfo("coefficient", identityCoeff);
-            idBuffer->setName("I");
-            idBuffer->addExtraInfo("kernel", "I");
-            idBuffer->addExtraInfo("parameters", x);
-            idBuffer->addExtraInfo("exp-val-z", 1.0);
-            buffer->appendChild("I", idBuffer);
-
-            if (gradientStrategy){ // gradient-based optimization
-
-              for (int i = 0; i < nInstructionsEnergy; i++) {// compute energy
-                auto expval = buffers[i]->getExpectationValueZ();
-                energy += expval * coefficients[i];
-                buffers[i]->addExtraInfo("coefficient", coefficients[i]);
-                buffers[i]->addExtraInfo("kernel", fsToExec[i]->name());
-                buffers[i]->addExtraInfo("exp-val-z", expval);
-                buffers[i]->addExtraInfo("parameters", x);
-                buffer->appendChild(fsToExec[i]->name(), buffers[i]);
-              }
-
-              std::stringstream ss;
-              ss << std::setprecision(12) << "Current Energy: " << energy;
-              xacc::info(ss.str());
-              ss.str(std::string());
-
-           // If gradientStrategy is numerical, pass the energy
-           // We subtract the identityCoeff from the energy
-           // instead of passing the energy because the gradients 
-           // only take the coefficients of parameterized instructions
-            if(gradientStrategy->isNumerical()){
-              gradientStrategy->passObsExpValue(energy - identityCoeff);
-            }             
-
-              // update gradient vector
-              gradientStrategy->compute(dx, 
-                std::vector<std::shared_ptr<AcceleratorBuffer>>(buffers.begin() + nInstructionsEnergy, buffers.end()));
-
-            } else {// normal QAOA run
-
-              for (int i = 0; i < buffers.size(); i++) 
-              {
-                  auto expval = buffers[i]->getExpectationValueZ();
-                  energy += expval * coefficients[i];
-                  buffers[i]->addExtraInfo("coefficient", coefficients[i]);
-                  buffers[i]->addExtraInfo("kernel", fsToExec[i]->name());
-                  buffers[i]->addExtraInfo("exp-val-z", expval);
-                  buffers[i]->addExtraInfo("parameters", x);
-                  buffer->appendChild(fsToExec[i]->name(), buffers[i]);
-              }
-            }
-            
-            std::stringstream ss;
-            iterCount++;
-            ss << "Iter " << iterCount << ": E(" << ( !x.empty() ? std::to_string(x[0]) : "");
-            for (int i = 1; i < x.size(); i++)
-            {
-                ss << "," << std::setprecision(3) << x[i];
-                if (i > 4)
-                {
-                    // Don't print too many params
-                    ss << ", ...";
-                    break;
-                }
-            }
-            ss << ") = " << std::setprecision(12) << energy;
-            std::cout << ss.str() << '\n';
-            return energy;
-        },
-        kernel->nVariables());
-
-    auto result = m_optimizer->optimize(f);
-    buffer->addExtraInfo("opt-val", ExtraInfo(result.first));
-    buffer->addExtraInfo("opt-params", ExtraInfo(result.second));
-}
-
-std::vector<double> QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<double>& x) 
-{
-    const int nbQubits = buffer->size();
-    std::shared_ptr<CompositeInstruction> kernel;
-    if(externalAnsatz){
-      kernel = externalAnsatz;
-    } else {
-      kernel = std::dynamic_pointer_cast<CompositeInstruction>(xacc::getService<Instruction>("qaoa"));
-      kernel->expand({
-          std::make_pair("nbQubits", nbQubits),
-          std::make_pair("nbSteps", m_nbSteps),
-          std::make_pair("cost-ham", m_costHamObs),
-          std::make_pair("ref-ham", m_refHamObs)
-      });
-    }
-
-    // Observe the cost Hamiltonian:
-    auto kernels = m_costHamObs->observe(kernel);
-    std::vector<double> coefficients;
-    std::vector<std::string> kernelNames;
-    std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
-
-    double identityCoeff = 0.0;
-    for (auto& f : kernels) 
-    {
-        kernelNames.push_back(f->name());
-        std::complex<double> coeff = f->getCoefficient();
-
-        int nFunctionInstructions = 0;
-        if (f->getInstruction(0)->isComposite()) 
-        {
-            nFunctionInstructions = kernel->nInstructions() + f->nInstructions() - 1;
-        } 
-        else 
-        {
+          int nFunctionInstructions = 0;
+          if (f->getInstruction(0)->isComposite()) {
+            nFunctionInstructions =
+                kernel->nInstructions() + f->nInstructions() - 1;
+          } else {
             nFunctionInstructions = f->nInstructions();
-        }
+          }
 
-        if (nFunctionInstructions > kernel->nInstructions()) 
-        {
+          if (nFunctionInstructions > kernel->nInstructions()) {
             auto evaled = f->operator()(x);
             fsToExec.push_back(evaled);
             coefficients.push_back(std::real(coeff));
-        } 
-        else 
-        {
+          } else {
             identityCoeff += std::real(coeff);
+          }
         }
+
+        // enables gradients (Daniel)
+        if (gradientStrategy) {
+
+          auto gradFsToExec =
+              gradientStrategy->getGradientExecutions(kernel, x);
+          // Add gradient instructions to be sent to the qpu
+          nInstructionsEnergy = fsToExec.size();
+          nInstructionsGradient = gradFsToExec.size();
+          for (auto inst : gradFsToExec) {
+            fsToExec.push_back(inst);
+          }
+          xacc::info("Number of instructions for energy calculation: " +
+                     std::to_string(nInstructionsEnergy));
+          xacc::info("Number of instructions for gradient calculation: " +
+                     std::to_string(nInstructionsGradient));
+        }
+
+        auto tmpBuffer = xacc::qalloc(buffer->size());
+        m_qpu->execute(tmpBuffer, fsToExec);
+        auto buffers = tmpBuffer->getChildren();
+
+        double energy = identityCoeff;
+        auto idBuffer = xacc::qalloc(buffer->size());
+        idBuffer->addExtraInfo("coefficient", identityCoeff);
+        idBuffer->setName("I");
+        idBuffer->addExtraInfo("kernel", "I");
+        idBuffer->addExtraInfo("parameters", x);
+        idBuffer->addExtraInfo("exp-val-z", 1.0);
+        buffer->appendChild("I", idBuffer);
+
+        if (gradientStrategy) { // gradient-based optimization
+
+          for (int i = 0; i < nInstructionsEnergy; i++) { // compute energy
+            auto expval = buffers[i]->getExpectationValueZ();
+            energy += expval * coefficients[i];
+            buffers[i]->addExtraInfo("coefficient", coefficients[i]);
+            buffers[i]->addExtraInfo("kernel", fsToExec[i]->name());
+            buffers[i]->addExtraInfo("exp-val-z", expval);
+            buffers[i]->addExtraInfo("parameters", x);
+            buffer->appendChild(fsToExec[i]->name(), buffers[i]);
+          }
+
+          std::stringstream ss;
+          ss << std::setprecision(12) << "Current Energy: " << energy;
+          xacc::info(ss.str());
+          ss.str(std::string());
+
+          // If gradientStrategy is numerical, pass the energy
+          // We subtract the identityCoeff from the energy
+          // instead of passing the energy because the gradients
+          // only take the coefficients of parameterized instructions
+          if (gradientStrategy->isNumerical()) {
+            gradientStrategy->setFunctionValue(energy - identityCoeff);
+          }
+
+          // update gradient vector
+          gradientStrategy->compute(
+              dx, std::vector<std::shared_ptr<AcceleratorBuffer>>(
+                      buffers.begin() + nInstructionsEnergy, buffers.end()));
+
+        } else { // normal QAOA run
+
+          for (int i = 0; i < buffers.size(); i++) {
+            auto expval = buffers[i]->getExpectationValueZ();
+            energy += expval * coefficients[i];
+            buffers[i]->addExtraInfo("coefficient", coefficients[i]);
+            buffers[i]->addExtraInfo("kernel", fsToExec[i]->name());
+            buffers[i]->addExtraInfo("exp-val-z", expval);
+            buffers[i]->addExtraInfo("parameters", x);
+            buffer->appendChild(fsToExec[i]->name(), buffers[i]);
+          }
+        }
+
+        std::stringstream ss;
+        iterCount++;
+        ss << "Iter " << iterCount << ": E("
+           << (!x.empty() ? std::to_string(x[0]) : "");
+        for (int i = 1; i < x.size(); i++) {
+          ss << "," << std::setprecision(3) << x[i];
+          if (i > 4) {
+            // Don't print too many params
+            ss << ", ...";
+            break;
+          }
+        }
+        ss << ") = " << std::setprecision(12) << energy;
+        std::cout << ss.str() << '\n';
+        return energy;
+      },
+      kernel->nVariables());
+
+  auto result = m_optimizer->optimize(f);
+  buffer->addExtraInfo("opt-val", ExtraInfo(result.first));
+  buffer->addExtraInfo("opt-params", ExtraInfo(result.second));
+}
+
+std::vector<double>
+QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer,
+              const std::vector<double> &x) {
+  const int nbQubits = buffer->size();
+  std::shared_ptr<CompositeInstruction> kernel;
+  if (externalAnsatz) {
+    kernel = externalAnsatz;
+  } else {
+    kernel = std::dynamic_pointer_cast<CompositeInstruction>(
+        xacc::getService<Instruction>("qaoa"));
+    kernel->expand({std::make_pair("nbQubits", nbQubits),
+                    std::make_pair("nbSteps", m_nbSteps),
+                    std::make_pair("cost-ham", m_costHamObs),
+                    std::make_pair("ref-ham", m_refHamObs)});
+  }
+
+  // Observe the cost Hamiltonian:
+  auto kernels = m_costHamObs->observe(kernel);
+  std::vector<double> coefficients;
+  std::vector<std::string> kernelNames;
+  std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
+
+  double identityCoeff = 0.0;
+  for (auto &f : kernels) {
+    kernelNames.push_back(f->name());
+    std::complex<double> coeff = f->getCoefficient();
+
+    int nFunctionInstructions = 0;
+    if (f->getInstruction(0)->isComposite()) {
+      nFunctionInstructions = kernel->nInstructions() + f->nInstructions() - 1;
+    } else {
+      nFunctionInstructions = f->nInstructions();
     }
 
-    auto tmpBuffer = xacc::qalloc(buffer->size());
-    m_qpu->execute(tmpBuffer, fsToExec);
-    auto buffers = tmpBuffer->getChildren();
-
-    double energy = identityCoeff;
-    auto idBuffer = xacc::qalloc(buffer->size());
-    idBuffer->addExtraInfo("coefficient", identityCoeff);
-    idBuffer->setName("I");
-    idBuffer->addExtraInfo("kernel", "I");
-    idBuffer->addExtraInfo("parameters", x);
-    idBuffer->addExtraInfo("exp-val-z", 1.0);
-    buffer->appendChild("I", idBuffer);
-
-    for (int i = 0; i < buffers.size(); i++) 
-    {
-        auto expval = buffers[i]->getExpectationValueZ();
-        energy += expval * coefficients[i];
-        buffers[i]->addExtraInfo("coefficient", coefficients[i]);
-        buffers[i]->addExtraInfo("kernel", fsToExec[i]->name());
-        buffers[i]->addExtraInfo("exp-val-z", expval);
-        buffers[i]->addExtraInfo("parameters", x);
-        buffer->appendChild(fsToExec[i]->name(), buffers[i]);
+    if (nFunctionInstructions > kernel->nInstructions()) {
+      auto evaled = f->operator()(x);
+      fsToExec.push_back(evaled);
+      coefficients.push_back(std::real(coeff));
+    } else {
+      identityCoeff += std::real(coeff);
     }
-    
-    return { energy };
+  }
+
+  auto tmpBuffer = xacc::qalloc(buffer->size());
+  m_qpu->execute(tmpBuffer, fsToExec);
+  auto buffers = tmpBuffer->getChildren();
+
+  double energy = identityCoeff;
+  auto idBuffer = xacc::qalloc(buffer->size());
+  idBuffer->addExtraInfo("coefficient", identityCoeff);
+  idBuffer->setName("I");
+  idBuffer->addExtraInfo("kernel", "I");
+  idBuffer->addExtraInfo("parameters", x);
+  idBuffer->addExtraInfo("exp-val-z", 1.0);
+  buffer->appendChild("I", idBuffer);
+
+  for (int i = 0; i < buffers.size(); i++) {
+    auto expval = buffers[i]->getExpectationValueZ();
+    energy += expval * coefficients[i];
+    buffers[i]->addExtraInfo("coefficient", coefficients[i]);
+    buffers[i]->addExtraInfo("kernel", fsToExec[i]->name());
+    buffers[i]->addExtraInfo("exp-val-z", expval);
+    buffers[i]->addExtraInfo("parameters", x);
+    buffer->appendChild(fsToExec[i]->name(), buffers[i]);
+  }
+
+  return {energy};
 }
 
 } // namespace algorithm

--- a/quantum/plugins/algorithms/vqe/vqe.cpp
+++ b/quantum/plugins/algorithms/vqe/vqe.cpp
@@ -28,13 +28,13 @@ bool VQE::initialize(const HeterogeneousMap &parameters) {
   if (!parameters.pointerLikeExists<Observable>("observable")) {
     std::cout << "Obs was false\n";
     return false;
-  } 
-  
+  }
+
   if (!parameters.pointerLikeExists<CompositeInstruction>("ansatz")) {
     std::cout << "Ansatz was false\n";
     return false;
-  } 
-  
+  }
+
   if (!parameters.pointerLikeExists<Accelerator>("accelerator")) {
     std::cout << "Acc was false\n";
     return false;
@@ -49,23 +49,30 @@ bool VQE::initialize(const HeterogeneousMap &parameters) {
 
   // if gradient is provided
   if (parameters.pointerLikeExists<AlgorithmGradientStrategy>(
-      "gradient_strategy")){
-    gradientStrategy = parameters.get<std::shared_ptr<AlgorithmGradientStrategy>>(
-      "gradient_strategy");
-    gradientStrategy->passObservable(xacc::as_shared_ptr(observable));
+          "gradient_strategy")) {
+    gradientStrategy =
+        parameters.get<std::shared_ptr<AlgorithmGradientStrategy>>(
+            "gradient_strategy");
+    // gradientStrategy->initialize({std::make_pair("observable",
+    // xacc::as_shared_ptr(observable))});
   }
 
-  if (parameters.stringExists("gradient_strategy") && 
-      !parameters.pointerLikeExists<AlgorithmGradientStrategy>("gradient_strategy") &&
-       optimizer->isGradientBased()){
-    gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(parameters.getString("gradient_strategy"));
-    gradientStrategy->passObservable(xacc::as_shared_ptr(observable));
+  if (parameters.stringExists("gradient_strategy") &&
+      !parameters.pointerLikeExists<AlgorithmGradientStrategy>(
+          "gradient_strategy") &&
+      optimizer->isGradientBased()) {
+    gradientStrategy = xacc::getService<AlgorithmGradientStrategy>(
+        parameters.getString("gradient_strategy"));
+    gradientStrategy->initialize(
+        {std::make_pair("observable", xacc::as_shared_ptr(observable))});
   }
 
-  if ((parameters.stringExists("gradient_strategy") || 
-      parameters.pointerLikeExists<AlgorithmGradientStrategy>("gradient_strategy")) &&
-      !optimizer->isGradientBased()){
-    xacc::warning("Chosen optimizer does not support gradients. Using default.");
+  if ((parameters.stringExists("gradient_strategy") ||
+       parameters.pointerLikeExists<AlgorithmGradientStrategy>(
+           "gradient_strategy")) &&
+      !optimizer->isGradientBased()) {
+    xacc::warning(
+        "Chosen optimizer does not support gradients. Using default.");
   }
 
   return true;
@@ -119,22 +126,22 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
           }
         }
 
-        // Retrieve instructions for gradient, if a pointer of type 
+        // Retrieve instructions for gradient, if a pointer of type
         // AlgorithmGradientStrategy is given
-        if (gradientStrategy){
+        if (gradientStrategy) {
 
-          auto gradFsToExec = gradientStrategy->getGradientExecutions(xacc::as_shared_ptr(kernel), x);
+          auto gradFsToExec = gradientStrategy->getGradientExecutions(
+              xacc::as_shared_ptr(kernel), x);
           // Add gradient instructions to be sent to the qpu
           nInstructionsEnergy = fsToExec.size();
           nInstructionsGradient = gradFsToExec.size();
-          for (auto inst: gradFsToExec){
+          for (auto inst : gradFsToExec) {
             fsToExec.push_back(inst);
           }
-          xacc::info("Number of instructions for energy calculation: " 
-                      + std::to_string(nInstructionsEnergy));
-          xacc::info("Number of instructions for gradient calculation: "
-                      + std::to_string(nInstructionsGradient));
-
+          xacc::info("Number of instructions for energy calculation: " +
+                     std::to_string(nInstructionsEnergy));
+          xacc::info("Number of instructions for gradient calculation: " +
+                     std::to_string(nInstructionsGradient));
         }
 
         auto tmpBuffer = xacc::qalloc(buffer->size());
@@ -160,9 +167,9 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
             buffer->appendChild(b->name(), b);
           }
 
-        } else if (gradientStrategy){ // gradient-based optimization
+        } else if (gradientStrategy) { // gradient-based optimization
 
-          for (int i = 0; i < nInstructionsEnergy; i++) {// compute energy
+          for (int i = 0; i < nInstructionsEnergy; i++) { // compute energy
             auto expval = buffers[i]->getExpectationValueZ();
             energy += expval * coefficients[i];
             buffers[i]->addExtraInfo("coefficient", coefficients[i]);
@@ -177,19 +184,20 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
           xacc::info(ss.str());
           ss.str(std::string());
 
-           // If gradientStrategy is numerical, pass the energy
-           // We subtract the identityCoeff from the energy
-           // instead of passing the energy because the gradients 
-           // only take the coefficients of parameterized instructions
-            if(gradientStrategy->isNumerical()){
-              gradientStrategy->passObsExpValue(energy - identityCoeff);
-            }   
+          // If gradientStrategy is numerical, pass the energy
+          // We subtract the identityCoeff from the energy
+          // instead of passing the energy because the gradients
+          // only take the coefficients of parameterized instructions
+          if (gradientStrategy->isNumerical()) {
+            gradientStrategy->setFunctionValue(energy - identityCoeff);
+          }
 
           // update gradient vector
-          gradientStrategy->compute(dx, 
-            std::vector<std::shared_ptr<AcceleratorBuffer>>(buffers.begin() + nInstructionsEnergy, buffers.end()));
+          gradientStrategy->compute(
+              dx, std::vector<std::shared_ptr<AcceleratorBuffer>>(
+                      buffers.begin() + nInstructionsEnergy, buffers.end()));
 
-        } else {// normal VQE run
+        } else { // normal VQE run
           for (int i = 0; i < buffers.size(); i++) {
             auto expval = buffers[i]->getExpectationValueZ();
             energy += expval * coefficients[i];

--- a/xacc/algorithm/AlgorithmGradientStrategy.hpp
+++ b/xacc/algorithm/AlgorithmGradientStrategy.hpp
@@ -21,41 +21,38 @@ namespace xacc {
 class AlgorithmGradientStrategy : public Identifiable {
 
 protected:
-
-  std::vector<int> nInstructionsElement; // # of instructions for each element in gradient vector
+  std::vector<int> nInstructionsElement; // # of instructions for each element
+                                         // in gradient vector
   std::vector<double> coefficients; // coefficient that multiplies Pauli term
 
 public:
-
   // Finite differences need <H(x)>, so we need to know if it's numerical
-  virtual bool isNumerical() const = 0 ;
+  virtual bool isNumerical() const = 0;
 
   // Pass expectation value of observable if it is numerical
-  virtual void passObsExpValue(const double expValue) {
+  virtual void setFunctionValue(const double expValue) {
     XACCLogger::instance()->error(
-        "AlgorithmGradientStrategy::passObsExpValue(double) not implemented for " +
+        "AlgorithmGradientStrategy::passEvaledCostFxn(double) not implemented "
+        "for " +
         name());
     exit(0);
     return;
   }
 
-  // Pass parameters to a specific gradient implementation
-  virtual bool optionalParameters(const HeterogeneousMap parameters) = 0;
-
-  // Pass Observable to compute gradients of
-  // Moved this out of optionalParameters because it's not optional
-  virtual void passObservable(const std::shared_ptr<Observable> observable) = 0; 
+  // Pass parameters to initialize specific gradient implementation
+  virtual bool initialize(const HeterogeneousMap parameters) = 0;
 
   // Generate circuits to enable gradient computation
   virtual std::vector<std::shared_ptr<CompositeInstruction>>
   getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
                         const std::vector<double> &x) = 0;
 
-  // Compute the gradient vector given a vector of AcceleratorBuffers with executed circuits
-  virtual void compute(std::vector<double> &dx, 
-                       std::vector<std::shared_ptr<AcceleratorBuffer>> results) = 0;
-
+  // Compute the gradient vector given a vector of AcceleratorBuffers with
+  // executed circuits
+  virtual void
+  compute(std::vector<double> &dx,
+          std::vector<std::shared_ptr<AcceleratorBuffer>> results) = 0;
 };
 
-} 
+} // namespace xacc
 #endif

--- a/xacc/algorithm/AlgorithmGradientStrategy.hpp
+++ b/xacc/algorithm/AlgorithmGradientStrategy.hpp
@@ -27,15 +27,33 @@ protected:
 
 public:
 
+  // Finite differences need <H(x)>, so we need to know if it's numerical
+  virtual bool isNumerical() const = 0 ;
+
+  // Pass expectation value of observable if it is numerical
+  virtual void passObsExpValue(const double expValue) {
+    XACCLogger::instance()->error(
+        "AlgorithmGradientStrategy::passObsExpValue(double) not implemented for " +
+        name());
+    exit(0);
+    return;
+  }
+
   // Pass parameters to a specific gradient implementation
   virtual bool optionalParameters(const HeterogeneousMap parameters) = 0;
 
+  // Pass Observable to compute gradients of
+  // Moved this out of optionalParameters because it's not optional
+  virtual void passObservable(const std::shared_ptr<Observable> observable) = 0; 
+
   // Generate circuits to enable gradient computation
   virtual std::vector<std::shared_ptr<CompositeInstruction>>
-  getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit, const std::vector<double> &x) = 0;
+  getGradientExecutions(std::shared_ptr<CompositeInstruction> circuit,
+                        const std::vector<double> &x) = 0;
 
   // Compute the gradient vector given a vector of AcceleratorBuffers with executed circuits
-  virtual void compute(std::vector<double> &dx, std::vector<std::shared_ptr<AcceleratorBuffer>> results) = 0;
+  virtual void compute(std::vector<double> &dx, 
+                       std::vector<std::shared_ptr<AcceleratorBuffer>> results) = 0;
 
 };
 


### PR DESCRIPTION
- `AlgorithmGradientStrategy.hpp` declares ` void passObservable()` to pass the observable we're computing the gradients of since the observable used to compute the gradients is a required parameter
- `AlgorithmGradientStrategy.hpp` declares `bool isNumerical()` to check if gradient is numerical
- `AlgorithmGradientStrategy.hpp` declares `void passObsExpValue()` to take the expectation value of observable if gradient is numerical
- `CentralDifferenceGradient.hpp` implements central finite differences
- `ForwardDifferenceGradient.hpp` implements forward finite differences
- `BackwardDifferenceGradient.hpp` implements backward finite differences
- `ParameterShiftGradient.hpp` no longer requires the `factor` variable
- `GradientStrategyTester.cpp` implements tests for the newly implemented gradient strategies
- Modified `adapt.cpp`, `qaoa.cpp`, and `vqe.ccp` to work with the updated `AlgorihmGradientStrategy` methods