### PR TITLE
Support If statement in QObj generation

### DIFF
--- a/python/examples/teleport.py
+++ b/python/examples/teleport.py
@@ -1,6 +1,6 @@
 import xacc 
 
-qpu = xacc.getAccelerator('qpp', {'shots':100})
+qpu = xacc.getAccelerator('aer', {'shots':1024})
 
 xacc.qasm('''
 .compiler xasm

--- a/quantum/gate/ir/CommonGates.cpp
+++ b/quantum/gate/ir/CommonGates.cpp
@@ -17,5 +17,21 @@ bool IfStmt::expand(const HeterogeneousMap &runtimeOptions) {
   }
   return true;
 }
+
+const std::string IfStmt::toString() {
+    std::stringstream retStr;
+    retStr << "if (" << bufferName << "[" << bitIdx <<  "]) {\n";
+
+    for (auto i : instructions) {
+      if (i->isComposite() &&
+          !std::dynamic_pointer_cast<CompositeInstruction>(i)->hasChildren()) {
+        retStr << " " << i->name() << "()\n";
+      } else {
+        retStr << " " << i->toString() << "\n";
+      }
+    }
+    retStr << "}\n";
+    return retStr.str();
+  }
 } // namespace quantum
 } // namespace xacc

--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -93,6 +93,7 @@ public:
     }
   }
 
+  const std::string toString() override; 
   DEFINE_CLONE(IfStmt)
   DEFINE_VISITABLE()
 };

--- a/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
@@ -50,6 +50,7 @@ public:
       qubit2MemorySlot.insert({b, counter});
       counter++;
     }
+    xacc::ibm::RegisterAllocator::getInstance()->reset();
   }
 
   const std::string toString() override {

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -292,9 +292,9 @@ public:
 struct Bfunc {
   Bfunc(int64_t in_regId, const std::string &in_hexMask,
         const std::string &in_relation = "==",
-        const std::string &in_val = "0x1")
+        const std::string &in_val = "")
       : registerId(in_regId), hex_mask(in_hexMask), relation(in_relation),
-        hex_val(in_val) {}
+        hex_val(in_val.empty() ? in_hexMask : in_val) {}
   int64_t registerId;
   std::string hex_mask;
   std::string relation;
@@ -333,6 +333,11 @@ public:
     const auto result = registerId;
     ++registerId;
     return result;
+  }
+
+  void reset() {
+    memoryToRegister.clear();
+    registerId = 0;
   }
 };
 

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -289,16 +289,83 @@ public:
   }
 };
 
+struct Bfunc {
+  Bfunc(int64_t in_regId, const std::string &in_hexMask,
+        const std::string &in_relation = "==",
+        const std::string &in_val = "0x1")
+      : registerId(in_regId), hex_mask(in_hexMask), relation(in_relation),
+        hex_val(in_val) {}
+  int64_t registerId;
+  std::string hex_mask;
+  std::string relation;
+  std::string hex_val;
+};
+
+class RegisterAllocator {
+  static inline RegisterAllocator *instance = nullptr;
+  std::unordered_map<int64_t, int64_t> memoryToRegister;
+  int64_t registerId;
+
+  RegisterAllocator() { registerId = 0; }
+
+public:
+  static RegisterAllocator *getInstance() {
+    if (!instance) {
+      instance = new RegisterAllocator;
+    }
+    return instance;
+  }
+
+  std::optional<int64_t> getRegisterId(int64_t in_memoryId) {
+    if (memoryToRegister.find(in_memoryId) != memoryToRegister.end()) {
+      return memoryToRegister[in_memoryId];
+    }
+    return std::nullopt;
+  }
+
+  int64_t mapMemory(int64_t in_memoryId) {
+    memoryToRegister[in_memoryId] = registerId;
+    registerId++;
+    return memoryToRegister[in_memoryId];
+  }
+
+  int64_t getNextRegister() {
+    const auto result = registerId;
+    ++registerId;
+    return result;
+  }
+};
+
 class Instruction {
 public:
   Instruction() = default;
   virtual ~Instruction() = default;
+  // Construct a binary function instruction
+  // Returns the Bfunc instruction and the register Id to condition the
+  // sub-circuit.
+  static Instruction createConditionalInst(int64_t memoryId) {
+    // Map the memory Id to a register:
+    const auto measRegisterId =
+        RegisterAllocator::getInstance()->mapMemory(memoryId);
+    const int64_t maskVal = 1ULL << measRegisterId;
+    const std::string hexMaskStr = "0x" + std::to_string(maskVal);
+    const int64_t resultRegisterId =
+        RegisterAllocator::getInstance()->getNextRegister();
+    Bfunc bFuncObj(resultRegisterId, hexMaskStr);
+    Instruction newInst;
+    newInst.bfunc = bFuncObj;
+    return newInst;
+  }
 
 private:
   std::vector<int64_t> qubits;
   std::string name;
   std::vector<double> params;
   std::vector<int64_t> memory;
+  // Conditional on a register value
+  std::optional<int64_t> conditional;
+  // If this is a Bfunc to compute a register value
+  std::optional<Bfunc> bfunc;
 
 public:
   const std::vector<int64_t> &get_qubits() const { return qubits; }
@@ -314,6 +381,13 @@ public:
 
   std::vector<int64_t> get_memory() const { return memory; }
   void set_memory(std::vector<int64_t> value) { this->memory = value; }
+
+  std::optional<Bfunc> get_bFunc() const { return bfunc; }
+  void set_bFunc(Bfunc value) { this->bfunc = value; }
+  bool isBfuc() const { return get_bFunc().has_value(); }
+
+  std::optional<int64_t> get_condition_reg_id() const { return conditional; }
+  void set_condition_reg_id(int64_t value) { this->conditional = value; }
 };
 
 class Experiment {
@@ -698,6 +772,15 @@ inline void from_json(const json &j, xacc::ibm::Instruction &x) {
 
 inline void to_json(json &j, const xacc::ibm::Instruction &x) {
   j = json::object();
+  if (x.isBfuc()) {
+    j["name"] = "bfunc";
+    j["register"] = x.get_bFunc()->registerId;
+    j["mask"] = x.get_bFunc()->hex_mask;
+    j["relation"] = x.get_bFunc()->relation;
+    j["val"] = x.get_bFunc()->hex_val;
+    return;
+  }
+
   j["qubits"] = x.get_qubits();
   j["name"] = x.get_name();
   if (!x.get_params().empty()) {
@@ -705,6 +788,20 @@ inline void to_json(json &j, const xacc::ibm::Instruction &x) {
   }
   if (!x.get_memory().empty()) {
     j["memory"] = x.get_memory();
+    // Technically, we only use one memory slot in each Measure Op:
+    if (x.get_memory().size() == 1) {
+      const auto memoryId = x.get_memory()[0];
+      const auto measRegisterId =
+          xacc::ibm::RegisterAllocator::getInstance()->getRegisterId(memoryId);
+      if (measRegisterId.has_value()) {
+        std::vector<int64_t> registerIds;
+        registerIds.emplace_back(measRegisterId.value());
+        j["register"] = registerIds;
+      }
+    }
+  }
+  if (x.get_condition_reg_id().has_value()) {
+    j["conditional"] = x.get_condition_reg_id().value();
   }
 }
 

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -147,7 +147,7 @@ void AerAccelerator::execute(
     nlohmann::json j = nlohmann::json::parse(qobj_str)["qObject"];
     j["config"]["shots"] = m_shots;
     j["config"]["noise_model"] = noise_model;
-
+    xacc::info("Qobj:\n" + j.dump(2));
     auto results_json = nlohmann::json::parse(
         AER::controller_execute_json<AER::Simulator::QasmController>(j.dump()));
 

--- a/quantum/plugins/ibm/aer/tests/AerAcceleratorTester.cpp
+++ b/quantum/plugins/ibm/aer/tests/AerAcceleratorTester.cpp
@@ -302,7 +302,8 @@ TEST(AerAcceleratorTester, checkConditional) {
   auto accelerator = xacc::getAccelerator("aer");
   xacc::set_verbose(true);
   auto xasmCompiler = xacc::getCompiler("xasm");
-  auto ir = xasmCompiler->compile(R"(__qpu__ void conditionalCirc(qbit q) {
+  {
+    auto ir = xasmCompiler->compile(R"(__qpu__ void conditionalCirc(qbit q) {
       X(q[0]);
       Measure(q[0]);
       Measure(q[1]);
@@ -320,15 +321,138 @@ TEST(AerAcceleratorTester, checkConditional) {
       Measure(q[3]);
       Measure(q[4]);
     })",
-                                  accelerator);
+                                    accelerator);
 
-  auto program = ir->getComposite("conditionalCirc");
+    auto program = ir->getComposite("conditionalCirc");
 
-  auto buffer = xacc::qalloc(5);
-  accelerator->execute(buffer, program);
-  buffer->print();
-  // Expected: q0 = 1, q1 = 0, q2 = 1, q3 = 0, q4 = 1
-  EXPECT_EQ(buffer->computeMeasurementProbability("10101"), 1.0);
+    auto buffer = xacc::qalloc(5);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // Expected: q0 = 1, q1 = 0, q2 = 1, q3 = 0, q4 = 1
+    EXPECT_EQ(buffer->computeMeasurementProbability("10101"), 1.0);
+  }
+  {
+    // Check Teleport
+    auto ir = xasmCompiler->compile(R"(__qpu__ void teleportOneState(qbit q) {
+      // State to be transported
+      X(q[0]);
+      // Bell channel setup
+      H(q[1]);
+      CX(q[1], q[2]);
+      // Alice Bell measurement
+      CX(q[0], q[1]);
+      H(q[0]);
+      Measure(q[0]);
+      Measure(q[1]);
+      // Correction
+      if (q[0])
+      {
+        Z(q[2]);
+      }
+      if (q[1])
+      {
+        X(q[2]);
+      }
+      // Measure teleported qubit
+      Measure(q[2]);
+    })",
+                                    accelerator);
+
+    auto program = ir->getComposite("teleportOneState");
+    auto buffer = xacc::qalloc(3);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    for (const auto &bitStr : buffer->getMeasurements()) {
+      EXPECT_EQ(bitStr.length(), 3);
+      // q[2] (MSB) must be '1' (teleported)
+      EXPECT_EQ(bitStr[0], '1');
+    }
+  }
+
+  {
+    // Check Teleport
+    auto ir = xasmCompiler->compile(R"(__qpu__ void teleportZeroState(qbit q) {
+      // Bell channel setup
+      H(q[1]);
+      CX(q[1], q[2]);
+      // Alice Bell measurement
+      CX(q[0], q[1]);
+      H(q[0]);
+      Measure(q[0]);
+      Measure(q[1]);
+      // Correction
+      if (q[0])
+      {
+        Z(q[2]);
+      }
+      if (q[1])
+      {
+        X(q[2]);
+      }
+      // Measure teleported qubit
+      Measure(q[2]);
+    })",
+                                    accelerator);
+
+    auto program = ir->getComposite("teleportZeroState");
+    auto buffer = xacc::qalloc(3);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    for (const auto &bitStr : buffer->getMeasurements()) {
+      EXPECT_EQ(bitStr.length(), 3);
+      // q[2] (MSB) must be '0' (teleported)
+      EXPECT_EQ(bitStr[0], '0');
+    }
+  }
+
+  {
+    // Check Teleport (50-50)
+    auto ir = xasmCompiler->compile(
+        R"(__qpu__ void teleportSuperpositionState(qbit q) {
+      // State to be transported
+      // superposition of 0 and 1
+      H(q[0]);
+      // Bell channel setup
+      H(q[1]);
+      CX(q[1], q[2]);
+      // Alice Bell measurement
+      CX(q[0], q[1]);
+      H(q[0]);
+      Measure(q[0]);
+      Measure(q[1]);
+      // Correction
+      if (q[0])
+      {
+        Z(q[2]);
+      }
+      if (q[1])
+      {
+        X(q[2]);
+      }
+      // Measure teleported qubit
+      Measure(q[2]);
+    })",
+        accelerator);
+
+    auto program = ir->getComposite("teleportSuperpositionState");
+    auto buffer = xacc::qalloc(3);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    double zeroProb = 0.0;
+    double oneProb = 0.0;
+    for (const auto &bitStr : buffer->getMeasurements()) {
+      EXPECT_EQ(bitStr.length(), 3);
+      // q[2] (MSB) is the teleported qubit
+      if (bitStr[0] == '0') {
+        zeroProb += buffer->computeMeasurementProbability(bitStr);
+      } else {
+        oneProb += buffer->computeMeasurementProbability(bitStr);
+      }
+    }
+    EXPECT_NEAR(zeroProb, 0.5, 0.1);
+    EXPECT_NEAR(oneProb, 0.5, 0.1);
+  }
+
   xacc::set_verbose(false);
 }
 


### PR DESCRIPTION
- Added `bfunc` instruction type which is the way IBM captures/computes classical bit value.

- Each measure instruction whose result will subsequently be used in a conditional `if` statement will need a `register` field.

- All instructions in a conditional block need to refer to the result register of the `bfunc`.

- Added unit tests.

- Fixed the toString() of the if statement circuit.  