### PR TITLE
Fix to enable HPCVirtDecorator to work with VQE::execute(q, x) when x != {}

### DIFF
--- a/quantum/plugins/algorithms/vqe/vqe.cpp
+++ b/quantum/plugins/algorithms/vqe/vqe.cpp
@@ -315,6 +315,13 @@ VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer,
         fsToExec.push_back(f);
       } else {
         auto evaled = f->operator()(x);
+        // Need to add this if x != {}
+        // so that the HPCVirtDecorator can 
+        // access the coefficients to compute the energy
+        if (std::dynamic_pointer_cast<xacc::AcceleratorDecorator>(
+          xacc::as_shared_ptr(accelerator))) {
+          evaled->setCoefficient(coeff);
+        }
         fsToExec.push_back(evaled);
       }
       coefficients.push_back(std::real(coeff));


### PR DESCRIPTION
This allows the HPCVirtDecorator to compute the energy with the coefficients from the measured Hamiltonian terms, otherwise they default to 1.0.

Signed-off-by: Daniel Claudino <6d3@ornl.gov>