### PR TITLE
Fixes for scientific notation string format

### DIFF
--- a/quantum/plugins/staq/transformations/staq_rotation_folding.cpp
+++ b/quantum/plugins/staq/transformations/staq_rotation_folding.cpp
@@ -41,6 +41,11 @@ void RotationFolding::apply(std::shared_ptr<CompositeInstruction> program,
   // map prog back to staq src string and
   // compile to ir
   std::stringstream ss;
+  // Staq has a *bug* whereby it cannot parse floating point parameters in
+  // scientific notation form, yet happily 'pretty_print' parameters in that
+  // form => cannot recompile itself.
+  // Hence, we need to set the fixed format here to work around that.
+  ss << std::fixed << std::setprecision(16);
   prog->pretty_print(ss);
   auto ir = staq->compile(ss.str());
 

--- a/quantum/plugins/staq/transformations/tests/RotationFoldingTester.cpp
+++ b/quantum/plugins/staq/transformations/tests/RotationFoldingTester.cpp
@@ -92,6 +92,16 @@ TEST(Staq_RotationFoldingTester, checkSimple) {
   EXPECT_EQ("CNOT", program->getInstruction(2)->name());
   EXPECT_EQ(1, program->getInstruction(2)->bits()[0]);
   EXPECT_EQ(0, program->getInstruction(2)->bits()[1]);
+
+  program = compiler->compile(R"(__qpu__ void test_rz_merge_float(qreg q) {
+     Rz(q[0], 0.000000025);
+     Rz(q[0], 0.000000025);
+  })")->getComposite("test_rz_merge_float");
+  irt->apply(program, nullptr);
+
+  EXPECT_EQ(1, program->nInstructions());
+  EXPECT_EQ("Rz", program->getInstruction(0)->name());
+  EXPECT_NEAR(0.00000005, program->getInstruction(0)->getParameter(0).as<double>(), 1e-12);
 }
 
 

--- a/quantum/plugins/staq/utils/staq_visitors.cpp
+++ b/quantum/plugins/staq/utils/staq_visitors.cpp
@@ -33,15 +33,15 @@ void XACCToStaqOpenQasm::visit(CNOT &cx) {
      << "[" << cx.bits()[0] << "], " << (cx.getBufferNames().empty() ? "q" : cx.getBufferName(1)) << "[" << cx.bits()[1] << "];\n";
 }
 void XACCToStaqOpenQasm::visit(Rz &rz) {
-  ss << "rz(" << xacc::InstructionParameterToDouble(rz.getParameter(0)) << ") " << (rz.getBufferNames().empty() ? "q" : rz.getBufferName(0))
+  ss << "rz(" << std::fixed << std::setprecision(16) << xacc::InstructionParameterToDouble(rz.getParameter(0)) << ") " << (rz.getBufferNames().empty() ? "q" : rz.getBufferName(0))
      << rz.bits() << ";\n";
 }
 void XACCToStaqOpenQasm::visit(Ry &ry) {
-  ss << "ry(" << xacc::InstructionParameterToDouble(ry.getParameter(0)) << ") " << (ry.getBufferNames().empty() ? "q" : ry.getBufferName(0))
+  ss << "ry(" << std::fixed << std::setprecision(16) << xacc::InstructionParameterToDouble(ry.getParameter(0)) << ") " << (ry.getBufferNames().empty() ? "q" : ry.getBufferName(0))
      << ry.bits() << ";\n";
 }
 void XACCToStaqOpenQasm::visit(Rx &rx) {
-  ss << "rx(" << xacc::InstructionParameterToDouble(rx.getParameter(0)) << ") " << (rx.getBufferNames().empty() ? "q" : rx.getBufferName(0))
+  ss << "rx(" << std::fixed << std::setprecision(16) << xacc::InstructionParameterToDouble(rx.getParameter(0)) << ") " << (rx.getBufferNames().empty() ? "q" : rx.getBufferName(0))
      << rx.bits() << ";\n";
 }
 void XACCToStaqOpenQasm::visit(X &x) {
@@ -69,7 +69,7 @@ void XACCToStaqOpenQasm::visit(Swap &s) {
      << "[" << s.bits()[0] << "], " << (s.getBufferNames().empty() ? "q" : s.getBufferName(1)) << "[" << s.bits()[1] << "];\n";
 }
 void XACCToStaqOpenQasm::visit(CRZ &crz) {
-  ss << "crz(" << xacc::InstructionParameterToDouble(crz.getParameter(0)) << ") " << (crz.getBufferNames().empty() ? "q" : crz.getBufferName(0))
+  ss << "crz(" << std::fixed << std::setprecision(16) << xacc::InstructionParameterToDouble(crz.getParameter(0)) << ") " << (crz.getBufferNames().empty() ? "q" : crz.getBufferName(0))
      << "[" << crz.bits()[0] << "], " << (crz.getBufferNames().empty() ? "q" : crz.getBufferName(1)) << "[" << crz.bits()[1] << "];\n";
 }
 void XACCToStaqOpenQasm::visit(CH &ch) {
@@ -93,7 +93,7 @@ void XACCToStaqOpenQasm::visit(Tdg &tdg) {
      << tdg.bits() << ";\n";
 }
 void XACCToStaqOpenQasm::visit(CPhase &cphase) {
-  ss << "cu1(" << xacc::InstructionParameterToDouble(cphase.getParameter(0)) << ") " << (cphase.getBufferNames().empty() ? "q" : cphase.getBufferName(0))
+  ss << "cu1(" << std::fixed << std::setprecision(16) << xacc::InstructionParameterToDouble(cphase.getParameter(0)) << ") " << (cphase.getBufferNames().empty() ? "q" : cphase.getBufferName(0))
      << "[" << cphase.bits()[0] << "], " << (cphase.getBufferNames().empty() ? "q" : cphase.getBufferName(1)) << "[" << cphase.bits()[1] << "];\n";
 }
 void XACCToStaqOpenQasm::visit(Measure &m) {
@@ -101,7 +101,7 @@ void XACCToStaqOpenQasm::visit(Measure &m) {
 }
 void XACCToStaqOpenQasm::visit(Identity &i) {}
 void XACCToStaqOpenQasm::visit(U &u) {
-    ss << "u3(" << xacc::InstructionParameterToDouble(u.getParameter(0)) << "," << xacc::InstructionParameterToDouble(u.getParameter(1)) << "," <<xacc::InstructionParameterToDouble(u.getParameter(2)) << ") " << (u.getBufferNames().empty() ? "q" : u.getBufferName(0)) << u.bits() << ";\n";
+    ss << "u3(" << std::fixed << std::setprecision(16) << xacc::InstructionParameterToDouble(u.getParameter(0)) << "," << xacc::InstructionParameterToDouble(u.getParameter(1)) << "," <<xacc::InstructionParameterToDouble(u.getParameter(2)) << ") " << (u.getBufferNames().empty() ? "q" : u.getBufferName(0)) << u.bits() << ";\n";
 }
 void XACCToStaqOpenQasm::visit(IfStmt &ifStmt) {}
 } // namespace internal_staq


### PR DESCRIPTION
Need to fix the scientific notation issue for XACC ->Staq translation as well.

More importantly, staq rotation folding can be broken since staq's `pretty_print()` can generate numbers in scientific notation form -> cannot recompile the AST after optimization. 

Hence, fixed accordingly.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>