### PR TITLE
Fixed a bug when the XACC install directory is not accessible

### DIFF
--- a/xacc/utils/Utils.cpp
+++ b/xacc/utils/Utils.cpp
@@ -211,7 +211,7 @@ void XACCLogger::createFileLogger() {
     if (!directoryExists(logDir)) {
       if (!makeDirectory(logDir)) {
         // Cannot make the directory, use the current directory instead.
-        logDir = "";
+        logDir = ".";
       }
     }
 


### PR DESCRIPTION
The directory should be ".", not empty. Otherwise, the logger will try to write to the root directory.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>