### PR TITLE
use `--no-install-recommends` flag to `apt-get` in dockerfile to save space

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,5 @@
-from ubuntu:18.04
-run rm /bin/sh && ln -s /bin/bash /bin/sh && apt-get -y update && apt-get install -y gcc g++ cmake git libssl-dev \
+FROM ubuntu:18.04
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh && apt-get -y update && apt-get --no-install-recommends -yq install gcc g++ cmake git libssl-dev \
       python3 libpython3-dev python3-pip vim exuberant-ctags gdb gfortran libblas-dev liblapack-dev pkg-config wget \
     && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim \ 
@@ -12,4 +12,4 @@ run rm /bin/sh && ln -s /bin/bash /bin/sh && apt-get -y update && apt-get instal
     && echo "let g:cpp_class_decl_highlight = 1\nlet g:cpp_experimental_simple_template_highlight = 1\n" >> ~/.vimrc && cat ~/.vimrc && vim +PluginInstall +qall \
     && cd ~/.vim/bundle/YouCompleteMe && python3 install.py --clang-completer \
     && vim +PluginInstall +qall
-workdir /projects
+WORKDIR /projects

--- a/docker/base/plugin-ci/Dockerfile
+++ b/docker/base/plugin-ci/Dockerfile
@@ -1,5 +1,5 @@
-from xacc/base-ci
-run git clone --recursive https://github.com/eclipse/xacc \
+FROM xacc/base-ci
+RUN git clone --recursive https://github.com/eclipse/xacc \
     && cd xacc && mkdir build && cd build \
     && cmake .. -DPYTHON_INCLUDE_DIR=/usr/include/python3.5 && make -j4 install
-run apt-get update -y && apt-get install -y libblas-dev liblapack-dev && python3 -m pip install ipopo configparser numpy scipy
+RUN apt-get update -y && apt-get --no-install-recommends -yq install libblas-dev liblapack-dev && python3 -m pip install ipopo configparser numpy scipy

--- a/docker/ci/ubuntu1804/base/Dockerfile
+++ b/docker/ci/ubuntu1804/base/Dockerfile
@@ -1,10 +1,10 @@
-from ubuntu:18.04
-run apt-get -y update && apt-get install -y gcc g++ git wget \
+FROM ubuntu:18.04
+RUN apt-get -y update && apt-get --no-install-recommends -yq install gcc g++ git wget \
             libcurl4-openssl-dev libssl-dev python3 libunwind-dev \
             libpython3-dev python3-pip libblas-dev liblapack-dev software-properties-common \
     && python3 -m pip install ipopo cmake \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" > /etc/apt/sources.list.d/llvm.list \
-    && apt-get update -y && apt-get install -y libclang-9-dev llvm-9-dev \
+    && apt-get update -y && apt-get --no-install-recommends -yq install libclang-9-dev llvm-9-dev \
     && ln -s /usr/bin/llvm-config-9 /usr/bin/llvm-config \
     && rm -rf /var/lib/apt/lists/* 

--- a/docker/deploy/base/Dockerfile
+++ b/docker/deploy/base/Dockerfile
@@ -18,7 +18,7 @@ ADD settings.json /home/dev/.theia/
 
 #Common deps
 RUN apt-get update && \
-    apt-get --no-install-recommends -y install build-essential \
+    apt-get --no-install-recommends -yq install build-essential \
                        curl \
                        git \
                        python python3 \
@@ -32,7 +32,7 @@ RUN apt-get update && \
                        && python3 -m pip install setuptools \
                        && python3 -m pip install python-language-server flake8 autopep8 \
                                 cmake ipopo pint numpy scipy pydantic qiskit pylint pyquil cirq matplotlib \
-    && apt-get install -y gpg && rm -rf /var/lib/apt/lists/* \
+    && apt-get --no-install-recommends -yq install gpg && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 50 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50 \
     && update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-8 50 \
@@ -107,7 +107,7 @@ RUN apt-get update && \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y \
+    apt-get --no-install-recommends -yq install --no-install-recommends -y \
                        clang-tools-11 \
                        clangd-11 \
                        clang-tidy-11 \

--- a/docker/deploy/dev_qcs/Dockerfile
+++ b/docker/deploy/dev_qcs/Dockerfile
@@ -1,6 +1,6 @@
-from xacc/deploy-base
-workdir /home/dev
-run cd /home/dev && apt-get update && apt-get install -y uuid-dev pkg-config \
+FROM xacc/deploy-base
+WORKDIR /home/dev
+RUN cd /home/dev && apt-get update && apt-get --no-install-recommends -yq install uuid-dev pkg-config \
     && git clone https://github.com/zeromq/libzmq \
     && cd libzmq/ && mkdir build && cd build \
     && cmake .. -DCMAKE_INSTALL_PREFIX=~/.zmq \
@@ -25,7 +25,7 @@ run cd /home/dev && apt-get update && apt-get install -y uuid-dev pkg-config \
     && npm install && npm link
 
 # Theia application
-workdir /home/dev
+WORKDIR /home/dev
 ARG version=latest
 ADD $version.package.json ./package.json
 

--- a/docker/deploy/gitpod-base/Dockerfile
+++ b/docker/deploy/gitpod-base/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:disco
 ENV LANG=en_US.UTF-8
 ### base ###
 RUN yes | unminimize \
-    && apt-get install -yq \
+    && apt-get --no-install-recommends -yq install \
         asciidoctor \
         bash-completion \
         build-essential \
@@ -24,7 +24,7 @@ RUN yes | unminimize \
 
 ### Git ###
     && add-apt-repository -y ppa:git-core/ppa \
-    && apt-get install -yq git \
+    && apt-get --no-install-recommends -yq install git \
     && rm -rf /var/lib/apt/lists/* \
 
 ### Gitpod user ###
@@ -52,7 +52,7 @@ USER root
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && echo "deb http://apt.llvm.org/disco/ llvm-toolchain-disco main" >> /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
-    && apt-get install -yq \
+    && apt-get --no-install-recommends -yq install \
         clang-format \
         clang-tidy \
         # clang-tools \ # breaks the build atm
@@ -68,7 +68,7 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$(python3 -m site --user-site)/psi4 \
     && make -j8 install && cd ../.. && rm -rf psi4
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y texlive-latex-recommended texlive-latex-extra dvipng \
+RUN apt-get update && apt-get --no-install-recommends -yq install texlive-latex-recommended texlive-latex-extra dvipng \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
 
 USER gitpod


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>