### PR TITLE
Added noise model interface and initial impl for IBM backends

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -202,6 +202,97 @@ void AerAccelerator::execute(
     buffer->appendChild(f->name(), tmpBuffer);
   }
 }
+
+void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
+  m_nbQubits = 0;
+  m_qubitT1.clear();
+  m_qubitT2.clear();
+  m_gateErrors.clear();
+  m_gateDurations.clear();
+  m_roErrors.clear();
+  if (params.stringExists("backend")) {
+    auto ibm = xacc::getAccelerator("ibm:" + params.getString("backend"));
+    auto props = ibm->getProperties().get<std::string>("total-json");
+    std::cout << "JSON: \n" << props << "\n";
+    auto backEndJson = nlohmann::json::parse(props);
+    // Parse qubit data:
+    auto qubitsData = backEndJson["qubits"];
+    size_t nbQubit = 0;
+    for (auto qubitIter = qubitsData.begin(); qubitIter != qubitsData.end();
+         ++qubitIter) {
+      std::optional<double> meas0Prep1, meas1Prep0;
+      // Each qubit contains an array of properties.
+      for (auto probIter = qubitIter->begin(); probIter != qubitIter->end();
+           ++probIter) {
+        const auto probObj = *probIter;
+        const std::string probName = probObj["name"].get<std::string>();
+        const double probVal = probObj["value"].get<double>();
+        const std::string unit = probObj["unit"].get<std::string>();
+        if (probName == "T1") {
+          assert(unit == "µs" || unit == "us" || unit == "ns");
+          m_qubitT1.emplace_back((unit == "µs" || unit == "us") ? 1000.0 * probVal : probVal);
+        }
+
+        if (probName == "T2") {
+          assert(unit == "µs" || unit == "us" || unit == "ns");
+          m_qubitT2.emplace_back((unit == "µs" || unit == "us") ? 1000.0 * probVal : probVal);
+        }
+
+        if (probName == "prob_meas0_prep1") {
+          assert(unit.empty());
+          meas0Prep1 = probVal;
+        }
+
+        if (probName == "prob_meas1_prep0") {
+          assert(unit.empty());
+          meas1Prep0 = probVal;
+        }
+      }
+      assert(meas0Prep1.has_value() && meas1Prep0.has_value());
+      m_roErrors.emplace_back(std::make_pair(*meas0Prep1, *meas1Prep0));
+
+      nbQubit++;
+    }
+    m_nbQubits = nbQubit;
+    assert(m_qubitT1.size() == m_nbQubits);
+    assert(m_qubitT2.size() == m_nbQubits);
+    assert(m_roErrors.size() == m_nbQubits);
+
+    // Parse gate data:
+    auto gateData = backEndJson["gates"];
+    for (auto gateIter = gateData.begin(); gateIter != gateData.end();
+         ++gateIter) {
+      auto gateObj = *gateIter;
+      const std::string gateName = gateObj["name"].get<std::string>();
+      auto gateParams = gateObj["parameters"];
+      for (auto it = gateParams.begin(); it != gateParams.end(); ++it) {
+        auto paramObj = *it;
+        const std::string paramName = paramObj["name"].get<std::string>();
+        if (paramName == "gate_length") {
+          const std::string unit = paramObj["unit"].get<std::string>();
+          assert(unit == "µs" || unit == "us" || unit == "ns");
+          const double gateLength =
+              (unit == "µs" || unit == "us") ? 1000.0 * paramObj["value"].get<double>()
+                           : paramObj["value"].get<double>();
+          const bool insertOk =
+              m_gateDurations.insert({gateName, gateLength}).second;
+          // Must not contain duplicates.
+          assert(insertOk);
+        }
+
+        if (paramName == "gate_error") {
+          assert(paramObj["unit"].get<std::string>().empty());
+          const bool insertOk =
+              m_gateErrors.insert({gateName, paramObj["value"].get<double>()})
+                  .second;
+          // Must not contain duplicates.
+          assert(insertOk);
+        }
+      }
+    }
+  }
+}
+
 } // namespace quantum
 } // namespace xacc
 
@@ -221,6 +312,8 @@ public:
   void Start(BundleContext context) {
     auto xt = std::make_shared<xacc::quantum::AerAccelerator>();
     context.RegisterService<xacc::Accelerator>(xt);
+    context.RegisterService<xacc::NoiseModel>(
+        std::make_shared<xacc::quantum::IbmqNoiseModel>());
   }
 
   /**

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -11,7 +11,7 @@
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
 #include "aer_accelerator.hpp"
-
+#include "aer_noise_model.hpp"
 #include "CommonGates.hpp"
 #include "CountGatesOfTypeVisitor.hpp"
 #include "InstructionIterator.hpp"

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -213,7 +213,6 @@ void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
   if (params.stringExists("backend")) {
     auto ibm = xacc::getAccelerator("ibm:" + params.getString("backend"));
     auto props = ibm->getProperties().get<std::string>("total-json");
-    std::cout << "JSON: \n" << props << "\n";
     auto backEndJson = nlohmann::json::parse(props);
     // Parse qubit data:
     auto qubitsData = backEndJson["qubits"];
@@ -230,12 +229,14 @@ void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
         const std::string unit = probObj["unit"].get<std::string>();
         if (probName == "T1") {
           assert(unit == "µs" || unit == "us" || unit == "ns");
-          m_qubitT1.emplace_back((unit == "µs" || unit == "us") ? 1000.0 * probVal : probVal);
+          m_qubitT1.emplace_back(
+              (unit == "µs" || unit == "us") ? 1000.0 * probVal : probVal);
         }
 
         if (probName == "T2") {
           assert(unit == "µs" || unit == "us" || unit == "ns");
-          m_qubitT2.emplace_back((unit == "µs" || unit == "us") ? 1000.0 * probVal : probVal);
+          m_qubitT2.emplace_back(
+              (unit == "µs" || unit == "us") ? 1000.0 * probVal : probVal);
         }
 
         if (probName == "prob_meas0_prep1") {
@@ -272,8 +273,9 @@ void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
           const std::string unit = paramObj["unit"].get<std::string>();
           assert(unit == "µs" || unit == "us" || unit == "ns");
           const double gateLength =
-              (unit == "µs" || unit == "us") ? 1000.0 * paramObj["value"].get<double>()
-                           : paramObj["value"].get<double>();
+              (unit == "µs" || unit == "us")
+                  ? 1000.0 * paramObj["value"].get<double>()
+                  : paramObj["value"].get<double>();
           const bool insertOk =
               m_gateDurations.insert({gateName, gateLength}).second;
           // Must not contain duplicates.
@@ -293,6 +295,159 @@ void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
   }
 }
 
+std::string
+IbmqNoiseModel::getUniversalGateEquiv(xacc::quantum::Gate &in_gate) const {
+  if (in_gate.bits().size() == 1 && in_gate.name() != "Measure") {
+    // Note: rotation around Z is a noiseless *u1* operation;
+    // *u2* operations are those that requires a half-length rotation;
+    // *u3* operations are those that requires a full-length rotation.
+    static const std::unordered_map<std::string, std::string>
+        SINGLE_QUBIT_GATE_MAP{{"X", "u3"},   {"Y", "u3"},  {"Z", "u1"},
+                              {"H", "u2"},   {"U", "u3"},  {"T", "u1"},
+                              {"Tdg", "u1"}, {"S", "u1"},  {"Sdg", "u1"},
+                              {"Rz", "u1"},  {"Rx", "u3"}, {"Ry", "u3"}};
+    const auto iter = SINGLE_QUBIT_GATE_MAP.find(in_gate.name());
+    // If cannot find the gate, just treat that as a noiseless u1 op.
+    const std::string universalGateName =
+        (iter == SINGLE_QUBIT_GATE_MAP.end()) ? "u1" : iter->second;
+    return universalGateName + "_" + std::to_string(in_gate.bits()[0]);
+  }
+
+  if (in_gate.bits().size() == 2) {
+    return "cx" + std::to_string(in_gate.bits()[0]) + "_" +
+           std::to_string(in_gate.bits()[1]);
+  }
+
+  return "id_" + std::to_string(in_gate.bits()[0]);
+}
+
+std::vector<double>
+IbmqNoiseModel::calculateAmplitudeDamping(xacc::quantum::Gate &in_gate) const {
+  const std::string universalGateName = getUniversalGateEquiv(in_gate);
+  const auto gateDurationIter = m_gateDurations.find(universalGateName);
+  assert(gateDurationIter != m_gateDurations.end());
+  const double gateDuration = gateDurationIter->second;
+  std::vector<double> amplitudeDamping;
+  for (const auto &qubitIdx : in_gate.bits()) {
+    const double qubitT1 = m_qubitT1[qubitIdx];
+    const double dampingRate = 1.0 / qubitT1;
+    const double resetProb = 1.0 * std::exp(-gateDuration * dampingRate);
+    amplitudeDamping.emplace_back(1.0 - resetProb);
+  }
+  return amplitudeDamping;
+}
+
+std::vector<double> IbmqNoiseModel::calculateDepolarizing(
+    xacc::quantum::Gate &in_gate,
+    const std::vector<double> &in_amplitudeDamping) const {
+  //  Compute the depolarizing channel error parameter in the
+  //  presence of T1/T2 thermal relaxation.
+  //  Hence we have that the depolarizing error probability
+  //  for the composed depolarization channel is
+  //  p = dim * (F(E_relax) - F) / (dim * F(E_relax) - 1)
+  const double averageThermalError =
+      1.0 - averageGateFidelity(in_gate, in_amplitudeDamping);
+  const std::string universalGateName = getUniversalGateEquiv(in_gate);
+  // Retrieve the error rate:
+  const auto gateErrorIter = m_gateErrors.find(universalGateName);
+  const double gateError =
+      (gateErrorIter == m_gateErrors.end()) ? 0.0 : gateErrorIter->second;
+  // If the backend gate error (estimated by randomized benchmarking) is more
+  // than thermal relaxation error. We need to add depolarization to simulate
+  // the total gate error.
+  if (gateError > averageThermalError) {
+    // Model gate error entirely as depolarizing error
+    const double depolError = 2 * (gateError - averageThermalError) /
+                              (2 * (1 - averageThermalError) - 1);
+    return {depolError};
+  }
+  return {0.0};
+}
+
+double IbmqNoiseModel::averageGateFidelity(
+    xacc::quantum::Gate &in_gate,
+    const std::vector<double> &in_amplitudeDamping) const {
+  // We only handle single-qubit gates for now.
+  if (in_gate.bits().size() == 1 && in_amplitudeDamping.size() == 1) {
+    // Note: this is based on the simplified amplitude-damping channel
+    const double processFidelity =
+        (std::cos(std::asin(std::sqrt(in_amplitudeDamping[0]))) * 2.0 + 2.0 -
+         in_amplitudeDamping[0]) /
+        4.0;
+    assert(processFidelity <= 1.0);
+    const double averageFidelity = (4.0 * processFidelity + 1.0) / 5.0;
+    return averageFidelity;
+  }
+  return 1.0;
+}
+
+std::vector<KrausOp>
+IbmqNoiseModel::gateError(xacc::quantum::Gate &gate) const {
+  std::vector<KrausOp> krausOps;
+  if (gate.bits().size() == 1 && gate.name() != "Measure") {
+    const auto adAmpl = calculateAmplitudeDamping(gate);
+    if (!adAmpl.empty()) {
+      const double probAD = adAmpl[0];
+      // TODO: add dephasing calculation
+      const double adElem = std::cos(std::asin(std::sqrt(probAD)));
+      KrausOp newOp;
+      newOp.qubit = gate.bits()[0];
+      const std::vector<std::vector<std::complex<double>>> cmats{
+          {1., 0., 0., adElem},
+          {0., 0., 0., 0.},
+          {0., 0., probAD, 0.},
+          {adElem, 0., 0., 1.0 - probAD}};
+      newOp.mats = cmats;
+      krausOps.emplace_back(std::move(newOp));
+    }
+  }
+  return krausOps;
+}
+
+std::string IbmqNoiseModel::toJson() const {
+  // Aer noise model Json
+  nlohmann::json noiseModel;
+  std::vector<nlohmann::json> noiseElements;
+  // Adds RO errors:
+  const auto roErrors = readoutErrors();
+  for (size_t qIdx = 0; qIdx < roErrors.size(); ++qIdx) {
+    const auto &[meas0Prep1, meas1Prep0] = roErrors[qIdx];
+    const std::vector<std::vector<double>> probs{{1 - meas1Prep0, meas1Prep0},
+                                                 {meas0Prep1, 1 - meas0Prep1}};
+    nlohmann::json element;
+    element["type"] = "roerror";
+    element["operations"] = std::vector<std::string>{"measure"};
+    element["probabilities"] = probs;
+    element["gate_qubits"] = std::vector<std::vector<std::size_t>>{{qIdx}};
+    noiseElements.push_back(element);
+  }
+
+  // Add Kraus noise:
+  // Note: we must add noise ops for u2, u3, and cx gates:
+  for (size_t qIdx = 0; qIdx < roErrors.size(); ++qIdx) {
+    nlohmann::json instruction;
+    instruction["name"] = "kraus";
+    instruction["qubits"] = std::vector<std::size_t>{0};
+    // TODO: use actual Kraus values.
+    instruction["params"] =
+        std::vector<std::vector<std::vector<std::complex<double>>>>{
+            {{1., 0.}, {0., 1.}},
+            {{0., 0.}, {0., 0.}},
+            {{0., 0.}, {0., 0.}},
+            {{1., 0.}, {0., 1.}}};
+    const std::vector<std::vector<nlohmann::json>> krausOps{{instruction}};
+    nlohmann::json element;
+    element["type"] = "qerror";
+    element["operations"] = std::vector<std::string>{"u3"};
+    element["probabilities"] = std::vector<double>{1.0};
+    element["gate_qubits"] = std::vector<std::vector<std::size_t>>{{qIdx}};
+    element["instructions"] = krausOps;
+    noiseElements.push_back(element);
+  }
+
+  noiseModel["errors"] = noiseElements;
+  return noiseModel.dump(6);
+}
 } // namespace quantum
 } // namespace xacc
 

--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "NoiseModel.hpp"
+
+namespace xacc {
+namespace quantum {
+class IbmqNoiseModel : public NoiseModel {
+public:
+  // Identifiable interface impls
+  const std::string name() const override { return "IBM"; }
+  const std::string description() const override {
+    return "Backend noise model based on IBMQ backend specifications.";
+  }
+  void initialize(const HeterogeneousMap &params) override {}
+  std::string toJson() const override { return ""; }
+  RoErrors readoutError(size_t qubitIdx) const override {
+    return std::make_pair(0.0, 0.0);
+  }
+  std::vector<RoErrors> readoutErrors() const override { return {}; }
+
+  std::vector<KrausOp>
+  gateError(const xacc::quantum::Gate &gate) const override {
+    return {};
+  }
+};
+} // namespace quantum
+} // namespace xacc

--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -11,17 +11,28 @@ public:
   const std::string description() const override {
     return "Backend noise model based on IBMQ backend specifications.";
   }
-  void initialize(const HeterogeneousMap &params) override {}
+  void initialize(const HeterogeneousMap &params) override;
   std::string toJson() const override { return ""; }
   RoErrors readoutError(size_t qubitIdx) const override {
-    return std::make_pair(0.0, 0.0);
+    // If this noise model has not been initialized with a backend, give zero ro
+    // errors.
+    return m_roErrors.empty() ? std::make_pair(0.0, 0.0) : m_roErrors[qubitIdx];
   }
-  std::vector<RoErrors> readoutErrors() const override { return {}; }
+  std::vector<RoErrors> readoutErrors() const override { return m_roErrors; }
 
   std::vector<KrausOp>
   gateError(const xacc::quantum::Gate &gate) const override {
     return {};
   }
+
+private:
+  // Parsed parameters needed for noise model construction.
+  size_t m_nbQubits;
+  std::vector<double> m_qubitT1;
+  std::vector<double> m_qubitT2;
+  std::unordered_map<std::string, double> m_gateErrors;
+  std::unordered_map<std::string, double> m_gateDurations;
+  std::vector<std::pair<double, double>> m_roErrors;
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -12,7 +12,7 @@ public:
     return "Backend noise model based on IBMQ backend specifications.";
   }
   void initialize(const HeterogeneousMap &params) override;
-  std::string toJson() const override { return ""; }
+  std::string toJson() const override;
   RoErrors readoutError(size_t qubitIdx) const override {
     // If this noise model has not been initialized with a backend, give zero ro
     // errors.
@@ -21,9 +21,22 @@ public:
   std::vector<RoErrors> readoutErrors() const override { return m_roErrors; }
 
   std::vector<KrausOp>
-  gateError(const xacc::quantum::Gate &gate) const override {
-    return {};
-  }
+  gateError(xacc::quantum::Gate &gate) const override; 
+
+private:
+  // Gets the name of the equivalent universal gate.
+  // e.g. an Rz <=> u1; H <==> u2, etc.
+  std::string getUniversalGateEquiv(xacc::quantum::Gate &in_gate) const;
+  // Helper methods to generate noise Kraus Ops
+  std::vector<double>
+  calculateAmplitudeDamping(xacc::quantum::Gate &in_gate) const;
+  std::vector<double>
+  calculateDepolarizing(xacc::quantum::Gate &in_gate,
+                        const std::vector<double> &in_amplitudeDamping) const;
+  // Compute the gate fidelity given the amplitude damping noise:
+  double
+  averageGateFidelity(xacc::quantum::Gate &in_gate,
+                      const std::vector<double> &in_amplitudeDamping) const;
 
 private:
   // Parsed parameters needed for noise model construction.

--- a/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
+++ b/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
@@ -16,8 +16,6 @@ TEST(AerNoiseModelTester, checkSimple) {
     EXPECT_GT(meas1Prep0, 0.0);
     EXPECT_LT(meas1Prep0, 0.1);
   }
-
-  std::cout << "HOWDY: \n" << noiseModel->toJson() << "\n";
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
+++ b/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
@@ -1,0 +1,30 @@
+#include "xacc.hpp"
+#include <gtest/gtest.h>
+#include "xacc_service.hpp"
+#include "NoiseModel.hpp"
+
+// Note: this test can only be run if having IBMQ credential.
+TEST(AerNoiseModelTester, checkSimple) {
+  auto noiseModel = xacc::getService<xacc::NoiseModel>("IBM");
+  noiseModel->initialize({{"backend", "ibmq_ourense"}});
+  // There are 5 qubits.
+  EXPECT_EQ(noiseModel->readoutErrors().size(), 5);
+  for (const auto &[meas0Prep1, meas1Prep0] : noiseModel->readoutErrors()) {
+    // Check readout error parsing
+    EXPECT_GT(meas0Prep1, 0.0);
+    EXPECT_LT(meas0Prep1, 0.1);
+    EXPECT_GT(meas1Prep0, 0.0);
+    EXPECT_LT(meas1Prep0, 0.1);
+  }
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize();
+
+  ::testing::InitGoogleTest(&argc, argv);
+  const auto result = RUN_ALL_TESTS();
+
+  xacc::Finalize();
+
+  return result;
+}

--- a/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
+++ b/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
@@ -16,6 +16,8 @@ TEST(AerNoiseModelTester, checkSimple) {
     EXPECT_GT(meas1Prep0, 0.0);
     EXPECT_LT(meas1Prep0, 0.1);
   }
+
+  std::cout << "HOWDY: \n" << noiseModel->toJson() << "\n";
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/ibm/aer/tests/CMakeLists.txt
+++ b/quantum/plugins/ibm/aer/tests/CMakeLists.txt
@@ -13,3 +13,6 @@
 
 add_xacc_test(AerAccelerator)
 target_link_libraries(AerAcceleratorTester xacc xacc-quantum-gate)
+
+add_xacc_test(AerNoiseModel)
+target_link_libraries(AerNoiseModelTester xacc xacc-quantum-gate)

--- a/quantum/plugins/ibm/aer/tests/CMakeLists.txt
+++ b/quantum/plugins/ibm/aer/tests/CMakeLists.txt
@@ -14,5 +14,6 @@
 add_xacc_test(AerAccelerator)
 target_link_libraries(AerAcceleratorTester xacc xacc-quantum-gate)
 
-add_xacc_test(AerNoiseModel)
-target_link_libraries(AerNoiseModelTester xacc xacc-quantum-gate)
+# Note: This test must be disabled since the CI machine doesn't have IBMQ access.
+# add_xacc_test(AerNoiseModel)
+# target_link_libraries(AerNoiseModelTester xacc xacc-quantum-gate)

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Thien Nguyen - initial API and implementation
+ *******************************************************************************/
+#pragma once
+#include "Identifiable.hpp"
+#include "heterogeneous.hpp"
+
+namespace xacc {
+namespace quantum {
+// Forward declaration
+class Gate;
+} // namespace quantum
+
+// Readout error: pair of prep0meas1 and prep1meas0
+using RoErrors = std::pair<double, double>;
+
+struct KrausOp {
+  size_t qubit;
+  // Kraus matrix
+  std::vector<std::vector<std::complex<double>>> mats;
+};
+
+class NoiseModel : public Identifiable {
+public:
+  NoiseModel() = default;
+  virtual void initialize(const HeterogeneousMap &params) = 0;
+  virtual std::string toJson() const = 0;
+  // Readout errors:
+  virtual RoErrors readoutError(size_t qubitIdx) const = 0;
+  virtual std::vector<RoErrors> readoutErrors() const = 0;
+  // Gate errors:
+  // Returns a list of Kraus operators represent quantum noise processes
+  // associated with a quantum gate.
+  // Note: we use Kraus operators to capture generic noise processes.
+  // Any probabilistic gate-based noise representations must be converted to
+  // the equivalent Kraus operators.
+  virtual std::vector<KrausOp>
+  gateError(const xacc::quantum::Gate &gate) const = 0;
+};
+} // namespace xacc

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -20,7 +20,7 @@ namespace quantum {
 class Gate;
 } // namespace quantum
 
-// Readout error: pair of prep0meas1 and prep1meas0
+// Readout error: pair of meas0Prep1, meas1Prep0
 using RoErrors = std::pair<double, double>;
 
 struct KrausOp {

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -44,6 +44,6 @@ public:
   // Any probabilistic gate-based noise representations must be converted to
   // the equivalent Kraus operators.
   virtual std::vector<KrausOp>
-  gateError(const xacc::quantum::Gate &gate) const = 0;
+  gateError(xacc::quantum::Gate &gate) const = 0;
 };
 } // namespace xacc


### PR DESCRIPTION
- Added a NoiseModel interface that supports generic readout error and gate errors (as Kraus matrix).

- Added an IBM-specific implementation that loads the backend JSON.

Tested by: using this in TNQVM new visitor.