### PR TITLE
Added ability to add a custom prefix to the XACC log filename

### DIFF
--- a/xacc/utils/Utils.cpp
+++ b/xacc/utils/Utils.cpp
@@ -217,7 +217,7 @@ void XACCLogger::createFileLogger() {
 
     const std::string DEFAULT_FILE_NAME_PREFIX = "xacc_log_";
     const std::string DEFAULT_FILE_NAME_POSTFIX = ".txt";
-    const std::string fileName = DEFAULT_FILE_NAME_PREFIX + getCurrentTimeForFileName() + DEFAULT_FILE_NAME_POSTFIX;
+    const std::string fileName = logFileNamePrefix + "_" + DEFAULT_FILE_NAME_PREFIX + getCurrentTimeForFileName() + DEFAULT_FILE_NAME_POSTFIX;
     // Create a file logger using the timestamped filename in the logs folder.
     fileLogger = spdlog::basic_logger_mt(loggerName, logDir + "/" + fileName);
   }
@@ -225,7 +225,7 @@ void XACCLogger::createFileLogger() {
   fileLogger->set_level(spdlog::level::info);
 }
 
-void XACCLogger::logToFile(bool enable) {
+void XACCLogger::logToFile(bool enable, const std::string& fileNamePrefix) {
   // Switching the current setting
   if (enable != useFile) {
     // Always dump any enqueued messages before switching.
@@ -234,6 +234,7 @@ void XACCLogger::logToFile(bool enable) {
     // log message to the appropriate logger.
     useFile = enable;
   }
+  logFileNamePrefix = fileNamePrefix;
 }
 
 void XACCLogger::setLoggingLevel(int level) {

--- a/xacc/utils/Utils.hpp
+++ b/xacc/utils/Utils.hpp
@@ -164,6 +164,9 @@ protected:
   std::vector<LoggingLevelNotification> loggingLevelSubscribers;
   
   std::queue<std::string> logQueue;
+  
+  // Custom filename prefix (if logging to file)
+  std::string logFileNamePrefix;
 
   XACCLogger();
   
@@ -193,7 +196,8 @@ public:
   // If enable = true, switch to File logging (if not already logging to file).
   // If enable = false, stop logging to File if currently is.
   // This enables dev to scope a section which should log to File.
-  void logToFile(bool enable);
+  // Optionally, a prefix can be specified to customize log file.
+  void logToFile(bool enable, const std::string& fileNamePrefix = "");
 
   // Set level for log filtering:
   // 0: Errors and Warnings only

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -112,7 +112,7 @@ void setGlobalLoggerPredicate(MessagePredicate predicate) {
   XACCLogger::instance()->dumpQueue();
 }
 
-void logToFile(bool enable) { XACCLogger::instance()->logToFile(enable); }
+void logToFile(bool enable, const std::string &fileNamePrefix) { XACCLogger::instance()->logToFile(enable, fileNamePrefix); }
 
 void setLoggingLevel(int level) {
   XACCLogger::instance()->setLoggingLevel(level);

--- a/xacc/xacc.hpp
+++ b/xacc/xacc.hpp
@@ -95,7 +95,7 @@ void addCommandLineOptions(const std::string &category,
 void addCommandLineOptions(const std::map<std::string, std::string> &options);
 
 void setGlobalLoggerPredicate(MessagePredicate predicate);
-void logToFile(bool enable);
+void logToFile(bool enable, const std::string &fileNamePrefix = "");
 void setLoggingLevel(int level);
 int getLoggingLevel();
 void subscribeLoggingLevel(LoggingLevelNotification callback);


### PR DESCRIPTION
Use case: MPI execution, e.g. each MPI process uses its rank to customize the filename.

Tested by: using this with TNQVM and checking log files.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>