### PR TITLE
Speed-up OpenQASM compilation for long circuits

### DIFF
--- a/quantum/gate/ir/Circuit.hpp
+++ b/quantum/gate/ir/Circuit.hpp
@@ -224,6 +224,21 @@ public:
     for (auto &i : insts)
       addInstruction(i);
   }
+
+  void addInstructions(const std::vector<InstPtr> &&insts,
+                       bool shouldValidate = true) override {
+    if (shouldValidate) {
+      for (auto &i : insts) {
+        addInstruction(i);
+      }
+    } else {
+      // Bypass instruction validation, append all the instructions directly.
+      instructions.insert(instructions.end(),
+                          std::make_move_iterator(insts.begin()),
+                          std::make_move_iterator(insts.end()));
+    }
+  }
+
   void clear() override { instructions.clear(); }
 
   bool hasChildren() const override { return !instructions.empty(); }

--- a/quantum/plugins/staq/compiler/staq_compiler.cpp
+++ b/quantum/plugins/staq/compiler/staq_compiler.cpp
@@ -226,9 +226,37 @@ std::shared_ptr<IR> StaqCompiler::compile(const std::string &src,
       *prog, {false, transformations::default_overrides, "anc"});
 
   //   std::cout <<"PROG: " << *prog << "\n";
-  // Visit Program to find out how many qreg there are and
-  // use that to build up openqasm xacc function prototype
+  
+  // Determine the number of qreqs
+  internal_staq::CountQregs countQreq;
+  dynamic_cast<ast::Traverse &>(countQreq).visit(*prog);
+  const auto nbQreqs = countQreq.qregs.size() + ancillas.ancillas.size();
+  // Direct Staq's AST -> XACC's IR translation:
+  // This can only be used (reliably) for simple QASM source,
+  // that uses a single qreg (we can use simple qubit indexing to construct IR)
+  // Note: we don't handle *embedded* QASM source in this direct translate mode.
+  if (!isXaccKernel && nbQreqs == 1) {
+    // Create a temporary kernel name:
+    std::string name = "tmp";
+    if (xacc::hasCompiled(name)) {
+      int counter = 0;
+      while (true) {
+        name = "tmp" + std::to_string(counter);
+        if (!xacc::hasCompiled(name)) {
+          break;
+        }
+        counter++;
+      }
+    }
 
+    // Direct translation
+    internal_staq::StaqToIr translate(name);
+    translate.visit(*prog);
+    return translate.getIr();
+  }
+
+  // Otherwise, translate Staq's AST to XASM source string
+  // then recompile.
   internal_staq::StaqToXasm translate;
   translate.visit(*prog);
 

--- a/quantum/plugins/staq/compiler/tests/StaqCompilerTester.in.cpp
+++ b/quantum/plugins/staq/compiler/tests/StaqCompilerTester.in.cpp
@@ -15,6 +15,11 @@
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 
+namespace {
+  // CU1 decompose: 5 instructions
+  constexpr int CU1_DECOMP_N_INSTS = 5;
+}
+
 TEST(StaqCompilerTester, checkCphase) {
 
   auto src = R"#(
@@ -34,9 +39,10 @@ measure q[2] -> c[2];)#";
 
   auto hello = IR->getComposites()[0];
   std::cout << "HELLO:\n" << hello->toString() << "\n";
-
-
+  const int expectedNinsts = 7 + CU1_DECOMP_N_INSTS;
+  EXPECT_EQ(hello->nInstructions(), expectedNinsts);
 }
+
 TEST(StaqCompilerTester, checkSimple) {
   auto compiler = xacc::getCompiler("staq");
   auto IR = compiler->compile(R"(
@@ -50,7 +56,8 @@ TEST(StaqCompilerTester, checkSimple) {
 
   auto hello = IR->getComposites()[0];
   std::cout << "HELLO:\n" << hello->toString() << "\n";
-
+  EXPECT_EQ(hello->nInstructions(), 5);
+  
   auto q = xacc::qalloc(2);
   q->setName("q");
   xacc::storeBuffer(q);
@@ -67,6 +74,7 @@ TEST(StaqCompilerTester, checkSimple) {
 
   hello = IR->getComposites()[0];
   std::cout << "HELLO:\n" << hello->toString() << "\n";
+  EXPECT_EQ(hello->nInstructions(), 5);
 }
 
 TEST(StaqCompilerTester, checkCanParse) {

--- a/xacc/ir/CompositeInstruction.hpp
+++ b/xacc/ir/CompositeInstruction.hpp
@@ -176,7 +176,7 @@ public:
   virtual void addInstruction(InstPtr instruction) = 0;
   virtual void addInstructions(std::vector<InstPtr> &instruction) = 0;
   virtual void addInstructions(const std::vector<InstPtr> &instruction) = 0;
-  virtual void addInstructions(const std::vector<InstPtr> &&insts) {
+  virtual void addInstructions(const std::vector<InstPtr> &&insts, bool shouldValidate = true) {
     addInstructions(insts);
   }
 


### PR DESCRIPTION
- Add a visitor to translate Staq's AST to XACC's IR directly.

- Add the ability to add a vector of instructions to Composite without validation. These instructions are translated from a valid AST hence should be valid.

Tested by: unit testing.