### PR TITLE
Fixes for Qfast convergence instability if using mlpack

### DIFF
--- a/quantum/plugins/circuits/qfast/qfast.cpp
+++ b/quantum/plugins/circuits/qfast/qfast.cpp
@@ -368,6 +368,11 @@ std::vector<QFAST::Block> QFAST::refine(const std::vector<QFAST::PauliReps>& in_
         // Set the tolerance so that it will terminate when the
         // trace distance is sufficiently converged.
         optimizer->appendOption("mlpack-tolerance", m_distanceLimit/20.0);
+        
+        if (optimizer->get_algorithm() == "adam")
+        {
+            optimizer->appendOption("adam-exact-objective", true);
+        }
     }
     
     if (needGrads)
@@ -617,6 +622,10 @@ bool QFAST::optimizeAtDepth(std::vector<PauliReps>& io_repsToOpt, double in_targ
         optimizer->appendOption("mlpack-max-iter", maxEval);
         optimizer->appendOption("mlpack-step-size", 0.01);
         optimizer->appendOption("mlpack-tolerance", in_targetDistance/100.0);
+        if (optimizer->get_algorithm() == "adam")
+        {
+            optimizer->appendOption("adam-exact-objective", true);
+        }
     }
     
     if (needGrads)

--- a/quantum/plugins/circuits/qfast/tests/QfastTester.cpp
+++ b/quantum/plugins/circuits/qfast/tests/QfastTester.cpp
@@ -24,8 +24,10 @@ TEST(QFastTester, checkSimple)
 {
   srand(time(0));
   // Pick 0 or 1
-  const int randPick = rand() % 2;
-  const std::string optimizerName = (randPick == 0) ? "nlopt" : "mlpack";
+  // const int randPick = rand() % 2;
+  // const std::string optimizerName = (randPick == 0) ? "nlopt" : "mlpack";
+  const std::string optimizerName = "mlpack";
+  
   // Randomly pick an optimizer:
   // To save test time, we don't want to run many long tests.
   auto optimizer = xacc::getOptimizer(optimizerName);

--- a/quantum/plugins/circuits/qfast/tests/QfastTester.cpp
+++ b/quantum/plugins/circuits/qfast/tests/QfastTester.cpp
@@ -24,9 +24,8 @@ TEST(QFastTester, checkSimple)
 {
   srand(time(0));
   // Pick 0 or 1
-  // const int randPick = rand() % 2;
-  // const std::string optimizerName = (randPick == 0) ? "nlopt" : "mlpack";
-  const std::string optimizerName = "mlpack";
+  const int randPick = rand() % 2;
+  const std::string optimizerName = (randPick == 0) ? "nlopt" : "mlpack";
   
   // Randomly pick an optimizer:
   // To save test time, we don't want to run many long tests.

--- a/xacc/optimizer/mlpack/mlpack_optimizer.cpp
+++ b/xacc/optimizer/mlpack/mlpack_optimizer.cpp
@@ -102,7 +102,14 @@ OptResult MLPACKOptimizer::optimize(OptFunction &function) {
       beta2 = options.get<double>("mlpack-beta2");
     }
 
-    Adam optimizer(stepSize, 1, beta1, beta2, eps, maxiter, tol, false, false);
+    // Adam's exactObjective property (default = false)
+    bool exactObjective = false;
+    if (options.keyExists<bool>("adam-exact-objective")) {
+      exactObjective = options.get<bool>("adam-exact-objective");
+    }
+
+    Adam optimizer(stepSize, 1, beta1, beta2, eps, maxiter, tol, false, false,
+                   exactObjective);
     results = optimizer.Optimize(f, coordinates);
   } else if (mlpack_opt_name == "spsa") {
     SPSA optimizer(0.1, 0.102, 0.16, 0.3, 100000, 1e-5);


### PR DESCRIPTION
We don't really know the root cause of this but `mlpack` can get stuck at a certain fidelity value.

My suspicion is the `exactObjective` setting of `mlpack`'s Adam optimizer. 
By default, it uses an **estimate** of the objective function (`exactObjective = false`).  

We changed this to `true` inside `Qfast` and it seems to be effective.

Hence, commit this fix. 