### PR TITLE
Add support for offline noise-model JSON

### DIFF
--- a/quantum/plugins/ibm/aer/CMakeLists.txt
+++ b/quantum/plugins/ibm/aer/CMakeLists.txt
@@ -37,6 +37,12 @@ if(APPLE)
   set_target_properties(${LIBRARY_NAME}
                         PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 else()
+  find_package(LAPACK)
+  if(LAPACK_FOUND)
+   target_link_libraries(${LIBRARY_NAME} PRIVATE ${LAPACK_LIBRARIES})
+  else()
+    message(STATUS "LAPACK NOT FOUND. Aer plugin may not work.")
+  endif()
   set_target_properties(${LIBRARY_NAME}
                         PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
   set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -97,6 +97,8 @@ void AerAccelerator::initialize(const HeterogeneousMap &params) {
     // noise_model["x90_gates"] = std::vecto
 
     std::cout << "NoiseModelJson:\n" << noise_model.dump(4) << "\n";
+  } else if (params.stringExists("noise-model")) {
+    noise_model = nlohmann::json::parse(params.getString("noise-model"));
   }
 }
 double AerAccelerator::calcExpectationValueZ(


### PR DESCRIPTION
- Allowed users to load an IBM noise model JSON string to the Aer accelerator.  

- Fixed a runtime LAPACK linkage error:
Aer can use BLAS functions, e.g. in 
https://github.com/Qiskit/qiskit-aer/blob/e5923b44569fe82651c9dedd4f4fe7b76f649cc1/src/framework/matrix.hpp

I guess when activating complete noisy simulation (not just readout errors), these functions were called and caused errors.
Fixed by adding LAPACK linkage in CMake. 