### PR TITLE
AER's JSON needs to set number of qubits according to the max qubit index

### DIFF
--- a/quantum/plugins/ibm/compiler/QObjectCompiler.cpp
+++ b/quantum/plugins/ibm/compiler/QObjectCompiler.cpp
@@ -107,9 +107,11 @@ QObjectCompiler::translate(std::shared_ptr<xacc::CompositeInstruction> function)
   std::vector<xacc::ibm::Experiment> experiments;
 
   auto uniqueBits = function->uniqueBits();
-
+  // The number of qubits required for an experiment is the number of *physical* qubits,
+  // i.e. the max index of qubit used in the circuit.  
+  auto nbRequiredBits = function->nPhysicalBits();
   auto visitor =
-      std::make_shared<QObjectExperimentVisitor>(function->name(), uniqueBits.size());
+      std::make_shared<QObjectExperimentVisitor>(function->name(), nbRequiredBits);
 
   InstructionIterator it(function);
   int memSlots = 0;

--- a/xacc/compiler/qalloc.hpp
+++ b/xacc/compiler/qalloc.hpp
@@ -14,6 +14,7 @@
 #define XACC_QALLOC_HPP_
 
 #include <map>
+#include <string>
 
 namespace xacc {
 class AcceleratorBuffer;


### PR DESCRIPTION

Added a unit test case to validate: before the fix, Aer threw exceptions. Now fixed.

Also added a missing standard header include (gcc 10.2)

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>