### PR TITLE
Added immediate execution support for Qpp and AER accelerators 

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
@@ -13,6 +13,13 @@
 #pragma one
 #include "xacc.hpp"
 #include <nlohmann/json.hpp>
+
+namespace AER {
+namespace Noise {
+class NoiseModel;
+}
+} // namespace AER
+
 namespace xacc {
 namespace quantum {
 
@@ -45,8 +52,14 @@ public:
   void execute(std::shared_ptr<AcceleratorBuffer> buffer,
                const std::vector<std::shared_ptr<CompositeInstruction>>
                    compositeInstructions) override;
-  std::vector<std::pair<int, int>> getConnectivity() override { return connectivity; }
-  
+  std::vector<std::pair<int, int>> getConnectivity() override {
+    return connectivity;
+  }
+
+  void apply(std::shared_ptr<AcceleratorBuffer> buffer,
+             std::shared_ptr<Instruction> inst) override;
+  bool isInitialized() const { return initialized; }
+
 private:
   static double calcExpectationValueZ(
       const std::vector<std::pair<double, double>> &in_stateVec,
@@ -58,6 +71,8 @@ private:
   nlohmann::json noise_model;
   std::vector<std::pair<int, int>> connectivity;
   HeterogeneousMap m_options;
+  bool initialized = false;
+  std::shared_ptr<AER::Noise::NoiseModel> noiseModelObj;
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -320,8 +320,7 @@ namespace quantum {
         if (inst->name() == "Measure")
         {
             const auto measRes = m_visitor->measure(inst->bits()[0]);
-            buffer->clearMeasurements();
-            buffer->appendMeasurement(measRes ? "1" : "0");
+            buffer->measure(inst->bits()[0], (measRes ? 1 : 0));
         }
         else
         {

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -313,6 +313,10 @@ namespace quantum {
 
     void QppAccelerator::apply(std::shared_ptr<AcceleratorBuffer> buffer, std::shared_ptr<Instruction> inst) 
     {
+        if (!m_visitor->isInitialized()) {
+            m_visitor->initialize(buffer);
+        }
+        
         if (inst->isComposite() || inst->isAnalog())
         {
             xacc::error("Only gates are allowed.");

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -311,6 +311,26 @@ namespace quantum {
         }
     }
 
+    void QppAccelerator::apply(std::shared_ptr<AcceleratorBuffer> buffer, std::shared_ptr<Instruction> inst) 
+    {
+        if (inst->isComposite() || inst->isAnalog())
+        {
+            xacc::error("Only gates are allowed.");
+        }
+        if (inst->name() == "Measure")
+        {
+            const auto measRes = m_visitor->measure(inst->bits()[0]);
+            buffer->clearMeasurements();
+            buffer->appendMeasurement(measRes ? "1" : "0");
+        }
+        else
+        {
+            auto gateCast = std::dynamic_pointer_cast<xacc::quantum::Gate>(inst);
+            assert(gateCast);
+            m_visitor->applyGate(*gateCast);
+        }
+    }
+
     NoiseModelUtils::cMat DefaultNoiseModelUtils::krausToChoi(const std::vector<NoiseModelUtils::cMat>& in_krausMats) const
     {
         std::vector<Eigen::MatrixXcd> krausMats;

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -31,6 +31,8 @@ public:
     virtual BitOrder getBitOrder() override {return BitOrder::LSB;}
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::shared_ptr<CompositeInstruction> compositeInstruction) override;
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<std::shared_ptr<CompositeInstruction>> compositeInstructions) override;
+    virtual void apply(std::shared_ptr<AcceleratorBuffer> buffer, std::shared_ptr<Instruction> inst) override;
+
 private:
     std::shared_ptr<QppVisitor> m_visitor;
     // Number of 'shots' if random sampling simulation is enabled.

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -51,6 +51,7 @@ namespace quantum {
         m_dims = std::move(dims);
         m_measureBits.clear();
         m_shotsMode = shotsMode;
+        m_initialized = true;
     }
 
     void QppVisitor::finalize()
@@ -61,6 +62,7 @@ namespace quantum {
             m_bitString.clear();
         }
         m_stateVec.resize(0);
+        m_initialized = false;
     }
 
     qpp::idx QppVisitor::xaccIdxToQppIdx(size_t in_idx) const

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -60,6 +60,7 @@ namespace quantum {
             m_buffer->appendMeasurement(m_bitString);
             m_bitString.clear();
         }
+        m_stateVec.resize(0);
     }
 
     qpp::idx QppVisitor::xaccIdxToQppIdx(size_t in_idx) const
@@ -304,5 +305,41 @@ namespace quantum {
         {
             std::cout << "If statement expanded to: " << ifStmt.toString() << "\n";
         }
+    }
+    
+    void QppVisitor::applyGate(Gate& in_gate) 
+    {
+        if (in_gate.name() == "Measure")
+        {
+            xacc::error("Only unitary gates are allowed.");
+        }
+        in_gate.accept(this);
+    }
+
+    bool QppVisitor::measure(size_t in_bit) 
+    {
+        const auto qubitIdx = xaccIdxToQppIdx(in_bit);
+        const auto measured = qpp::measure(m_stateVec, qpp::Gates::get_instance().Id2, { qubitIdx }, 2,  false);
+        const auto& measProbs = std::get<qpp::PROB>(measured);
+        const auto& postMeasStates = std::get<qpp::ST>(measured);
+        const auto randomSelectedResult = std::get<qpp::RES>(measured);
+
+        assert(measProbs.size() == 2 && postMeasStates.size() == 2 && randomSelectedResult < 2);
+       
+        if (xacc::verbose)
+        {
+            std::cout << ">> Probability of all results: ";
+            std::cout << qpp::disp(measProbs, ", ") << "\n";
+            std::cout << ">> Measurement result is: " << randomSelectedResult << "\n";
+        }
+
+        const auto& collapsedState = postMeasStates[randomSelectedResult];
+        m_stateVec = Eigen::Map<const qpp::ket>(collapsedState.data(), collapsedState.size());
+        if (xacc::verbose)
+        {
+            std::cout << ">> State after measurement: " << qpp::disp(m_stateVec, ", ") << "\n";
+        }
+        // 0 -> False; 1 -> True
+        return (randomSelectedResult == 1);
     }
 }}

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -56,6 +56,10 @@ public:
   virtual std::shared_ptr<QppVisitor> clone() { return std::make_shared<QppVisitor>(); }
   const KetVectorType& getStateVec() const { return m_stateVec; }
   static double calcExpectationValueZ(const KetVectorType& in_stateVec, const std::vector<qpp::idx>& in_bits);
+
+  // Gate-by-gate API
+  void applyGate(Gate& in_gate);
+  bool measure(size_t in_bit);
 private:
   qpp::idx xaccIdxToQppIdx(size_t in_idx) const;
 private:

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -60,6 +60,7 @@ public:
   // Gate-by-gate API
   void applyGate(Gate& in_gate);
   bool measure(size_t in_bit);
+  bool isInitialized() const { return m_initialized; }
 private:
   qpp::idx xaccIdxToQppIdx(size_t in_idx) const;
 private:
@@ -71,5 +72,6 @@ private:
   // Otherwise, it will only compute the expectation value.
   bool m_shotsMode;
   std::string m_bitString;
+  bool m_initialized = false;
 };
 }}

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -95,7 +95,12 @@ public:
   }
 
   virtual bool isRemote() { return false; }
-
+  // Gate-by-gate application (with a persistent underlying quantum state)
+  virtual void apply(std::shared_ptr<AcceleratorBuffer> buffer,
+                     std::shared_ptr<Instruction> inst) {
+    throw std::logic_error("Accelerator '" + name() +
+                           "' doesn't support single gate application.");
+  }
   virtual ~Accelerator() {}
 };
 

--- a/xacc/compiler/qalloc.cpp
+++ b/xacc/compiler/qalloc.cpp
@@ -38,6 +38,11 @@ qubit qreg::operator[](const std::size_t i) {
 //   buffer = q.buffer;
 //   return *this;
 // }
+bool qreg::cReg(std::size_t i) {
+  xacc::AcceleratorBuffer buffer = *results();
+  // Throw if this qubit hasn't been measured.
+  return buffer[i];
+}
 
 AcceleratorBuffer *qreg::results() { return buffer.get(); }
 std::map<std::string, int> qreg::counts() {

--- a/xacc/compiler/qalloc.cpp
+++ b/xacc/compiler/qalloc.cpp
@@ -25,11 +25,13 @@ qreg::qreg(const int n) {
   buffer = xacc::qalloc(n);
   auto name = "qreg_" + random_string(5);
   xacc::storeBuffer(name, buffer);
+  cReg classicalReg(buffer);
+  creg = classicalReg;
 }
 
 qreg::qreg(const qreg &other)
-    : buffer(other.buffer), been_named_and_stored(other.been_named_and_stored) {
-}
+    : buffer(other.buffer), been_named_and_stored(other.been_named_and_stored),
+      creg(buffer) {}
 
 qubit qreg::operator[](const std::size_t i) {
   return std::make_pair(buffer->name(), i);
@@ -38,10 +40,10 @@ qubit qreg::operator[](const std::size_t i) {
 //   buffer = q.buffer;
 //   return *this;
 // }
-bool qreg::cReg(std::size_t i) {
-  xacc::AcceleratorBuffer &buffer = *results();
+cReg::cReg(std::shared_ptr<AcceleratorBuffer> in_buffer) : buffer(in_buffer) {}
+bool cReg::operator[](std::size_t i) {
   // Throw if this qubit hasn't been measured.
-  return buffer[i];
+  return (*buffer)[i];
 }
 
 AcceleratorBuffer *qreg::results() { return buffer.get(); }

--- a/xacc/compiler/qalloc.cpp
+++ b/xacc/compiler/qalloc.cpp
@@ -23,7 +23,7 @@ std::string qreg::random_string(std::size_t length) {
 
 qreg::qreg(const int n) {
   buffer = xacc::qalloc(n);
-  auto name = "qreg_"+random_string(5);
+  auto name = "qreg_" + random_string(5);
   xacc::storeBuffer(name, buffer);
 }
 
@@ -39,7 +39,7 @@ qubit qreg::operator[](const std::size_t i) {
 //   return *this;
 // }
 bool qreg::cReg(std::size_t i) {
-  xacc::AcceleratorBuffer buffer = *results();
+  xacc::AcceleratorBuffer &buffer = *results();
   // Throw if this qubit hasn't been measured.
   return buffer[i];
 }
@@ -60,9 +60,7 @@ void qreg::setNameAndStore(const char *name) {
     been_named_and_stored = true;
   }
 }
-void qreg::store() {
-  xacc::storeBuffer(buffer);
-}
+void qreg::store() { xacc::storeBuffer(buffer); }
 int qreg::size() { return buffer->size(); }
 void qreg::addChild(qreg &q) {
   for (auto &child : q.buffer->getChildren()) {

--- a/xacc/compiler/qalloc.hpp
+++ b/xacc/compiler/qalloc.hpp
@@ -47,6 +47,8 @@ public:
   void store();
   void print();
   double weighted_sum(Observable *obs);
+  // Access classical measurement bit.
+  bool cReg(std::size_t i);
 };
 
 } // namespace internal_compiler

--- a/xacc/compiler/qalloc.hpp
+++ b/xacc/compiler/qalloc.hpp
@@ -22,7 +22,19 @@ class AcceleratorBuffer;
 class Observable;
 namespace internal_compiler {
 using qubit = std::pair<std::string, std::size_t>;
+class qreg;
+// Classical register associated with a qubit register to store single-shot
+// measurement results. i.e. after Measure(q[0]) => q.creg[0] will contain the
+// boolean (true/false) result of the measurement.
+class cReg {
+public:
+  cReg() = default;
+  cReg(std::shared_ptr<AcceleratorBuffer> in_buffer);
+  bool operator[](std::size_t i);
 
+private:
+  std::shared_ptr<AcceleratorBuffer> buffer;
+};
 class qreg {
 private:
   std::string random_string(std::size_t length);
@@ -47,10 +59,11 @@ public:
   void store();
   void print();
   double weighted_sum(Observable *obs);
-  // Access classical measurement bit.
-  bool cReg(std::size_t i);
+  // Public member var to simplify the single measurement syntax:
+  // i.e. we can access the single measurement results via the syntax:
+  // q.creg[i] vs. (*q.results())[i]
+  cReg creg;
 };
-
 } // namespace internal_compiler
 } // namespace xacc
 


### PR DESCRIPTION
- New API: `Accelerator::apply()` -> apply the instruction synchronously. Measurement results (if any) are reflected in the buffer's classical register.

- Added a short-hand notation: `qreg.creg[idx]` to access measurement data. 