### PR TITLE
Further perf improvement

### DIFF
--- a/quantum/examples/qasm/phase_estimation_10q.cpp
+++ b/quantum/examples/qasm/phase_estimation_10q.cpp
@@ -14,10 +14,11 @@ int main(int argc, char **argv) {
     const std::string qasmSrcStr = strStream.str();
    
     // Compile:
+    xacc::ScopeTimer timer("compile", false);
     auto IR = compiler->compile(qasmSrcStr);
     auto program = IR->getComposites()[0];
     std::cout << "Number of instructions: " << program->nInstructions() << "\n";
-    
+    std::cout << "Elapsed time: " << timer.getDurationMs() << " ms.\n";
     // Allocate some qubits and execute:
     auto buffer = xacc::qalloc(10);
     accelerator->execute(buffer, program);


### PR DESCRIPTION
Fast look-up to find IR ctor function for a Staq's gate node.

Got ~30 sec reduction (50%) in the test circuit (650k gates)

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>