### PR TITLE
Added method to convert single bit measurement map to bitstring

### DIFF
--- a/xacc/accelerator/AcceleratorBuffer.cpp
+++ b/xacc/accelerator/AcceleratorBuffer.cpp
@@ -343,6 +343,29 @@ bool AcceleratorBuffer::operator[](const std::size_t &i) {
   return single_measurements[i];
 }
 
+std::string
+AcceleratorBuffer::single_measurements_to_bitstring(BitOrder bitOrder,
+                                                    bool shouldClear) {
+  std::string bitString;
+  // single_measurements is an *ordered* map
+  if (bitOrder == BitOrder::LSB) {
+    for (auto iter = single_measurements.begin();
+         iter != single_measurements.end(); ++iter) {
+      bitString.append(iter->second ? "1" : "0");
+    }
+  } else {
+    for (auto iter = single_measurements.rbegin();
+         iter != single_measurements.rend(); ++iter) {
+      bitString.append(iter->second ? "1" : "0");
+    }
+  }
+
+  if (shouldClear) {
+    single_measurements.clear();
+  }
+  return bitString;
+}
+
 double
 AcceleratorBuffer::computeMeasurementProbability(const std::string &bitStr) {
   return (double)bitStringToCounts[bitStr] /

--- a/xacc/accelerator/AcceleratorBuffer.hpp
+++ b/xacc/accelerator/AcceleratorBuffer.hpp
@@ -128,6 +128,8 @@ protected:
   std::map<std::size_t, bool> single_measurements;
 
 public:
+  enum BitOrder {LSB, MSB};
+
   AcceleratorBuffer() {}
   AcceleratorBuffer(const int N);
   AcceleratorBuffer(const std::string &str, const int N);
@@ -208,6 +210,10 @@ public:
   }
 
   void reset_single_measurements() { single_measurements.clear(); }
+
+  std::string
+  single_measurements_to_bitstring(BitOrder bitOrder = BitOrder::MSB,
+                                   bool shouldClear = true);
 
   void setName(const std::string n) { bufferId = n; }
 


### PR DESCRIPTION
Can specify either LSB or MSB (default) ordering scheme.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>