### PR TITLE
Qrack: Adding QUnitMulti option

### DIFF
--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
@@ -40,6 +40,11 @@ namespace quantum {
             m_use_qunit = params.get<bool>("use_qunit");
         }
 
+        if (params.keyExists<bool>("use_opencl_multi"))
+        {
+            m_use_opencl_multi = params.get<bool>("use_opencl_multi");
+        }
+
         if (params.keyExists<int>("device_id"))
         {
             m_device_id = params.get<int>("device_id");
@@ -101,7 +106,7 @@ namespace quantum {
         }
 
         const auto runCircuit = [&](int shots){
-            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_device_id, m_do_normalize, m_zero_threshold);
+            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_opencl_multi, m_device_id, m_do_normalize, m_zero_threshold);
 
             // Walk the IR tree, and visit each node
             InstructionIterator it(compositeInstruction);

--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
@@ -36,6 +36,7 @@ private:
     int m_shots = -1;
     bool m_use_opencl = true;
     bool m_use_qunit = true;
+    bool m_use_opencl_multi = false;
     int m_device_id = -1;
     bool m_do_normalize = true;
     double m_zero_threshold = min_norm;

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
@@ -19,7 +19,7 @@
 
 namespace xacc {
 namespace quantum {
-    void QrackVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, int device_id, bool doNormalize, double zero_threshold)
+    void QrackVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, int device_id, bool doNormalize, double zero_threshold)
     {
         m_buffer = std::move(buffer);
         m_measureBits.clear();
@@ -27,7 +27,7 @@ namespace quantum {
         m_shotsMode = shots > 1;
 
         Qrack::QInterfaceEngine qIType2 = use_opencl ? Qrack::QINTERFACE_OPTIMAL : Qrack::QINTERFACE_CPU;
-        Qrack::QInterfaceEngine qIType1 = use_qunit ? Qrack::QINTERFACE_QUNIT : qIType2;
+        Qrack::QInterfaceEngine qIType1 = use_qunit ? (use_opencl_multi ? Qrack::QINTERFACE_QUNIT_MULTI : Qrack::QINTERFACE_QUNIT) : qIType2;
 
         m_qReg = MAKE_ENGINE(m_buffer->size(), 0);
     }

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
@@ -34,7 +34,7 @@ namespace xacc {
 namespace quantum {
 class QrackVisitor : public AllGateVisitor, public OptionsProvider, public xacc::Cloneable<QrackVisitor> {
 public:
-  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, int device_id, bool doNormalize, double zero_threshold);
+  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, int device_id, bool doNormalize, double zero_threshold);
   void finalize();
 
   void visit(Hadamard& h) override;


### PR DESCRIPTION
The Qrack library has offered an experimental multi-accelerator engine type for OpenCL, for some time. I previously hadn't included it as an option in third party integrations, because it long failed to return any practical gains. However, after further development, Qrack users are reporting that the `QUnitMulti` type can see performance advantages from the use of multiple OpenCL accelerators for the same `QInterface`.

It is likely worth including the option (off by default) of using `QUnitMulti`. This engine type is also cluster-ready, through an OpenCL virtualization layer such as SnuCL, though I can't guarantee this will give a performance advantage under arbitrary conditions.