### PR TITLE
Fixed MacOS build

### DIFF
--- a/quantum/python/CMakeLists.txt
+++ b/quantum/python/CMakeLists.txt
@@ -1,10 +1,20 @@
+set(LIBRARY_NAME xacc-quantum-py)
+
 include_directories(${Python_INCLUDE_DIRS})
 include_directories(${CMAKE_SOURCE_DIR}/tpls/pybind11/include)
 
-add_library(xacc-quantum-py SHARED xacc-quantum-py.cpp)
+add_library(${LIBRARY_NAME} SHARED xacc-quantum-py.cpp)
 
-target_include_directories(xacc-quantum-py PUBLIC . ${CMAKE_SOURCE_DIR}/quantum/plugins/utils ${CMAKE_SOURCE_DIR}/python)
+target_include_directories(${LIBRARY_NAME} PUBLIC . ${CMAKE_SOURCE_DIR}/quantum/plugins/utils ${CMAKE_SOURCE_DIR}/python)
 
-target_link_libraries(xacc-quantum-py PUBLIC xacc xacc-fermion xacc-pauli xacc-quantum-gate)
+target_link_libraries(${LIBRARY_NAME} PUBLIC xacc xacc-fermion xacc-pauli xacc-quantum-gate)
 
-install(TARGETS xacc-quantum-py DESTINATION ${CMAKE_INSTALL_PREFIX})
+if(APPLE)
+   set_target_properties(${LIBRARY_NAME} PROPERTIES INSTALL_RPATH "@loader_path/lib")
+   set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else()
+   set_target_properties(${LIBRARY_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN/lib")
+   set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")
+endif()
+
+install(TARGETS ${LIBRARY_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
`xacc-quantum-py` shared lib build config missed the 'magic' `rpath` config.

Tested by: building and unit testing on both Mac and Linux.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>