### PR TITLE
Fixed gate merge bug during circuit rewrite

### DIFF
--- a/quantum/plugins/optimizers/gate_merge/GateMergeOptimizer.cpp
+++ b/quantum/plugins/optimizers/gate_merge/GateMergeOptimizer.cpp
@@ -109,11 +109,12 @@ void MergeSingleQubitGatesOptimizer::apply(std::shared_ptr<CompositeInstruction>
                 }
                 else
                 {
-                    const auto locationToInsert = sequence[0];
+                    auto locationToInsert = sequence[0];
                     for (auto& newInst: zyz->getInstructions())
                     {
                         newInst->setBits({bitIdx});
                         program->insertInstruction(locationToInsert, newInst->clone());
+                        locationToInsert++;
                     }
                 }
                 
@@ -283,11 +284,12 @@ void MergeTwoQubitBlockOptimizer::apply(std::shared_ptr<CompositeInstruction> pr
                 }
                 else
                 {
-                    const auto locationToInsert = sequence[0];
+                    auto locationToInsert = sequence[0];
                     for (auto& newInst: kak->getInstructions())
                     {
                         newInst->setBits(remapBits(newInst->bits()));
                         program->insertInstruction(locationToInsert, newInst->clone());
+                        locationToInsert++;
                     }
                 }
                 // Jump forward since we don't want to re-analyze this block.


### PR DESCRIPTION
The gates were inserted in reverse order :(

This fixes https://github.com/ORNL-QCI/qcor/issues/28 

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>