### PR TITLE
Run XACC HPC TearDown after others (e.g. ExaTN's TearDown)

### DIFF
--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
@@ -71,6 +71,7 @@ private:
 class HPCVirtTearDown : public xacc::TearDown {
 public:
   virtual void tearDown() override;
+  virtual std::string name() const override { return "xacc-hpc-virt"; }
 };
 } // namespace quantum
 } // namespace xacc

--- a/xacc/utils/TearDown.hpp
+++ b/xacc/utils/TearDown.hpp
@@ -13,14 +13,15 @@
  *******************************************************************************/
 
 #pragma once
-
-// TearDown interface: all registered TearDown services 
+#include <string>
+// TearDown interface: all registered TearDown services
 // will have its tearDown() method called once xacc is about to Finalize().
-// Contributing services (e.g. plugins) can use this to clean up any global resources
-// that they instantiated.
+// Contributing services (e.g. plugins) can use this to clean up any global
+// resources that they instantiated.
 namespace xacc {
 class TearDown {
 public:
-    virtual void tearDown() = 0;
+  virtual void tearDown() = 0;
+  virtual std::string name() const { return ""; }
 };
-} //namespace
+} // namespace xacc


### PR DESCRIPTION
Added a name() method to TearDown, default is empty.

HPC Teardown to have a custom name and XACC will defer its execution to last.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>