### PR TITLE
Workaround an edge case of zero gate fidelity

### DIFF
--- a/quantum/plugins/placement/triq/tests/TriQPlacementTester.cpp
+++ b/quantum/plugins/placement/triq/tests/TriQPlacementTester.cpp
@@ -98,8 +98,71 @@ TEST(TriQPlacementTester, checkSimple) {
   EXPECT_GT(buffer->computeMeasurementProbability("111"), 0.35);
 }
 
+// Note: this test took a long time to complete.
+// Hence, we don't enable it by default.
+// Test the edge case whereby one qubit becomes effectively
+// isolated from all others.
+// i.e. the CNOT gate fidelity b/w its and neighbors is zero fidelity.
+// TEST(TriQPlacementTester, checkFailedQubit) {
+//   // Allocate some qubits
+//   auto buffer = xacc::qalloc(12);
+//   auto xasmCompiler = xacc::getCompiler("xasm");
+//   auto ir = xasmCompiler->compile(R"(__qpu__ void ghz(qbit q) {
+//       H(q[0]);
+//       H(q[1]);
+//       H(q[2]);
+//       H(q[3]);
+//       H(q[4]);
+//       H(q[5]);
+//       H(q[6]);
+//       H(q[7]);
+//       H(q[8]);
+//       CX(q[8], q[9]);
+//       CX(q[9], q[10]);
+//       CX(q[10], q[11]);
+//       Measure(q[0]);
+//       Measure(q[1]);
+//       Measure(q[2]);
+//       Measure(q[3]);
+//       Measure(q[4]);
+//       Measure(q[5]);
+//       Measure(q[6]);
+//       Measure(q[7]);
+//       Measure(q[8]);
+//       Measure(q[9]);
+//       Measure(q[10]);
+//       Measure(q[11]);
+// })",
+//                                   nullptr);
+//   auto program = ir->getComposites()[0];
+//   auto irt = xacc::getIRTransformation("triQ");
+//   const std::string BACKEND_JSON_FILE =
+//       std::string(RESOURCE_DIR) + "/backend_bit11.json";
+//   std::ifstream inFile;
+//   inFile.open(BACKEND_JSON_FILE);
+//   std::stringstream strStream;
+//   strStream << inFile.rdbuf();
+//   const std::string jsonStr = strStream.str();
+//   irt->apply(program, nullptr, {{"backend-json", jsonStr}});
+//   std::cout << "HOWDY: \n" << program->toString() << "\n";
+//   for (size_t instIdx = 0; instIdx < program->nInstructions(); ++instIdx) {
+//     auto instPtr = program->getInstruction(instIdx);
+//     // Check routing:
+//     if (instPtr->bits().size() == 2) {
+//       // In this particular JSON, Q11 of the the Melbourne backend is
+//       // effectively isolated, the CNOT gates w/ Q11 have error rates of 1.0. We
+//       // check that TriQ can avoid that qubit.
+//       const size_t q0 = instPtr->bits()[0];
+//       const size_t q1 = instPtr->bits()[1];
+//       EXPECT_NE(q0, 11);
+//       EXPECT_NE(q0, 11);
+//     }
+//   }
+// }
+
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
+  xacc::set_verbose(true);
   ::testing::InitGoogleTest(&argc, argv);
   auto ret = RUN_ALL_TESTS();
   xacc::Finalize();

--- a/quantum/plugins/placement/triq/tests/resources/backend_bit11.json
+++ b/quantum/plugins/placement/triq/tests/resources/backend_bit11.json
@@ -1,0 +1,3051 @@
+{
+    "backend_name": "ibmq_16_melbourne",
+    "last_update_date": "2020-09-02T10:06:47.000Z",
+    "backend_version": "2.3.0",
+    "gates": [
+      {
+        "gate": "id",
+        "name": "id_0",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0006397318691349585
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          0
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_0",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          0
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_0",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0006397318691349585
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          0
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_0",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0012790544814054172
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          0
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0010335505176428015
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          1
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          1
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0010335505176428015
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          1
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.00206603280861295
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          1
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0006368683488375013
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          2
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          2
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0006368683488375013
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          2
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0012733310963811695
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          2
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_3",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0004961583616632905
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          3
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_3",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          3
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_3",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0004961583616632905
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          3
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_3",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0009920705502066696
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          3
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0008021496789520868
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          4
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          4
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0008021496789520868
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          4
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:55:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.001603655913796742
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          4
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0031646828690412043
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          5
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          5
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0031646828690412043
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          5
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.006319350520420874
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 284.44444444444446
+          }
+        ],
+        "qubits": [
+          5
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_6",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.001192623523814824
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          6
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_6",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          6
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_6",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.001192623523814824
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          6
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_6",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0023838246967600174
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 284.44444444444446
+          }
+        ],
+        "qubits": [
+          6
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_7",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0016618173134415346
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          7
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_7",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          7
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_7",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0016618173134415346
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          7
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_7",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0033208729900997547
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 284.44444444444446
+          }
+        ],
+        "qubits": [
+          7
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0007575391583552327
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          8
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          8
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0007575391583552327
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          8
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0015145044511339911
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          8
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0014763465391032001
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          9
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          9
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0014763465391032001
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          9
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:59:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.002950513479102912
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 284.44444444444446
+          }
+        ],
+        "qubits": [
+          9
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_10",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.001996713510817448
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          10
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_10",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          10
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_10",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.001996713510817448
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          10
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_10",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.003989440156790591
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 284.44444444444446
+          }
+        ],
+        "qubits": [
+          10
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_11",
+        "parameters": [
+          {
+            "date": "2020-09-01T04:46:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.05090406651275079
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          11
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_11",
+        "parameters": [
+          {
+            "date": "2020-09-01T04:46:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          11
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_11",
+        "parameters": [
+          {
+            "date": "2020-09-01T04:46:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.05090406651275079
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          11
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_11",
+        "parameters": [
+          {
+            "date": "2020-09-01T04:46:44Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0992169090379671
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          11
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_12",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0008290585633407117
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          12
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_12",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          12
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_12",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0008290585633407117
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          12
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_12",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0016574297885799671
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          12
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0021422060767891343
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          13
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          13
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0021422060767891343
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 142.22222222222223
+          }
+        ],
+        "qubits": [
+          13
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T05:01:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.00427982310670294
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 284.44444444444446
+          }
+        ],
+        "qubits": [
+          13
+        ]
+      },
+      {
+        "gate": "id",
+        "name": "id_14",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0006058879947826924
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          14
+        ]
+      },
+      {
+        "gate": "u1",
+        "name": "u1_14",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 0
+          }
+        ],
+        "qubits": [
+          14
+        ]
+      },
+      {
+        "gate": "u2",
+        "name": "u2_14",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0006058879947826924
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 53.33333333333333
+          }
+        ],
+        "qubits": [
+          14
+        ]
+      },
+      {
+        "gate": "u3",
+        "name": "u3_14",
+        "parameters": [
+          {
+            "date": "2020-09-02T04:57:17Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.001211408889303156
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 106.66666666666666
+          }
+        ],
+        "qubits": [
+          14
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx0_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:22:06Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.019885683467623844
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 743.1111111111111
+          }
+        ],
+        "qubits": [
+          0,
+          1
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx0_14",
+        "parameters": [
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.02811870384146284
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 970.6666666666666
+          }
+        ],
+        "qubits": [
+          0,
+          14
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx1_0",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:22:06Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.019885683467623844
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 689.7777777777777
+          }
+        ],
+        "qubits": [
+          1,
+          0
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx1_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:29:04Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.011976302371106556
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 355.55555555555554
+          }
+        ],
+        "qubits": [
+          1,
+          2
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx1_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:12:15Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.04576428521293796
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1137.7777777777778
+          }
+        ],
+        "qubits": [
+          1,
+          13
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx2_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:29:04Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.011976302371106556
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 408.88888888888886
+          }
+        ],
+        "qubits": [
+          2,
+          1
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx2_3",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:34:14Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.025501534181445434
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 988.4444444444443
+          }
+        ],
+        "qubits": [
+          2,
+          3
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx2_12",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:22:24Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.038825683675891426
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1696
+          }
+        ],
+        "qubits": [
+          2,
+          12
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx3_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:34:14Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.025501534181445434
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1041.7777777777778
+          }
+        ],
+        "qubits": [
+          3,
+          2
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx3_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:39:37Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.01712596535369801
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 785.7777777777777
+          }
+        ],
+        "qubits": [
+          3,
+          4
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx3_11",
+        "parameters": [
+          {
+            "date": "2020-08-31T06:52:57Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 1
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 807.1111111111111
+          }
+        ],
+        "qubits": [
+          3,
+          11
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx4_3",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:39:37Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.01712596535369801
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 732.4444444444445
+          }
+        ],
+        "qubits": [
+          4,
+          3
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx4_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:55:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.026211588646125356
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 789.3333333333333
+          }
+        ],
+        "qubits": [
+          4,
+          5
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx4_10",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:41:46Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.027780789998080924
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1169.7777777777776
+          }
+        ],
+        "qubits": [
+          4,
+          10
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx5_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T07:55:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.026211588646125356
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 647.1111111111111
+          }
+        ],
+        "qubits": [
+          5,
+          4
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx5_6",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:07:08Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.05833749401543867
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1472
+          }
+        ],
+        "qubits": [
+          5,
+          6
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx5_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:48:16Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.03281587397896485
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 860.4444444444443
+          }
+        ],
+        "qubits": [
+          5,
+          9
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx6_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:07:08Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.05833749401543867
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1614.2222222222222
+          }
+        ],
+        "qubits": [
+          6,
+          5
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx6_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:54:05Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.028394141905825537
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 995.5555555555555
+          }
+        ],
+        "qubits": [
+          6,
+          8
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx7_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:22:31Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.034286941516688346
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 775.1111111111111
+          }
+        ],
+        "qubits": [
+          7,
+          8
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx8_6",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:54:05Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.028394141905825537
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1137.7777777777778
+          }
+        ],
+        "qubits": [
+          8,
+          6
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx8_7",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:22:31Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.034286941516688346
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 917.3333333333333
+          }
+        ],
+        "qubits": [
+          8,
+          7
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx8_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:29:56Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0393511980482924
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1159.111111111111
+          }
+        ],
+        "qubits": [
+          8,
+          9
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx9_5",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:48:16Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.03281587397896485
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1002.6666666666666
+          }
+        ],
+        "qubits": [
+          9,
+          5
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx9_8",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:29:56Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.0393511980482924
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1016.8888888888888
+          }
+        ],
+        "qubits": [
+          9,
+          8
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx9_10",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:37:36Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.03970776741544019
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 860.4444444444443
+          }
+        ],
+        "qubits": [
+          9,
+          10
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx10_4",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:41:46Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.027780789998080924
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1312
+          }
+        ],
+        "qubits": [
+          10,
+          4
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx10_9",
+        "parameters": [
+          {
+            "date": "2020-09-02T08:37:36Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.03970776741544019
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1002.6666666666666
+          }
+        ],
+        "qubits": [
+          10,
+          9
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx10_11",
+        "parameters": [
+          {
+            "date": "2020-08-31T06:21:25Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 1
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 945.7777777777777
+          }
+        ],
+        "qubits": [
+          10,
+          11
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx11_3",
+        "parameters": [
+          {
+            "date": "2020-08-31T06:52:57Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 1
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 753.7777777777777
+          }
+        ],
+        "qubits": [
+          11,
+          3
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx11_10",
+        "parameters": [
+          {
+            "date": "2020-08-31T06:21:25Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 1
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1088
+          }
+        ],
+        "qubits": [
+          11,
+          10
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx11_12",
+        "parameters": [
+          {
+            "date": "2020-08-29T09:19:48Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 1
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 597.3333333333333
+          }
+        ],
+        "qubits": [
+          11,
+          12
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx12_2",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:22:24Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.038825683675891426
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 1642.6666666666665
+          }
+        ],
+        "qubits": [
+          12,
+          2
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx12_11",
+        "parameters": [
+          {
+            "date": "2020-08-29T09:19:48Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 1
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 650.6666666666666
+          }
+        ],
+        "qubits": [
+          12,
+          11
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx12_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:03:59Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.02250000517954953
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 753.7777777777777
+          }
+        ],
+        "qubits": [
+          12,
+          13
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx13_1",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:12:15Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.04576428521293796
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 995.5555555555555
+          }
+        ],
+        "qubits": [
+          13,
+          1
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx13_12",
+        "parameters": [
+          {
+            "date": "2020-09-02T09:03:59Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.02250000517954953
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 611.5555555555555
+          }
+        ],
+        "qubits": [
+          13,
+          12
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx13_14",
+        "parameters": [
+          {
+            "date": "2020-09-02T10:00:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.035687116101247585
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 657.7777777777777
+          }
+        ],
+        "qubits": [
+          13,
+          14
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx14_0",
+        "parameters": [
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.02811870384146284
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 917.3333333333333
+          }
+        ],
+        "qubits": [
+          14,
+          0
+        ]
+      },
+      {
+        "gate": "cx",
+        "name": "cx14_13",
+        "parameters": [
+          {
+            "date": "2020-09-02T10:00:30Z",
+            "name": "gate_error",
+            "unit": "",
+            "value": 0.035687116101247585
+          },
+          {
+            "date": "2020-09-02T10:06:47Z",
+            "name": "gate_length",
+            "unit": "ns",
+            "value": 515.5555555555555
+          }
+        ],
+        "qubits": [
+          14,
+          13
+        ]
+      }
+    ],
+    "general": [
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_12",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_12",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_410",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_410",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_59",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_59",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_01",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_01",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_1011",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_1011",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_68",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_68",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_45",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_45",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_113",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_113",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_1213",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_1213",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_56",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_56",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_1314",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_1314",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_311",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_311",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_014",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_014",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_1112",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_1112",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_89",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_89",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_910",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_910",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_23",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_23",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_212",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_212",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_34",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_34",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "jq_78",
+        "unit": "GHz",
+        "value": 0
+      },
+      {
+        "date": "2020-09-02T10:06:47Z",
+        "name": "zz_78",
+        "unit": "GHz",
+        "value": 0
+      }
+    ],
+    "qubits": [
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 73.67159691259491
+        },
+        {
+          "date": "2020-09-02T04:53:26Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 95.64679630292493
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 5.1148580557661925
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.027800000000000047
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.04920000000000002
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.0064
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 56.02065088477446
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 56.02478466907801
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 5.235697473586735
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.0343
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.0562
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.012399999999999967
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 63.05740024379536
+        },
+        {
+          "date": "2020-09-02T04:53:26Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 87.94977549036209
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 5.038359289520821
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.0252
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.044
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.006399999999999961
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 66.65977084988623
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 16.469055273575126
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.894580503168903
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.08909999999999996
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.1256
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.05259999999999998
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 59.1243935918949
+        },
+        {
+          "date": "2020-09-02T04:53:26Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 63.12634553265308
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 5.021583618647239
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.03869999999999996
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.05740000000000001
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.02
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 20.339064216168264
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 37.65659859983473
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 5.073076043790158
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.04390000000000005
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.0794
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.008399999999999963
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 72.52251700875841
+        },
+        {
+          "date": "2020-09-02T04:53:26Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 77.41265998453287
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.929386590413643
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.03309999999999991
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.05479999999999996
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.0114
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 38.03591548432272
+        },
+        {
+          "date": "2020-09-02T04:53:26Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 14.394579279613211
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.982613293284842
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.06600000000000006
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.12319999999999998
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.0088
+        }
+      ],
+      [
+        {
+          "date": "2020-09-01T04:40:41Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 108.6289095891846
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 101.59552011995316
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.751646940675538
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.055400000000000005
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.08140000000000003
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.0294
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 44.52477891275218
+        },
+        {
+          "date": "2020-08-31T05:17:39Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 30.875577203243093
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.9734548047927545
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.07830000000000004
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.1106
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.04600000000000004
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 64.4824878966422
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 92.30357605787492
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.94479641933675
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.07289999999999996
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.12560000000000004
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.0202
+        }
+      ],
+      [
+        {
+          "date": "2020-08-31T05:15:01Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 14.566978626133032
+        },
+        {
+          "date": "2020-08-31T05:17:39Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 24.863772563531946
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.996231621100535
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.2683
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.4484
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.08819999999999995
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 71.86573932578519
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 68.80511781532815
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.763422295819544
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.1593
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.1638
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.15480000000000005
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 32.181123644017035
+        },
+        {
+          "date": "2020-09-02T04:53:26Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 34.38177172222237
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 4.974262182628905
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.08010000000000006
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.1024
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.05779999999999996
+        }
+      ],
+      [
+        {
+          "date": "2020-09-02T04:51:09Z",
+          "name": "T1",
+          "unit": "us",
+          "value": 45.78395173194921
+        },
+        {
+          "date": "2020-09-02T04:54:36Z",
+          "name": "T2",
+          "unit": "us",
+          "value": 64.57518681401663
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "frequency",
+          "unit": "GHz",
+          "value": 5.006780741045591
+        },
+        {
+          "date": "2020-09-02T10:06:47Z",
+          "name": "anharmonicity",
+          "unit": "GHz",
+          "value": 0
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "readout_error",
+          "unit": "",
+          "value": 0.05069999999999997
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas0_prep1",
+          "unit": "",
+          "value": 0.07620000000000005
+        },
+        {
+          "date": "2020-09-02T04:49:59Z",
+          "name": "prob_meas1_prep0",
+          "unit": "",
+          "value": 0.0252
+        }
+      ]
+    ]
+  }

--- a/quantum/plugins/placement/triq/triq_placement.cpp
+++ b/quantum/plugins/placement/triq/triq_placement.cpp
@@ -140,8 +140,11 @@ void TriQPlacement::apply(std::shared_ptr<CompositeInstruction> function,
   BackendMachine backendModel(*backendNoiseModel);
   // Step 3: Run TriQ (placement + optimize) for this backend
   // TriQ outputs a lot to std::cout, hence we need to bypass its logs. 
+  std::cout << std::flush;
   auto origBuf = std::cout.rdbuf();
-  std::cout.rdbuf(NULL);
+  if (!xacc::verbose) {
+    std::cout.rdbuf(NULL);
+  }
   const auto resultQasm = runTriQ(triqCirc, backendModel, compileAlgo);
   std::cout.rdbuf(origBuf);
   // DEBUG:


### PR DESCRIPTION
Today, ibmq_16_melbourne has Q11 effectively isolated: CNOT gates with neighbors have gate error = 1.0.
This causes TriQ to choke and eventually crash.

We put in a hack/workaround for now by assigning a rather small fidelity (relatively).
The crash can be prevented. However, the placement runtime for this scenario is still very high.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>