### PR TITLE
Implemented Quantum Natural Gradients as a XACC gradient strategy service

### DIFF
--- a/python/examples/qng_example.py
+++ b/python/examples/qng_example.py
@@ -1,0 +1,76 @@
+
+# Demonstrate Quantum Natural Gradient strategy
+# when using with VQE.
+import xacc,sys, numpy as np
+from matplotlib import pyplot as plt
+
+# Run the VQE algorithm using Gradient-Descent optimizer:
+# @param: gradientStrategy (string): the name of the gradient calculation strategy:
+# e.g. 'quantum-natural-gradient' or 'central-difference-gradient'
+# @return: the energy values during optimization (as an array)
+# Adapted from: https://pennylane.ai/qml/demos/tutorial_quantum_natural_gradient.html
+def runVqeGradientDescent(gradientStrategy):
+    # Get access to the desired QPU and
+    # allocate some qubits to run on
+    qpu = xacc.getAccelerator('qpp')
+
+    # Construct the Hamiltonian as an XACC PauliOperator
+    ham = xacc.getObservable('pauli', '1.0 Y0')
+
+    # Ansatz circuit:
+    xacc.qasm('''.compiler xasm
+    .circuit ansatz
+    .qbit q
+    .parameters t0, t1, t2, t3
+    // State-prep 
+    Ry(q[0], pi/4);
+    Ry(q[1], pi/3);
+    Ry(q[2], pi/7);
+    // Parametrized gates (layer 1)
+    Rz(q[0], t0);
+    Rz(q[1], t1);
+    CX(q[0], q[1]);
+    CX(q[1], q[2]);
+    // Parametrized gates (layer 2)
+    Ry(q[1], t2);
+    Rx(q[2], t3);
+    CX(q[0], q[1]);
+    CX(q[1], q[2]);
+    ''')
+
+    # We need 4 qubits
+    buffer = xacc.qalloc(4)
+    ansatz_circuit = xacc.getCompiled('ansatz')
+    initParams = [ 0.432, -0.123, 0.543, 0.233 ]
+    opt = xacc.getOptimizer('mlpack', { 
+                            # Using gradient descent:
+                            'mlpack-optimizer': 'gd',
+                            'initial-parameters': initParams,
+                            'mlpack-step-size': 0.01,
+                            'mlpack-max-iter': 200 })
+
+    # Create the VQE algorithm with the requested gradient strategy
+    vqe = xacc.getAlgorithm('vqe', {
+                            'ansatz': ansatz_circuit,
+                            'accelerator': qpu,
+                            'observable': ham,
+                            'optimizer': opt,
+                            'gradient_strategy': gradientStrategy
+                            })
+    vqe.execute(buffer)
+    energies = buffer.getInformation('params-energy')
+    return energies
+
+# Quantum Natural Gradients
+energies_qng = runVqeGradientDescent('quantum-natural-gradient')
+# Vanilla Gradients (central differential)
+energies_vanilla = runVqeGradientDescent('central-difference-gradient')
+
+# Plot the results:
+plt.style.use('seaborn')
+plt.plot(energies_qng, 'g', label='Quantum natural gradient')
+plt.plot(energies_vanilla, 'k', label='Vanilla gradient')
+plt.ylabel('Cost function value')
+plt.xlabel('Optimization steps')
+plt.legend()
+plt.show()

--- a/quantum/plugins/algorithms/gradient_strategies/CMakeLists.txt
+++ b/quantum/plugins/algorithms/gradient_strategies/CMakeLists.txt
@@ -48,6 +48,13 @@ else()
   set_target_properties(${LIBRARY_NAME}
                         PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
   set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")
+  # Armadillo solver (QNG strategy) needs LAPACK
+  find_package(LAPACK)
+  if(LAPACK_FOUND)
+   target_link_libraries(${LIBRARY_NAME} PRIVATE ${LAPACK_LIBRARIES})
+  else()
+    message(STATUS "LAPACK NOT FOUND. Quantum Natual Gradients plugin may not work.")
+  endif()
 endif()
 
 if(XACC_BUILD_TESTS)

--- a/quantum/plugins/algorithms/gradient_strategies/GradientStrategyActivator.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/GradientStrategyActivator.cpp
@@ -15,6 +15,7 @@
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/ServiceProperties.h"
+#include "QuantumNaturalGradient.hpp"
 
 #include <memory>
 
@@ -31,7 +32,7 @@ public:
 
     auto ps = std::make_shared<xacc::algorithm::ParameterShiftGradient>();
     context.RegisterService<xacc::AlgorithmGradientStrategy>(ps);
-
+    context.RegisterService<xacc::AlgorithmGradientStrategy>(std::make_shared<xacc::algorithm::QuantumNaturalGradient>());
   }
 
   void Stop(BundleContext /*context*/) {}

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Thien Nguyen - initial API and implementation
+ *******************************************************************************/
+
+#include "QuantumNaturalGradient.hpp"
+
+using namespace xacc;
+
+namespace xacc {
+namespace algorithm {
+bool QuantumNaturalGradient::optionalParameters(const HeterogeneousMap in_parameters)
+{
+    // TODO: 
+    return true;
+}
+
+std::vector<std::shared_ptr<CompositeInstruction>> QuantumNaturalGradient::getGradientExecutions(std::shared_ptr<CompositeInstruction> in_circuit, const std::vector<double>& in_x) 
+{
+    // TODO:
+    return { in_circuit };
+}
+
+void QuantumNaturalGradient::compute(std::vector<double>& out_dx, std::vector<std::shared_ptr<AcceleratorBuffer>> in_results)
+{
+    // TODO
+}
+}
+}

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -12,9 +12,31 @@
  *******************************************************************************/
 
 #include "QuantumNaturalGradient.hpp"
+#include "xacc.hpp"
+#include <cassert>
 
 using namespace xacc;
 
+namespace {
+std::optional<xacc::quantum::PauliOperator> getGenerator(const InstPtr& in_inst) 
+{
+    if (in_inst->name() == "Rx")
+    {
+        return xacc::quantum::PauliOperator(0.5, "X" + std::to_string(in_inst->bits()[0]));
+    }
+    if (in_inst->name() == "Ry")
+    {
+        return xacc::quantum::PauliOperator(0.5, "Y" + std::to_string(in_inst->bits()[0]));
+
+    }
+    if (in_inst->name() == "Rz")
+    {
+        return xacc::quantum::PauliOperator(0.5, "Z" + std::to_string(in_inst->bits()[0]));
+    }
+
+    return std::nullopt;
+}
+}
 namespace xacc {
 namespace algorithm {
 bool QuantumNaturalGradient::optionalParameters(const HeterogeneousMap in_parameters)
@@ -33,5 +55,57 @@ void QuantumNaturalGradient::compute(std::vector<double>& out_dx, std::vector<st
 {
     // TODO
 }
+
+std::vector<ParametrizedCircuitLayer> ParametrizedCircuitLayer::toParametrizedLayers(const std::shared_ptr<xacc::CompositeInstruction>& in_circuit)
+{
+    const auto variables = in_circuit->getVariables();
+    if (variables.empty())
+    {
+        xacc::error("Input circuit is not parametrized.");
+    }
+
+    // Assemble parametrized circuit layer:
+    std::vector<ParametrizedCircuitLayer> layers; 
+    auto& currentLayer = layers.emplace_back();
+    std::set<size_t> qubitsInLayer;
+    for (size_t instIdx = 0; instIdx < in_circuit->nInstructions(); ++instIdx)
+    {
+        const auto& inst = in_circuit->getInstruction(instIdx);
+        if (!inst->isParameterized())
+        {
+            currentLayer.ops.emplace_back(inst);
+        }
+        else
+        {
+            const auto& instParam = inst->getParameters()[0];
+            if (instParam.isVariable())
+            {
+                const auto varName = instParam.as<std::string>();
+                const auto iter = std::find(variables.begin(), variables.end(), varName); 
+                assert(iter != variables.end());
+                assert(inst->bits().size() == 1);
+                const auto bitIdx = inst->bits()[0];
+                // This qubit line was already acted upon in this layer by a parametrized gate.
+                // Hence, start a new layer.
+                if (xacc::container::contains(qubitsInLayer, bitIdx))
+                {
+                    assert(!currentLayer.ops.empty() && !currentLayer.paramInds.empty());
+                    auto& currentLayer = layers.emplace_back();
+                    qubitsInLayer.clear();
+                }
+
+                currentLayer.ops.emplace_back(inst);
+                currentLayer.paramInds.emplace_back(std::distance(iter, variables.begin()));
+                qubitsInLayer.emplace(bitIdx);
+            } 
+            else
+            {
+                currentLayer.ops.emplace_back(inst);
+            }
+        }
+    }
+
+    return layers;
+}    
 }
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -66,7 +66,7 @@ std::vector<ParametrizedCircuitLayer> ParametrizedCircuitLayer::toParametrizedLa
 
     // Assemble parametrized circuit layer:
     std::vector<ParametrizedCircuitLayer> layers; 
-    auto& currentLayer = layers.emplace_back();
+    ParametrizedCircuitLayer currentLayer;
     std::set<size_t> qubitsInLayer;
     for (size_t instIdx = 0; instIdx < in_circuit->nInstructions(); ++instIdx)
     {
@@ -77,7 +77,7 @@ std::vector<ParametrizedCircuitLayer> ParametrizedCircuitLayer::toParametrizedLa
         }
         else
         {
-            const auto& instParam = inst->getParameters()[0];
+            const auto& instParam = inst->getParameter(0);
             if (instParam.isVariable())
             {
                 const auto varName = instParam.as<std::string>();
@@ -90,10 +90,9 @@ std::vector<ParametrizedCircuitLayer> ParametrizedCircuitLayer::toParametrizedLa
                 if (xacc::container::contains(qubitsInLayer, bitIdx))
                 {
                     assert(!currentLayer.ops.empty() && !currentLayer.paramInds.empty());
-                    auto& currentLayer = layers.emplace_back();
+                    layers.emplace_back(std::move(currentLayer));
                     qubitsInLayer.clear();
                 }
-
                 currentLayer.ops.emplace_back(inst);
                 currentLayer.paramInds.emplace_back(std::distance(iter, variables.begin()));
                 qubitsInLayer.emplace(bitIdx);
@@ -105,6 +104,8 @@ std::vector<ParametrizedCircuitLayer> ParametrizedCircuitLayer::toParametrizedLa
         }
     }
 
+    assert(!currentLayer.ops.empty() && !currentLayer.paramInds.empty());
+    layers.emplace_back(std::move(currentLayer));
     return layers;
 }    
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -23,16 +23,15 @@ std::optional<xacc::quantum::PauliOperator> getGenerator(const InstPtr& in_inst)
 {
     if (in_inst->name() == "Rx")
     {
-        return xacc::quantum::PauliOperator(0.5, "X" + std::to_string(in_inst->bits()[0]));
+        return xacc::quantum::PauliOperator({{ in_inst->bits()[0], "X" }}, 0.5);
     }
     if (in_inst->name() == "Ry")
     {
-        return xacc::quantum::PauliOperator(0.5, "Y" + std::to_string(in_inst->bits()[0]));
-
+        return xacc::quantum::PauliOperator({{ in_inst->bits()[0], "Y" }}, 0.5);
     }
     if (in_inst->name() == "Rz")
     {
-        return xacc::quantum::PauliOperator(0.5, "Z" + std::to_string(in_inst->bits()[0]));
+        return xacc::quantum::PauliOperator({{ in_inst->bits()[0], "Z" }}, 0.5);
     }
 
     return std::nullopt;

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -140,6 +140,8 @@ void QuantumNaturalGradient::compute(std::vector<double>& out_dx, std::vector<st
     const auto gMat = constructMetricTensorMatrix(metricTensorResults);
     arma::dvec gradients(rawDx); 
     arma::dvec newGrads = arma::solve(gMat, gradients);
+    // std::cout << "Regular gradients:\n" << gradients << "\n";
+    // std::cout << "Natural gradients:\n" << newGrads << "\n";
     out_dx = arma::conv_to<std::vector<double>>::from(newGrads); 
 }
 
@@ -252,7 +254,6 @@ arma::dmat QuantumNaturalGradient::constructMetricTensorMatrix(const std::vector
             }
         }
 
-        std::cout << "Block matrix: \n" << blockMat << "\n";
         for (size_t i = 0; i < nbParamsInBlock; ++i)
         {
             for(size_t j = 0; j < nbParamsInBlock; ++j)
@@ -263,8 +264,6 @@ arma::dmat QuantumNaturalGradient::constructMetricTensorMatrix(const std::vector
 
         blockIdx += nbParamsInBlock;
     }
-
-    std::cout << "Metric tensor matrix: \n" << gMat << "\n";
 
     return gMat;
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -103,7 +103,7 @@ std::vector<std::shared_ptr<CompositeInstruction>> QuantumNaturalGradient::getGr
             if (!isIdentityTerm(layer.kiTerms[i]))
             {
                 metricTensorKernels.emplace_back(kernels[kernelIdx]);
-                m_metricTermToIdx.emplace(layer.kiTerms[i].toString(), metricTensorKernels.size());
+                m_metricTermToIdx.emplace(layer.kiTerms[i].toString(), metricTensorKernels.size() - 1);
             }
             kernelIdx++;
         }        
@@ -183,7 +183,8 @@ ObservedKernels QuantumNaturalGradient::constructMetricTensorSubCircuit(Parametr
             circuitToObs->addVariable(varName);
             const auto iter = std::find(in_varNames.begin(), in_varNames.end(), varName); 
             assert(iter != in_varNames.end());
-            const size_t idx = std::distance(iter, in_varNames.begin());
+            const size_t idx = std::distance(in_varNames.begin(), iter);
+            assert(idx < in_varVals.size());
             resolvedParams.emplace_back(in_varVals[idx]);
         }
     }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -14,6 +14,7 @@
 #include "AlgorithmGradientStrategy.hpp"
 #include "CompositeInstruction.hpp"
 #include "PauliOperator.hpp"
+#include <armadillo>
 
 using namespace xacc;
 
@@ -43,6 +44,7 @@ public:
     virtual bool initialize(const xacc::HeterogeneousMap in_parameters) override;
     virtual ObservedKernels getGradientExecutions(std::shared_ptr<xacc::CompositeInstruction> in_circuit, const std::vector<double>& in_x) override;
     virtual void compute(std::vector<double>& out_dx, std::vector<std::shared_ptr<xacc::AcceleratorBuffer>> in_results) override;
+    virtual void setFunctionValue(const double expValue) override { m_gradientStrategy->setFunctionValue(expValue); }
     virtual const std::string name() const override { return "quantum-natural-gradient"; }
     virtual const std::string description() const override { return ""; }
 
@@ -51,11 +53,15 @@ private:
     ObservedKernels constructMetricTensorSubCircuit(const ParametrizedCircuitLayer& in_layer, 
                                                     const std::vector<std::string>& in_varNames, 
                                                     const std::vector<double>& in_varVals) const; 
+    arma::dmat constructMetricTensorMatrix(const std::vector<std::shared_ptr<xacc::AcceleratorBuffer>>& in_results) const;
 
 private:
     // The *regular* gradient strategy service whose gradients will
     // be 'modified' via this QNG metric tensor.
     std::shared_ptr<AlgorithmGradientStrategy> m_gradientStrategy;
+    // Cache the circuit layer structure to reconstruct metric tensor.
+    std::vector<ParametrizedCircuitLayer> m_layers;
+    size_t m_nbMetricTensorKernels;
 };
 }
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -12,10 +12,29 @@
  *******************************************************************************/
 #pragma once
 #include "AlgorithmGradientStrategy.hpp"
+#include "CompositeInstruction.hpp"
+#include "PauliOperator.hpp"
+
 using namespace xacc;
 
 namespace xacc {
 namespace algorithm {
+// Represents a parametrized circuit layer:
+// we push the layer boundary as far as possible (greedy)
+struct ParametrizedCircuitLayer
+{
+    // Gates that precede the layer
+    std::vector<InstPtr> preOps; 
+    // Parametrized operators in the layer
+    std::vector<InstPtr> ops;
+    // Corresponding optimization parameter indices
+    std::vector<size_t> paramInds;
+    // Gates that succeed the layer
+    std::vector<InstPtr> postOps;
+    // Partition the circuit into layers.
+    static std::vector<ParametrizedCircuitLayer> toParametrizedLayers(const std::shared_ptr<xacc::CompositeInstruction>& in_circuit);
+};
+
 class QuantumNaturalGradient : public AlgorithmGradientStrategy
 {
 public:

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -32,6 +32,9 @@ struct ParametrizedCircuitLayer
     std::vector<size_t> paramInds;
     // Gates that succeed the layer
     std::vector<InstPtr> postOps;
+    // Tensor matrix terms:
+    std::vector<xacc::quantum::PauliOperator> kiTerms;
+    std::vector<xacc::quantum::PauliOperator> kikjTerms;
     // Partition the circuit into layers.
     static std::vector<ParametrizedCircuitLayer> toParametrizedLayers(const std::shared_ptr<xacc::CompositeInstruction>& in_circuit);
 };
@@ -50,7 +53,7 @@ public:
 
 private:
     // Constructs circuits to observe Fubini-Study metric tensor elements.
-    ObservedKernels constructMetricTensorSubCircuit(const ParametrizedCircuitLayer& in_layer, 
+    ObservedKernels constructMetricTensorSubCircuit(ParametrizedCircuitLayer& io_layer, 
                                                     const std::vector<std::string>& in_varNames, 
                                                     const std::vector<double>& in_varVals) const; 
     arma::dmat constructMetricTensorMatrix(const std::vector<std::shared_ptr<xacc::AcceleratorBuffer>>& in_results) const;
@@ -62,6 +65,8 @@ private:
     // Cache the circuit layer structure to reconstruct metric tensor.
     std::vector<ParametrizedCircuitLayer> m_layers;
     size_t m_nbMetricTensorKernels;
+    // Keeps track of the term and the index in the kernel sequence.
+    std::unordered_map<std::string, size_t> m_metricTermToIdx;
 };
 }
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -38,11 +38,20 @@ struct ParametrizedCircuitLayer
 class QuantumNaturalGradient : public AlgorithmGradientStrategy
 {
 public:
-virtual bool optionalParameters(const xacc::HeterogeneousMap in_parameters) override;
-virtual std::vector<std::shared_ptr<xacc::CompositeInstruction>> getGradientExecutions(std::shared_ptr<xacc::CompositeInstruction> in_circuit, const std::vector<double>& in_x) override;
-virtual void compute(std::vector<double>& out_dx, std::vector<std::shared_ptr<xacc::AcceleratorBuffer>> in_results) override;
-virtual const std::string name() const override { return "quantum-natural-gradient"; }
-virtual const std::string description() const override { return ""; }
+    virtual bool optionalParameters(const xacc::HeterogeneousMap in_parameters) override;
+    virtual std::vector<std::shared_ptr<xacc::CompositeInstruction>> getGradientExecutions(std::shared_ptr<xacc::CompositeInstruction> in_circuit, const std::vector<double>& in_x) override;
+    virtual void compute(std::vector<double>& out_dx, std::vector<std::shared_ptr<xacc::AcceleratorBuffer>> in_results) override;
+    virtual const std::string name() const override { return "quantum-natural-gradient"; }
+    virtual const std::string description() const override { return ""; }
+
+private:
+    // Constructs circuits to observe Fubini-Study metric tensor elements.
+    std::vector<std::shared_ptr<xacc::CompositeInstruction>> constructMetricTensorSubCircuit(const ParametrizedCircuitLayer& in_layer) const; 
+
+private:
+    // The *regular* gradient strategy service whose gradients will
+    // be 'modified' via this QNG metric tensor.
+    std::shared_ptr<AlgorithmGradientStrategy> m_gradientStrategy;
 };
 }
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -56,7 +56,7 @@ private:
     ObservedKernels constructMetricTensorSubCircuit(ParametrizedCircuitLayer& io_layer, 
                                                     const std::vector<std::string>& in_varNames, 
                                                     const std::vector<double>& in_varVals) const; 
-    arma::dmat constructMetricTensorMatrix(const std::vector<std::shared_ptr<xacc::AcceleratorBuffer>>& in_results) const;
+    arma::dmat constructMetricTensorMatrix(const std::vector<std::shared_ptr<xacc::AcceleratorBuffer>>& in_results);
 
 private:
     // The *regular* gradient strategy service whose gradients will
@@ -67,6 +67,7 @@ private:
     size_t m_nbMetricTensorKernels;
     // Keeps track of the term and the index in the kernel sequence.
     std::unordered_map<std::string, size_t> m_metricTermToIdx;
+    size_t m_nbParams;
 };
 }
 }

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Thien Nguyen - initial API and implementation
+ *******************************************************************************/
+#pragma once
+#include "AlgorithmGradientStrategy.hpp"
+using namespace xacc;
+
+namespace xacc {
+namespace algorithm {
+class QuantumNaturalGradient : public AlgorithmGradientStrategy
+{
+public:
+virtual bool optionalParameters(const xacc::HeterogeneousMap in_parameters) override;
+virtual std::vector<std::shared_ptr<xacc::CompositeInstruction>> getGradientExecutions(std::shared_ptr<xacc::CompositeInstruction> in_circuit, const std::vector<double>& in_x) override;
+virtual void compute(std::vector<double>& out_dx, std::vector<std::shared_ptr<xacc::AcceleratorBuffer>> in_results) override;
+virtual const std::string name() const override { return "quantum-natural-gradient"; }
+virtual const std::string description() const override { return ""; }
+};
+}
+}

--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.hpp
@@ -35,19 +35,22 @@ struct ParametrizedCircuitLayer
     static std::vector<ParametrizedCircuitLayer> toParametrizedLayers(const std::shared_ptr<xacc::CompositeInstruction>& in_circuit);
 };
 
+using ObservedKernels = std::vector<std::shared_ptr<xacc::CompositeInstruction>>;
 class QuantumNaturalGradient : public AlgorithmGradientStrategy
 {
 public:
     virtual bool isNumerical() const override { return true; }
     virtual bool initialize(const xacc::HeterogeneousMap in_parameters) override;
-    virtual std::vector<std::shared_ptr<xacc::CompositeInstruction>> getGradientExecutions(std::shared_ptr<xacc::CompositeInstruction> in_circuit, const std::vector<double>& in_x) override;
+    virtual ObservedKernels getGradientExecutions(std::shared_ptr<xacc::CompositeInstruction> in_circuit, const std::vector<double>& in_x) override;
     virtual void compute(std::vector<double>& out_dx, std::vector<std::shared_ptr<xacc::AcceleratorBuffer>> in_results) override;
     virtual const std::string name() const override { return "quantum-natural-gradient"; }
     virtual const std::string description() const override { return ""; }
 
 private:
     // Constructs circuits to observe Fubini-Study metric tensor elements.
-    std::vector<std::shared_ptr<xacc::CompositeInstruction>> constructMetricTensorSubCircuit(const ParametrizedCircuitLayer& in_layer) const; 
+    ObservedKernels constructMetricTensorSubCircuit(const ParametrizedCircuitLayer& in_layer, 
+                                                    const std::vector<std::string>& in_varNames, 
+                                                    const std::vector<double>& in_varVals) const; 
 
 private:
     // The *regular* gradient strategy service whose gradients will

--- a/quantum/plugins/algorithms/gradient_strategies/tests/CMakeLists.txt
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/CMakeLists.txt
@@ -13,3 +13,7 @@
 include_directories(${CMAKE_BINARY_DIR})
 add_xacc_test(GradientStrategies)
 target_link_libraries(GradientStrategiesTester xacc xacc-pauli) 
+
+add_xacc_test(QuantumNatualGradient)
+target_link_libraries(QuantumNatualGradientTester xacc xacc-pauli xacc-gradient-strategies) 
+target_include_directories(QuantumNatualGradientTester PRIVATE ../) 

--- a/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
@@ -15,6 +15,7 @@
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 #include "QuantumNaturalGradient.hpp"
+#include "Observable.hpp"
 
 using namespace xacc;
 using namespace xacc::algorithm;
@@ -92,6 +93,36 @@ TEST(QuantumNatualGradientTester, checkLayers)
         EXPECT_EQ(layers[1].preOps.size(), 7);
     }
 }
+
+TEST(QuantumNatualGradientTester, checkCircuitGen)
+{
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    auto ir = xasmCompiler->compile(R"(__qpu__ void ansatz3(qbit q, double t0, double t1, double t2, double t3) {
+        // State-prep 
+        Ry(q[0], pi/4);
+        Ry(q[1], pi/3);
+        Ry(q[2], pi/2);
+        // Parametrized gates (layer 1)
+        Rz(q[0], t0);
+        Rz(q[1], t1);
+        CX(q[0], q[1]);
+        CX(q[1], q[2]);
+        // Parametrized gates (layer 2)
+        Ry(q[1], t2);
+        Rx(q[2], t3);
+        CX(q[0], q[1]);
+        CX(q[1], q[2]);
+    })", nullptr);
+
+    auto program = ir->getComposite("ansatz3");
+    std::shared_ptr<Observable> observable = std::make_shared<xacc::quantum::PauliOperator>();
+    observable->fromString("Y0");
+
+    auto qng = xacc::getService<AlgorithmGradientStrategy>("quantum-natural-gradient");
+    EXPECT_TRUE(qng->initialize({std::make_pair("observable", observable)}));
+    const std::vector<double> params(4, 0.0);
+    auto kernels = qng->getGradientExecutions(program, params);
+} 
 
 int main(int argc, char **argv) 
 {

--- a/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
@@ -101,7 +101,7 @@ TEST(QuantumNatualGradientTester, checkCircuitGen)
         // State-prep 
         Ry(q[0], pi/4);
         Ry(q[1], pi/3);
-        Ry(q[2], pi/2);
+        Ry(q[2], pi/7);
         // Parametrized gates (layer 1)
         Rz(q[0], t0);
         Rz(q[1], t1);
@@ -135,7 +135,7 @@ TEST(QuantumNatualGradientTester, checkVQE)
         // State-prep 
         Ry(q[0], pi/4);
         Ry(q[1], pi/3);
-        Ry(q[2], pi/2);
+        Ry(q[2], pi/7);
         // Parametrized gates (layer 1)
         Rz(q[0], t0);
         Rz(q[1], t1);
@@ -167,6 +167,11 @@ TEST(QuantumNatualGradientTester, checkVQE)
                                 std::make_pair("gradient_strategy", "quantum-natural-gradient")}));
     auto buffer = xacc::qalloc(4);
     vqe->execute(buffer);
+    const double finalCostValue = (*buffer)["opt-val"].as<double>();
+    std::cout << "Energy = " << finalCostValue << "\n";
+    // Check this plot: ~ -0.6
+    // https://pennylane.ai/qml/demos/tutorial_quantum_natural_gradient.html#quantum-natural-gradient-optimization
+    EXPECT_NEAR(finalCostValue, -0.6, 0.1);
 } 
 
 int main(int argc, char **argv) 

--- a/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
@@ -35,7 +35,9 @@ TEST(QuantumNatualGradientTester, checkLayers)
         auto program = ir->getComposite("ansatz1");
         auto layers = ParametrizedCircuitLayer::toParametrizedLayers(program);
         EXPECT_EQ(layers.size(), 1);
-        EXPECT_EQ(layers[0].ops.size(), program->nInstructions());
+        EXPECT_EQ(layers[0].ops.size(), 1);
+        EXPECT_EQ(layers[0].preOps.size(), 1);
+        EXPECT_EQ(layers[0].postOps.size(), 3);
         EXPECT_EQ(layers[0].paramInds.size(), 1);
         EXPECT_EQ(layers[0].paramInds[0], 0);
     }
@@ -62,8 +64,8 @@ TEST(QuantumNatualGradientTester, checkLayers)
         auto program = ir->getComposite("ansatz2");
         auto layers = ParametrizedCircuitLayer::toParametrizedLayers(program);
         EXPECT_EQ(layers.size(), 2);
-        EXPECT_EQ(layers[0].ops.size(), 7);
-        EXPECT_EQ(layers[1].ops.size(), 4);
+        EXPECT_EQ(layers[0].ops.size(), 2);
+        EXPECT_EQ(layers[1].ops.size(), 2);
         EXPECT_EQ(layers[0].paramInds.size(), 2);
         EXPECT_EQ(layers[1].paramInds.size(), 2);
         // Direct compare (via stringtify) the layered circuit vs. the original
@@ -73,9 +75,21 @@ TEST(QuantumNatualGradientTester, checkLayers)
         reconstructedKernel->addVariable("t1");
         reconstructedKernel->addVariable("t2");
         reconstructedKernel->addVariable("t3");
+        
+        // Test layer 1
+        reconstructedKernel->addInstructions(layers[0].preOps);
         reconstructedKernel->addInstructions(layers[0].ops);
-        reconstructedKernel->addInstructions(layers[1].ops);
+        reconstructedKernel->addInstructions(layers[0].postOps);
         EXPECT_EQ(reconstructedKernel->toString(), program->toString());
+        EXPECT_EQ(layers[0].preOps.size(), 3);
+
+        // Test layer 2
+        reconstructedKernel->clear();
+        reconstructedKernel->addInstructions(layers[1].preOps);
+        reconstructedKernel->addInstructions(layers[1].ops);
+        reconstructedKernel->addInstructions(layers[1].postOps);
+        EXPECT_EQ(reconstructedKernel->toString(), program->toString());
+        EXPECT_EQ(layers[1].preOps.size(), 7);
     }
 }
 

--- a/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
@@ -122,7 +122,10 @@ TEST(QuantumNatualGradientTester, checkCircuitGen)
     EXPECT_TRUE(qng->initialize({std::make_pair("observable", observable)}));
     const std::vector<double> params(4, 0.0);
     auto kernels = qng->getGradientExecutions(program, params);
-    EXPECT_EQ(kernels.size(), 20);
+    // Ki = 4
+    // KiKj = 4*4 = 16
+    // out of 16 KiKj terms, 4 KiKi terms are identity terms, hence no circuits.
+    EXPECT_EQ(kernels.size(), 20 - 4);
 } 
 
 TEST(QuantumNatualGradientTester, checkVQE)
@@ -151,7 +154,7 @@ TEST(QuantumNatualGradientTester, checkVQE)
 
     auto qng = xacc::getService<AlgorithmGradientStrategy>("quantum-natural-gradient");
     EXPECT_TRUE(qng->initialize({std::make_pair("observable", observable)}));
-    const std::vector<double> params(4, 0.0);
+    const std::vector<double> params { 0.432, -0.123, 0.543, 0.233 };
     auto kernels = qng->getGradientExecutions(program, params);
 
     auto optimizer = xacc::getOptimizer("mlpack");

--- a/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/QuantumNatualGradientTester.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2020 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Thien Nguyen - initial API and implementation
+ *******************************************************************************/
+
+#include <gtest/gtest.h>
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "QuantumNaturalGradient.hpp"
+
+using namespace xacc;
+using namespace xacc::algorithm;
+
+TEST(QuantumNatualGradientTester, checkLayers) 
+{
+    // Single layer
+    {
+        auto xasmCompiler = xacc::getCompiler("xasm");
+        auto ir = xasmCompiler->compile(R"(__qpu__ void ansatz1(qbit q, double t) {
+            X(q[0]);
+            Ry(q[1], t);
+            CX(q[1], q[0]);
+            H(q[0]);
+            H(q[1]);
+        })", nullptr);
+
+        auto program = ir->getComposite("ansatz1");
+        auto layers = ParametrizedCircuitLayer::toParametrizedLayers(program);
+        EXPECT_EQ(layers.size(), 1);
+        EXPECT_EQ(layers[0].ops.size(), program->nInstructions());
+        EXPECT_EQ(layers[0].paramInds.size(), 1);
+        EXPECT_EQ(layers[0].paramInds[0], 0);
+    }
+    // Two layers
+    {
+        auto xasmCompiler = xacc::getCompiler("xasm");
+        auto ir = xasmCompiler->compile(R"(__qpu__ void ansatz2(qbit q, double t0, double t1, double t2, double t3) {
+            // State-prep 
+            Ry(q[0], pi/4);
+            Ry(q[1], pi/3);
+            Ry(q[2], pi/2);
+            // Parametrized gates (layer 1)
+            Rz(q[0], t0);
+            Rz(q[1], t1);
+            CX(q[0], q[1]);
+            CX(q[1], q[2]);
+            // Parametrized gates (layer 2)
+            Ry(q[1], t2);
+            Rx(q[2], t3);
+            CX(q[0], q[1]);
+            CX(q[1], q[2]);
+        })", nullptr);
+
+        auto program = ir->getComposite("ansatz2");
+        auto layers = ParametrizedCircuitLayer::toParametrizedLayers(program);
+        EXPECT_EQ(layers.size(), 2);
+        EXPECT_EQ(layers[0].ops.size(), 7);
+        EXPECT_EQ(layers[1].ops.size(), 4);
+        EXPECT_EQ(layers[0].paramInds.size(), 2);
+        EXPECT_EQ(layers[1].paramInds.size(), 2);
+        // Direct compare (via stringtify) the layered circuit vs. the original
+        auto gateRegistry = xacc::getService<IRProvider>("quantum");
+        auto reconstructedKernel = gateRegistry->createComposite("test_recon");
+        reconstructedKernel->addVariable("t0");
+        reconstructedKernel->addVariable("t1");
+        reconstructedKernel->addVariable("t2");
+        reconstructedKernel->addVariable("t3");
+        reconstructedKernel->addInstructions(layers[0].ops);
+        reconstructedKernel->addInstructions(layers[1].ops);
+        EXPECT_EQ(reconstructedKernel->toString(), program->toString());
+    }
+}
+
+int main(int argc, char **argv) 
+{
+    xacc::Initialize(argc, argv);
+    ::testing::InitGoogleTest(&argc, argv);
+    auto ret = RUN_ALL_TESTS();
+    xacc::Finalize();
+    return ret;
+}

--- a/quantum/plugins/algorithms/vqe/vqe.cpp
+++ b/quantum/plugins/algorithms/vqe/vqe.cpp
@@ -90,6 +90,8 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
   }
 
   auto kernels = observable->observe(xacc::as_shared_ptr(kernel));
+  // Cache of energy values during iterations.
+  std::vector<double> energies;
 
   // Here we just need to make a lambda kernel
   // to optimize that makes calls to the targeted QPU.
@@ -215,6 +217,8 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
           ss << "," << x[i];
         ss << ") = " << std::setprecision(12) << energy;
         xacc::info(ss.str());
+        // Saves the energy value.
+        energies.emplace_back(energy);
         return energy;
       },
       kernel->nVariables());
@@ -223,6 +227,8 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
 
   buffer->addExtraInfo("opt-val", ExtraInfo(result.first));
   buffer->addExtraInfo("opt-params", ExtraInfo(result.second));
+  // Adds energies so that users can examine the convergence.
+  buffer->addExtraInfo("params-energy", ExtraInfo(energies));
   return;
 }
 

--- a/xacc/algorithm/AlgorithmGradientStrategy.hpp
+++ b/xacc/algorithm/AlgorithmGradientStrategy.hpp
@@ -34,7 +34,7 @@ public:
   // Pass expectation value of observable if it is numerical
   virtual void setFunctionValue(const double expValue) {
     XACCLogger::instance()->error(
-        "AlgorithmGradientStrategy::passEvaledCostFxn(double) not implemented "
+        "AlgorithmGradientStrategy::setFunctionValue(double) not implemented "
         "for " +
         name());
     exit(0);

--- a/xacc/algorithm/AlgorithmGradientStrategy.hpp
+++ b/xacc/algorithm/AlgorithmGradientStrategy.hpp
@@ -15,9 +15,11 @@
 #define XACC_ALGORITHM_GRADIENT_STRATEGY_HPP_
 
 #include "Identifiable.hpp"
-
+#include "heterogeneous.hpp"
 namespace xacc {
-
+// Forward declare:
+class CompositeInstruction;
+class AcceleratorBuffer;
 class AlgorithmGradientStrategy : public Identifiable {
 
 protected:


### PR DESCRIPTION
The QNG strategy is implemented as a wrapper of another regular numerical gradient plugin (forward, backward, central, etc.)

It will analyze the ansatz circuit structure to define the Fubini-Study metric tensor structure (block-diagonal) and append the circuits required to observe those entries.

When the results are returned, it computes the regular gradients (using the wrapped gradient strategy) and the metric tensor. Then, the 'natural' gradients are computed from those two.

Minor enhancement to the VQE plugin to return the iterating energy values in the buffer.
