### PR TITLE
Potential fix for #296

### DIFF
--- a/quantum/plugins/algorithms/gradient_strategies/tests/CMakeLists.txt
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ include_directories(${CMAKE_BINARY_DIR})
 add_xacc_test(GradientStrategies)
 target_link_libraries(GradientStrategiesTester xacc xacc-quantum-gate xacc-pauli) 
 
-add_xacc_test(QuantumNatualGradient)
-target_link_libraries(QuantumNatualGradientTester xacc xacc-pauli xacc-gradient-strategies) 
-target_include_directories(QuantumNatualGradientTester PRIVATE ../) 
+# Only test QNG module if LAPACK was installed.
+find_package(LAPACK)
+if(LAPACK_FOUND)
+    add_xacc_test(QuantumNatualGradient)
+    target_link_libraries(QuantumNatualGradientTester xacc xacc-pauli xacc-gradient-strategies) 
+    target_include_directories(QuantumNatualGradientTester PRIVATE ../) 
+endif()


### PR DESCRIPTION
Disabled QNG test if no LAPACK

Fixed https://github.com/eclipse/xacc/issues/296

The compile errors were because QNG tester executable needs to link directly to the QNG plugin, which uses Armadillo.
Hence, don't try to compile this test if no LAPACK installed. 

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>