### PR TITLE
Fixed staq->xasm translation w.r.t. floating point format

### DIFF
--- a/quantum/plugins/staq/compiler/tests/StaqCompilerTester.in.cpp
+++ b/quantum/plugins/staq/compiler/tests/StaqCompilerTester.in.cpp
@@ -220,6 +220,24 @@ TEST(StaqCompilerTester, checkCirq) {
   auto c = compiler->translate(hello, {std::make_pair("lang-type", "cirq")});
   std::cout << "CIRQ: " << c << "\n";
 }
+
+TEST(StaqCompilerTester, checkFloatingPointFormat) {
+  auto compiler = xacc::getCompiler("staq");
+  // Checks that floating point params don't get
+  // converted to scientific form during translation.
+  auto IR = compiler->compile(R"(OPENQASM 2.0;
+                      include "qelib1.inc";
+                      qreg q[2];
+                      creg c[2];
+                      rx(0.00000025) q[0];
+                      measure q -> c;
+                      )");
+  auto hello = IR->getComposites()[0];
+  auto rxInst = hello->getInstruction(0);
+  // We must not lose any precision.
+  EXPECT_NEAR(rxInst->getParameter(0).as<double>(), 2.5e-07, 1e-12);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
   xacc::set_verbose(true);

--- a/quantum/plugins/staq/utils/staq_visitors.hpp
+++ b/quantum/plugins/staq/utils/staq_visitors.hpp
@@ -17,6 +17,7 @@
 #include "parser/parser.hpp"
 #include "ast/traversal.hpp"
 #include <map>
+#include <iomanip>
 
 #include "AllGateVisitor.hpp"
 
@@ -78,7 +79,9 @@ public:
   }
   void visit(UGate &u) override {
     ss << "U(" << u.arg().var() << "[" << u.arg().offset().value() << "], "
-       << u.theta().constant_eval().value() << ", "
+       // This is used internally for source-source translation,
+       // hence we don't want to lose any precision.
+       << std::fixed << std::setprecision(16) << u.theta().constant_eval().value() << ", "
        << u.phi().constant_eval().value() << ", "
        << u.lambda().constant_eval().value() << ");\n";
   }
@@ -97,7 +100,7 @@ public:
     }
 
     if (g.num_cargs() > 0) {
-      ss << ", " << g.carg(0).constant_eval().value();
+      ss << std::fixed << std::setprecision(16) << ", " << g.carg(0).constant_eval().value();
       for (int i = 1; i < g.num_cargs(); i++) {
         ss << ", " << g.carg(i).constant_eval().value() << "\n";
       }


### PR DESCRIPTION
We don't want to translate OpenQASM to XASM with scientific notations.

Also, added a simple test to validate.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>