### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/docker/base/plugin-ci/Dockerfile
+++ b/docker/base/plugin-ci/Dockerfile
@@ -2,4 +2,4 @@ from xacc/base-ci
 run git clone --recursive https://github.com/eclipse/xacc \
     && cd xacc && mkdir build && cd build \
     && cmake .. -DPYTHON_INCLUDE_DIR=/usr/include/python3.5 && make -j4 install
-run apt-get update -y && apt-get install -y libblas-dev liblapack-dev && python3 -m pip install ipopo configparser numpy scipy
+run apt-get update -y && apt-get install -y libblas-dev liblapack-dev && python3 -m pip install --no-cache-dir ipopo configparser numpy scipy

--- a/docker/ci/centos7/base/Dockerfile
+++ b/docker/ci/centos7/base/Dockerfile
@@ -2,4 +2,4 @@ from centos:7
 run yum install libcurl-devel python3-devel git centos-release-scl make \
     devtoolset-8-gcc devtoolset-8-gcc-c++ blas-devel lapack-devel \
     && scl enable devtoolset-8 -- bash \
-    && python3 -m pip install cmake
+    && python3 -m pip install --no-cache-dir cmake

--- a/docker/ci/fedora30/base/Dockerfile
+++ b/docker/ci/fedora30/base/Dockerfile
@@ -1,4 +1,4 @@
 from fedora:30
 run dnf install -y python3-devel libcurl-devel g++ gcc git make blas-devel lapack-devel \
-    && python3 -m pip install cmake
+    && python3 -m pip install --no-cache-dir cmake
 

--- a/docker/ci/ubuntu1804/base/Dockerfile
+++ b/docker/ci/ubuntu1804/base/Dockerfile
@@ -2,7 +2,7 @@ from ubuntu:18.04
 run apt-get -y update && apt-get install -y gcc g++ git wget \
             libcurl4-openssl-dev libssl-dev python3 libunwind-dev \
             libpython3-dev python3-pip libblas-dev liblapack-dev software-properties-common \
-    && python3 -m pip install ipopo cmake \
+    && python3 -m pip install --no-cache-dir ipopo cmake \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" > /etc/apt/sources.list.d/llvm.list \
     && apt-get update -y && apt-get install -y libclang-9-dev llvm-9-dev \

--- a/docker/ci/ubuntu1804/int_tests_base/Dockerfile
+++ b/docker/ci/ubuntu1804/int_tests_base/Dockerfile
@@ -1,6 +1,6 @@
 from xacc/ubuntu:18.04
 run git clone https://github.com/psi4/psi4 && cd psi4 && mkdir build && cd build \
-   && python3 -m pip install numpy qiskit scipy cirq pint cma --user \
+   && python3 -m pip install --no-cache-dir numpy qiskit scipy cirq pint cma --user \
    && cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$(python3 -m site --user-site)/psi4 \
    && make -j$(nproc) install
    

--- a/docker/ci/ubuntu1804/integration_tests/Dockerfile
+++ b/docker/ci/ubuntu1804/integration_tests/Dockerfile
@@ -4,7 +4,7 @@ copy --from=0 /root/.xacc /root/.xacc
 copy --from=0 /xacc/build/quantum /quantum
 copy --from=0 /xacc/python/examples /pyexamples
 add .ibm_config /root/
-run python3 -m pip install pydantic --user \
+run python3 -m pip install --no-cache-dir pydantic --user \
     && git clone https://github.com/ornl-qci/tnqvm \
     && cd tnqvm && mkdir build && cd build \
     && cmake .. -DXACC_DIR=~/.xacc && make -j12 install \

--- a/docker/deploy/base/Dockerfile
+++ b/docker/deploy/base/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
                        vim gcc-8 g++-8 gfortran-8 \
                        wget \
                        xz-utils && python3 -m pip install --upgrade pip --user \
-                       && python3 -m pip install setuptools \
-                       && python3 -m pip install python-language-server flake8 autopep8 \
+                       && python3 -m pip install --no-cache-dir setuptools \
+                       && python3 -m pip install --no-cache-dir python-language-server flake8 autopep8 \
                                 cmake ipopo pint numpy scipy pydantic qiskit pylint pyquil cirq matplotlib \
     && apt-get install -y gpg && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 50 \

--- a/docker/deploy/gitpod-base/Dockerfile
+++ b/docker/deploy/gitpod-base/Dockerfile
@@ -62,7 +62,7 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && cp /var/lib/dpkg/status /var/lib/apt/dazzle-marks/lang-c.status \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* \
 
-    && python3 -m pip install --upgrade pip && python3 -m pip install pint pydantic matplotlib qiskit scipy numpy pyquil cmake virtualenv pipenv pylint rope flake8 mypy autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
+    && python3 -m pip install --upgrade pip && python3 -m pip install --no-cache-dir pint pydantic matplotlib qiskit scipy numpy pyquil cmake virtualenv pipenv pylint rope flake8 mypy autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
     && sudo rm -rf /tmp/* \
     && git clone https://github.com/psi4/psi4 && cd psi4 && mkdir build && cd build \
     && cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$(python3 -m site --user-site)/psi4 \


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>