### PR TITLE
Fix crash when running IBM accelerator

### DIFF
--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -60,17 +60,19 @@ void IBMAccelerator::initialize(const HeterogeneousMap &params) {
 
     // We should have backend set by now
 
-    if (!hub.empty()) {
-      IBM_CREDENTIALS_PATH =
-          "/api/Network/" + hub + "/Groups/" + group + "/Projects/" + project;
-      getBackendPath = IBM_CREDENTIALS_PATH + "/devices?access_token=";
-      getBackendPropertiesPath = "/api/Network/" + hub + "/Groups/" + group +
-                                 "/Projects/" + project + "/devices/" +
-                                 backend + "/properties";
-    } else {
-      xacc::error(
-          "We do not currently support running on the open IBM devices.");
+    if (hub.empty() && group.empty() && project.empty()) {
+      // Fallback to public API credentials
+      hub = "ibm-q";
+      group = "open";
+      project = "main";
     }
+
+    IBM_CREDENTIALS_PATH =
+        "/api/Network/" + hub + "/Groups/" + group + "/Projects/" + project;
+    getBackendPath = IBM_CREDENTIALS_PATH + "/devices?access_token=";
+    getBackendPropertiesPath = "/api/Network/" + hub + "/Groups/" + group +
+                               "/Projects/" + project + "/devices/" +
+                               backend + "/properties";
 
     // Post apiKey to get temp api key
     tokenParam += apiKey + "\"}";
@@ -90,29 +92,28 @@ void IBMAccelerator::initialize(const HeterogeneousMap &params) {
     getBackendPropsResponse = "{\"backends\":" + response + "}";
 
     // Get current backend properties
-    if (backend != DEFAULT_IBM_BACKEND) {
-      auto response = get(IBM_API_URL, getBackendPropertiesPath, {},
-                          {std::make_pair("version", "1"),
-                           std::make_pair("access_token", currentApiToken)});
-      xacc::info("Backend property:\n" +  response);
-      auto props = json::parse(response);
-      backendProperties.insert({backend, props});
-      for (auto &b : backends_root["backends"]) {
-        if (b.count("backend_name") &&
-            b["backend_name"].get<std::string>() == backend) {
-          availableBackends.insert(std::make_pair(backend, b));
-        }
+    auto backend_props_response = get(IBM_API_URL, getBackendPropertiesPath, {},
+                                      {std::make_pair("version", "1"),
+                                       std::make_pair("access_token", currentApiToken)});
+    xacc::info("Backend property:\n" +  backend_props_response);
+    auto props = json::parse(backend_props_response);
+    backendProperties.insert({backend, props});
+    for (auto &b : backends_root["backends"]) {
+      if (b.count("backend_name") &&
+          b["backend_name"].get<std::string>() == backend) {
+        availableBackends.insert(std::make_pair(backend, b));
       }
-
-      chosenBackend = availableBackends[backend];
-
-      defaults_response =
-          get(IBM_API_URL,
-              IBM_CREDENTIALS_PATH + "/devices/" + backend + "/defaults", {},
-              {std::make_pair("version", "1"),
-               std::make_pair("access_token", currentApiToken)});
-      xacc::info("Backend default:\n" +  defaults_response);
     }
+
+    chosenBackend = availableBackends[backend];
+
+    defaults_response =
+        get(IBM_API_URL,
+            IBM_CREDENTIALS_PATH + "/devices/" + backend + "/defaults", {},
+            {std::make_pair("version", "1"),
+             std::make_pair("access_token", currentApiToken)});
+    xacc::info("Backend default:\n" +  defaults_response);
+
     initialized = true;
   }
 }


### PR DESCRIPTION
Hi,

I wrote a baby's first XACC program `bell.cpp` using the IBM accelerator:
```c++
#include <xacc/xacc.hpp>

int main(int argc, char **argv) {
    xacc::Initialize(argc, argv);

    auto qpu = xacc::getAccelerator("ibm");

    xacc::qasm(R"(
        .compiler xasm
        .circuit bell
        .qbit q

        H(q[0]);
        CNOT(q[0], q[1]);
        Measure(q[0]);
        Measure(q[1]);
    )");

    auto bell = xacc::getCompiled("bell");
    auto buf = xacc::qalloc(2);

    qpu->execute(buf, bell);
    buf->print();

    xacc::Finalize();
    return 0;
}
```

My `~/.ibm_config` is
```
key: [censored]
hub: ibm-q
group: open
project: main
```

But when I try to run it, I get:
```
$ ./bell
terminate called after throwing an instance of 'nlohmann::detail::type_error'
  what():  [json.exception.type_error.302] type must be number, but is null
Aborted (core dumped)
```
Full gdb backtrace:
```
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff76c4859 in __GI_abort () at abort.c:79
#2  0x00007ffff794a951 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff795647c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff79564e7 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff7956799 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007fffeb6253be in nlohmann::detail::from_json<nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer>, int, 0> (j=..., val=@0x7fffffffd274: 32767) at /home/austin/Documents/school/gatech/grad/xacc/xacc/tpls/nlohmann/json.hpp:1165
#7  0x00007fffeb6186ed in nlohmann::detail::from_json_fn::call<nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer>, int> (this=0x7ffff4f46508 <nlohmann::detail::static_const<nlohmann::detail::from_json_fn>::value>, j=..., val=@0x7fffffffd274: 32767)
    at /home/austin/Documents/school/gatech/grad/xacc/xacc/tpls/nlohmann/json.hpp:1195
#8  0x00007fffeb609837 in nlohmann::detail::from_json_fn::operator()<nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer>, int> (this=0x7ffff4f46508 <nlohmann::detail::static_const<nlohmann::detail::from_json_fn>::value>, j=..., val=@0x7fffffffd274: 32767)
    at /home/austin/Documents/school/gatech/grad/xacc/xacc/tpls/nlohmann/json.hpp:1216
#9  0x00007fffeb5f7de4 in nlohmann::adl_serializer<int, void>::from_json<nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer> const&, int> (j=..., val=@0x7fffffffd274: 32767) at /home/austin/Documents/school/gatech/grad/xacc/xacc/tpls/nlohmann/json.hpp:9669
#10 0x00007fffeb5e44ac in nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer>::get<int, int, 0> (this=0x5555556bd460) at /home/austin/Documents/school/gatech/grad/xacc/xacc/tpls/nlohmann/json.hpp:12094
#11 0x00007fffeb5bb410 in xacc::quantum::IBMAccelerator::getConnectivity (this=0x7ffff009d3b0) at /home/austin/Documents/school/gatech/grad/xacc/xacc/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp:570
#12 0x00007fffeb5b7973 in xacc::quantum::IBMAccelerator::execute (this=0x7ffff009d3b0, buffer=std::shared_ptr<class xacc::AcceleratorBuffer> (use count 4, weak count 0) = {...}, circuits=std::vector of length 1, capacity 1 = {...})
    at /home/austin/Documents/school/gatech/grad/xacc/xacc/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp:338
#13 0x00007fffeb5b54b4 in xacc::quantum::IBMAccelerator::execute (this=0x7ffff009d3b0, buffer=std::shared_ptr<class xacc::AcceleratorBuffer> (use count 4, weak count 0) = {...}, circuit=
    std::shared_ptr<class xacc::CompositeInstruction> (use count 5, weak count 1) = {...}) at /home/austin/Documents/school/gatech/grad/xacc/xacc/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp:123
#14 0x0000555555567cc0 in main (argc=1, argv=0x7fffffffdbb8) at bell.cpp:22

```

----

This PR attempts to fix that by removing a manual check that skips fetching backend properties when  `backend == DEFAULT_IBM_BACKEND`. I don't really know what I'm doing since I'm new to everything involved here — am I missing a reason for that check?

Along the same lines, I also added a check to fallback to the public API when hub/group/project aren't set. (For me, https://quantum-computing.ibm.com/account shows `IBMQ.get_provider(hub='ibm-q', group='open', project='main')`, which is where I got this. And I think [this is some prior art](https://pennylaneqiskit.readthedocs.io/en/latest/devices/ibmq.html#specifying-providers).) Am I missing a reason why the open API is not supported?

## Testing
Ran `ctests`

And then with the following `~/.ibm_config`:
```
key: [censored]
```
My original program works:
```
$ ./bell
IBM Job 5f65a62b434ac20013233106 Status: COMPLETED.                    
{
    "AcceleratorBuffer": {
        "name": "qreg_0x563066159e90",
        "size": 2,
        "Information": {
            "ibm-job-id": "5f65a62b434ac20013233106"
        },
        "Measurements": {
            "00": 520,
            "11": 504
        }
    }
}
```
Thanks