### PR TITLE
Implemented NoiseModel's toJson() method

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -211,6 +211,7 @@ void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
   m_gateErrors.clear();
   m_gateDurations.clear();
   m_roErrors.clear();
+  m_connectivity.clear();
   // Note: we support both remote backend JSON and cache JSON string.
   // So that we can test this with offline JSON.
   if (params.stringExists("backend") || params.stringExists("backend-json")) {
@@ -218,6 +219,7 @@ void IbmqNoiseModel::initialize(const HeterogeneousMap &params) {
       if (params.stringExists("backend")) {
         auto ibm = xacc::getAccelerator("ibm:" + params.getString("backend"));
         auto props = ibm->getProperties().get<std::string>("total-json");
+        m_connectivity = ibm->getConnectivity();
         return props;
       }
       return params.getString("backend-json");
@@ -331,32 +333,46 @@ IbmqNoiseModel::getUniversalGateEquiv(xacc::quantum::Gate &in_gate) const {
   return "id_" + std::to_string(in_gate.bits()[0]);
 }
 
-std::vector<double>
-IbmqNoiseModel::calculateAmplitudeDamping(xacc::quantum::Gate &in_gate) const {
+// Return gate time, T1, T2
+std::tuple<double, double, double>
+IbmqNoiseModel::relaxationParams(xacc::quantum::Gate &in_gate,
+                                 size_t in_qubitIdx) const {
   const std::string universalGateName = getUniversalGateEquiv(in_gate);
   const auto gateDurationIter = m_gateDurations.find(universalGateName);
   assert(gateDurationIter != m_gateDurations.end());
   const double gateDuration = gateDurationIter->second;
-  std::vector<double> amplitudeDamping;
-  for (const auto &qubitIdx : in_gate.bits()) {
-    const double qubitT1 = m_qubitT1[qubitIdx];
-    const double dampingRate = 1.0 / qubitT1;
-    const double resetProb = 1.0 * std::exp(-gateDuration * dampingRate);
-    amplitudeDamping.emplace_back(1.0 - resetProb);
-  }
-  return amplitudeDamping;
+  const double qubitT1 = m_qubitT1[in_qubitIdx];
+  const double qubitT2 = m_qubitT2[in_qubitIdx];
+  return std::make_tuple(gateDuration, qubitT1, qubitT2);
+}
+
+std::vector<std::vector<std::complex<double>>>
+IbmqNoiseModel::thermalRelaxationChoiMat(double in_gateTime, double in_T1,
+                                         double in_T2) const {
+  const double rate1 = 1.0 / in_T1;
+  const double pReset = 1.0 - std::exp(-in_gateTime * rate1);
+
+  const double rate2 = 1.0 / in_T2;
+  const double expT2 = std::exp(-in_gateTime * rate2);
+  const double p0 = 1.0;
+  const double p1 = 0.0;
+  return {{1 - p1 * pReset, 0, 0, expT2},
+          {0, p1 * pReset, 0, 0},
+          {0, 0, p0 * pReset, 0},
+          {expT2, 0, 0, 1 - p0 * pReset}};
 }
 
 std::vector<double> IbmqNoiseModel::calculateDepolarizing(
     xacc::quantum::Gate &in_gate,
-    const std::vector<double> &in_amplitudeDamping) const {
+    const std::vector<std::vector<std::complex<double>>> &in_relaxationError)
+    const {
   //  Compute the depolarizing channel error parameter in the
   //  presence of T1/T2 thermal relaxation.
   //  Hence we have that the depolarizing error probability
   //  for the composed depolarization channel is
   //  p = dim * (F(E_relax) - F) / (dim * F(E_relax) - 1)
   const double averageThermalError =
-      1.0 - averageGateFidelity(in_gate, in_amplitudeDamping);
+      1.0 - averageGateFidelity(in_gate, in_relaxationError);
   const std::string universalGateName = getUniversalGateEquiv(in_gate);
   // Retrieve the error rate:
   const auto gateErrorIter = m_gateErrors.find(universalGateName);
@@ -376,14 +392,16 @@ std::vector<double> IbmqNoiseModel::calculateDepolarizing(
 
 double IbmqNoiseModel::averageGateFidelity(
     xacc::quantum::Gate &in_gate,
-    const std::vector<double> &in_amplitudeDamping) const {
+    const std::vector<std::vector<std::complex<double>>> &in_relaxationError)
+    const {
   // We only handle single-qubit gates for now.
-  if (in_gate.bits().size() == 1 && in_amplitudeDamping.size() == 1) {
+  if (in_gate.bits().size() == 1 && in_relaxationError.size() == 4) {
     // Note: this is based on the simplified amplitude-damping channel
     const double processFidelity =
-        (std::cos(std::asin(std::sqrt(in_amplitudeDamping[0]))) * 2.0 + 2.0 -
-         in_amplitudeDamping[0]) /
+        (in_relaxationError[0][0].real() + in_relaxationError[0][3].real() +
+         in_relaxationError[3][0].real() + in_relaxationError[3][3].real()) /
         4.0;
+
     assert(processFidelity <= 1.0);
     const double averageFidelity = (4.0 * processFidelity + 1.0) / 5.0;
     return averageFidelity;
@@ -394,62 +412,51 @@ double IbmqNoiseModel::averageGateFidelity(
 std::vector<KrausOp>
 IbmqNoiseModel::gateError(xacc::quantum::Gate &gate) const {
   std::vector<KrausOp> krausOps;
-  const auto computeAdKrausOp = [](double in_probAD, size_t in_bit) {
-    // TODO: add dephasing calculation
-    const double adElem = std::cos(std::asin(std::sqrt(in_probAD)));
-    KrausOp newOp;
-    newOp.qubit = in_bit;
-    const std::vector<std::vector<std::complex<double>>> cmats{
-        {1., 0., 0., adElem},
-        {0., 0., 0., 0.},
-        {0., 0., in_probAD, 0.},
-        {adElem, 0., 0., 1.0 - in_probAD}};
-    newOp.mats = cmats;
-    return newOp;
-  };
-
   if (gate.bits().size() == 1 && gate.name() != "Measure") {
     // Amplitude damping + dephasing
-    const auto adAmpl = calculateAmplitudeDamping(gate);
-    if (!adAmpl.empty()) {
-      const double probAD = adAmpl[0];
-      // Add relaxation kraus
-      krausOps.emplace_back(computeAdKrausOp(probAD, gate.bits()[0]));
-    }
+    const auto [gateDuration, qubitT1, qubitT2] =
+        relaxationParams(gate, gate.bits()[0]);
+    const auto relaxationError =
+        thermalRelaxationChoiMat(gateDuration, qubitT1, qubitT2);
 
     // Depolarization
-    const auto dpAmpl = calculateDepolarizing(gate, adAmpl);
+    const auto dpAmpl = calculateDepolarizing(gate, relaxationError);
     if (!dpAmpl.empty()) {
       const double probDP = dpAmpl[0];
-      const std::vector<std::vector<std::complex<double>>> cmats{
+      const std::vector<std::vector<std::complex<double>>> depolError{
           {1.0 - probDP / 2.0, 0., 0., 1.0 - probDP},
           {0., probDP / 2.0, 0., 0.},
           {0., 0., probDP / 2.0, 0.},
           {1.0 - probDP, 0., 0., 1.0 - probDP / 2.0}};
+      const auto noiseUtils = xacc::getService<NoiseModelUtils>("default");
       KrausOp newOp;
       newOp.qubit = gate.bits()[0];
-      newOp.mats = cmats;
+      newOp.mats = noiseUtils->combineChannelOps({relaxationError, depolError});
       // Add depolarization kraus
       krausOps.emplace_back(std::move(newOp));
     }
   }
   // For two-qubit gates, we currently only support
   // amplitude damping on both qubits (scaled by gate time).
-  // We don't have ability to handle multi-qubit depolarization 
+  // We don't have ability to handle multi-qubit depolarization
   // in TNQVM yet.
   if (gate.bits().size() == 2) {
-    const auto adAmpl = calculateAmplitudeDamping(gate);
-    if (adAmpl.size() == 2) {
-      // Add relaxation kraus for both qubits
-      krausOps.emplace_back(computeAdKrausOp(adAmpl[0], gate.bits()[0]));
-      krausOps.emplace_back(computeAdKrausOp(adAmpl[1], gate.bits()[1]));
+
+    for (const auto &qubitIdx : gate.bits()) {
+      const auto [gateDuration, qubitT1, qubitT2] =
+          relaxationParams(gate, qubitIdx);
+      const auto relaxationError =
+          thermalRelaxationChoiMat(gateDuration, qubitT1, qubitT2);
+      KrausOp relaxErrorOp;
+      relaxErrorOp.qubit = gate.bits()[0];
+      relaxErrorOp.mats = relaxationError;
+      krausOps.emplace_back(std::move(relaxErrorOp));
     }
   }
   return krausOps;
 }
 
 std::string IbmqNoiseModel::toJson() const {
-  // !!! IMPORTANT !!! This function is *WIP*
   // Aer noise model Json
   nlohmann::json noiseModel;
   std::vector<nlohmann::json> noiseElements;
@@ -477,9 +484,8 @@ std::string IbmqNoiseModel::toJson() const {
     // U3 == X gate
     Hadamard gateU2({qIdx});
     X gateU3({qIdx});
-    const std::unordered_map<std::string, xacc::quantum::Gate*> gateMap {
-      {"u2", &gateU2}, {"u3", &gateU3}
-    };
+    const std::unordered_map<std::string, xacc::quantum::Gate *> gateMap{
+        {"u2", &gateU2}, {"u3", &gateU3}};
 
     for (const auto &[gateName, gate] : gateMap) {
       const auto errorChannels = gateError(*gate);
@@ -487,7 +493,7 @@ std::string IbmqNoiseModel::toJson() const {
       element["type"] = "qerror";
       element["operations"] = std::vector<std::string>{gateName};
       element["gate_qubits"] = std::vector<std::vector<std::size_t>>{{qIdx}};
-      std::vector<nlohmann::json>krausOps;
+      std::vector<nlohmann::json> krausOps;
       for (const auto &error : errorChannels) {
         const auto krausOpMats = noiseUtils->choiToKraus(error.mats);
         nlohmann::json instruction;
@@ -496,8 +502,44 @@ std::string IbmqNoiseModel::toJson() const {
         instruction["params"] = krausOpMats;
         krausOps.emplace_back(instruction);
       }
-      element["instructions"] = std::vector<std::vector<nlohmann::json>> { krausOps };
-      element["probabilities"] = std::vector<double>(krausOps.size(), 1.0);
+      element["instructions"] =
+          std::vector<std::vector<nlohmann::json>>{krausOps};
+      element["probabilities"] = std::vector<double>{1.0};
+      noiseElements.push_back(element);
+    }
+  }
+
+  // (2) Two-qubit gate noise:
+  for (const auto &[qubit1, qubit2] : m_connectivity) {
+    // We need to add noise for both CNOT directions
+    // Note: the duration of them can be different,
+    // hence the noise channels.
+    CNOT cx1(std::vector<std::size_t>{(size_t)qubit1, (size_t)qubit2});
+    CNOT cx2(std::vector<std::size_t>{(size_t)qubit2, (size_t)qubit1});
+    const std::vector<xacc::quantum::Gate *> cxGates{&cx1, &cx2};
+    for (const auto &cx : cxGates) {
+      const auto errorChannels = gateError(*cx);
+      assert(errorChannels.size() == 2);
+      nlohmann::json element;
+      element["type"] = "qerror";
+      element["operations"] =
+          std::vector<std::string>{getUniversalGateEquiv(*cx)};
+      element["gate_qubits"] =
+          std::vector<std::vector<std::size_t>>{cx->bits()};
+      std::vector<nlohmann::json> krausOps;
+      size_t noiseBitIdx = 0;
+      for (const auto &error : errorChannels) {
+        const auto krausOpMats = noiseUtils->choiToKraus(error.mats);
+        nlohmann::json instruction;
+        instruction["name"] = "kraus";
+        instruction["qubits"] = std::vector<std::size_t>{noiseBitIdx++};
+        instruction["params"] = krausOpMats;
+        krausOps.emplace_back(instruction);
+      }
+      assert(krausOps.size() == 2);
+      element["instructions"] =
+          std::vector<std::vector<nlohmann::json>>{krausOps};
+      element["probabilities"] = std::vector<double>{1.0};
       noiseElements.push_back(element);
     }
   }

--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -20,23 +20,28 @@ public:
   }
   std::vector<RoErrors> readoutErrors() const override { return m_roErrors; }
 
-  std::vector<KrausOp>
-  gateError(xacc::quantum::Gate &gate) const override; 
+  std::vector<KrausOp> gateError(xacc::quantum::Gate &gate) const override;
 
 private:
   // Gets the name of the equivalent universal gate.
   // e.g. an Rz <=> u1; H <==> u2, etc.
   std::string getUniversalGateEquiv(xacc::quantum::Gate &in_gate) const;
-  // Helper methods to generate noise Kraus Ops
-  std::vector<double>
-  calculateAmplitudeDamping(xacc::quantum::Gate &in_gate) const;
+  std::tuple<double, double, double>
+  relaxationParams(xacc::quantum::Gate &in_gate, size_t in_qubitIdx) const;
   std::vector<double>
   calculateDepolarizing(xacc::quantum::Gate &in_gate,
-                        const std::vector<double> &in_amplitudeDamping) const;
+                        const std::vector<std::vector<std::complex<double>>>
+                            &in_relaxationError) const;
   // Compute the gate fidelity given the amplitude damping noise:
-  double
-  averageGateFidelity(xacc::quantum::Gate &in_gate,
-                      const std::vector<double> &in_amplitudeDamping) const;
+  double averageGateFidelity(
+      xacc::quantum::Gate &in_gate,
+      const std::vector<std::vector<std::complex<double>>> &in_relaxationError) const;
+
+  // Helper to construct the Choi matrix represents overall thermal relaxation:
+  // i.e. amplitude damping + dephasing.
+  std::vector<std::vector<std::complex<double>>>
+  thermalRelaxationChoiMat(double in_gateTime, double in_T1,
+                           double in_T2) const;
 
 private:
   // Parsed parameters needed for noise model construction.
@@ -46,6 +51,7 @@ private:
   std::unordered_map<std::string, double> m_gateErrors;
   std::unordered_map<std::string, double> m_gateDurations;
   std::vector<std::pair<double, double>> m_roErrors;
+  std::vector<std::pair<int, int>> m_connectivity;
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
+++ b/quantum/plugins/ibm/aer/tests/AerNoiseModelTester.cpp
@@ -18,6 +18,40 @@ TEST(AerNoiseModelTester, checkSimple) {
   }
 }
 
+TEST(AerNoiseModelTester, checkNoiseModelJson) {
+  auto noiseModel = xacc::getService<xacc::NoiseModel>("IBM");
+  noiseModel->initialize({{"backend", "ibmq_ourense"}});
+  // There are 5 qubits.
+  EXPECT_EQ(noiseModel->readoutErrors().size(), 5);
+  const std::string noiseJson = noiseModel->toJson();
+  std::cout << "JSON:\n" << noiseJson << "\n";
+
+  // Load the *toJson()* noise model to Aer
+  auto accelerator = xacc::getAccelerator(
+      "aer", {{"noise-model", noiseJson}, {"shots", 8192}});
+
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto program = xasmCompiler
+                     ->compile(R"(__qpu__ void testBell(qbit q) {
+        H(q[0]);
+        CNOT(q[0],q[1]);                
+        Measure(q[0]);
+        Measure(q[1]);
+      })",
+                               accelerator)
+                     ->getComposite("testBell");
+
+  auto buffer = xacc::qalloc(2);
+  accelerator->execute(buffer, program);
+  buffer->print();
+  // Must have some errors
+  EXPECT_GT(buffer->computeMeasurementProbability("10"), 0.01);
+  EXPECT_GT(buffer->computeMeasurementProbability("01"), 0.01);
+  // Majority is still Bell state:
+  EXPECT_GT(buffer->computeMeasurementProbability("00"), 0.4);
+  EXPECT_GT(buffer->computeMeasurementProbability("11"), 0.4);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize();
 

--- a/quantum/plugins/qpp/QppActivator.cpp
+++ b/quantum/plugins/qpp/QppActivator.cpp
@@ -24,6 +24,7 @@ public:
   void Start(BundleContext context) {
     auto acc = std::make_shared<xacc::quantum::QppAccelerator>();
     context.RegisterService<xacc::Accelerator>(acc);
+    context.RegisterService<xacc::NoiseModelUtils>(std::make_shared<xacc::quantum::DefaultNoiseModelUtils>());
   }
 
   void Stop(BundleContext context) {}

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -331,4 +331,18 @@ namespace quantum {
         }
         return resultKraus;
     }
+
+    NoiseModelUtils::cMat DefaultNoiseModelUtils::combineChannelOps(const std::vector<NoiseModelUtils::cMat> &in_choiMats) const 
+    {
+        assert(!in_choiMats.empty());
+        auto choiSum = convertToEigenMat(in_choiMats[0]);
+        for (size_t i = 1; i < in_choiMats.size(); ++i)
+        {
+            const auto nextOp = convertToEigenMat(in_choiMats[i]);
+            choiSum = choiSum + nextOp;
+        }
+        const double normalized = std::abs((choiSum(0,0) + choiSum(1,1) + choiSum(2,2) + choiSum(3,3)).real()/2.0);
+        choiSum = (1/normalized)*choiSum;
+        return convertToStdMat(choiSum);
+    }
 }}

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -46,5 +46,6 @@ public:
     virtual const std::string description() const override { return "Default noise model utils."; }
     virtual NoiseModelUtils::cMat krausToChoi(const std::vector<NoiseModelUtils::cMat>& in_krausMats) const override;
     virtual std::vector<NoiseModelUtils::cMat> choiToKraus(const NoiseModelUtils::cMat& in_choiMat) const override;
+    virtual NoiseModelUtils::cMat combineChannelOps(const std::vector<NoiseModelUtils::cMat> &in_choiMats) const override;
 };
 }}

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -13,6 +13,7 @@
 #pragma one
 #include "xacc.hpp"
 #include "QppVisitor.hpp"
+#include "NoiseModel.hpp"
 
 namespace xacc {
 namespace quantum {
@@ -35,5 +36,15 @@ private:
     // Number of 'shots' if random sampling simulation is enabled.
     // -1 means disabled (no shots, just expectation value)
     int m_shots = -1;
+};
+
+class DefaultNoiseModelUtils : public NoiseModelUtils 
+{
+public:
+    // Identifiable interface impls
+    virtual const std::string name() const override { return "default"; }
+    virtual const std::string description() const override { return "Default noise model utils."; }
+    virtual NoiseModelUtils::cMat krausToChoi(const std::vector<NoiseModelUtils::cMat>& in_krausMats) const override;
+    virtual std::vector<NoiseModelUtils::cMat> choiToKraus(const NoiseModelUtils::cMat& in_choiMat) const override;
 };
 }}

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -25,7 +25,7 @@ using RoErrors = std::pair<double, double>;
 
 struct KrausOp {
   size_t qubit;
-  // Kraus matrix
+  // Choi matrix
   std::vector<std::vector<std::complex<double>>> mats;
 };
 
@@ -45,5 +45,14 @@ public:
   // the equivalent Kraus operators.
   virtual std::vector<KrausOp>
   gateError(xacc::quantum::Gate &gate) const = 0;
+};
+
+// Utils to convert b/w different noise channel representations.
+// The default implementation to be contributed elsewhere.
+class NoiseModelUtils : public Identifiable {
+public:
+  using cMat = std::vector<std::vector<std::complex<double>>>;
+  virtual cMat krausToChoi(const std::vector<cMat> &in_krausMats) const = 0;
+  virtual std::vector<cMat> choiToKraus(const cMat &in_choiMat) const = 0;
 };
 } // namespace xacc

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -54,5 +54,8 @@ public:
   using cMat = std::vector<std::vector<std::complex<double>>>;
   virtual cMat krausToChoi(const std::vector<cMat> &in_krausMats) const = 0;
   virtual std::vector<cMat> choiToKraus(const cMat &in_choiMat) const = 0;
+  // Combine Choi matrices acting on a single channel:
+  virtual cMat
+  combineChannelOps(const std::vector<cMat> &in_choiMats) const = 0;
 };
 } // namespace xacc


### PR DESCRIPTION
- Added a utility class to convert b/w Choi and Kraus representations. Utilized the implementation of Qpp library.

- Construct the noise model explicitly in terms of Kraus ops which can be serialized according to IBM Json format.  

Tested by: using the generated noise model Json with the `aer` accelerator. 