### PR TITLE
Fixed a regression bug due to direct Staq IR translation

### DIFF
--- a/quantum/plugins/staq/compiler/staq_compiler.cpp
+++ b/quantum/plugins/staq/compiler/staq_compiler.cpp
@@ -250,7 +250,7 @@ std::shared_ptr<IR> StaqCompiler::compile(const std::string &src,
     }
 
     // Direct translation
-    internal_staq::StaqToIr translate(name);
+    internal_staq::StaqToIr translate(name, countQreq.qregs[0]);
     translate.visit(*prog);
     return translate.getIr();
   }


### PR DESCRIPTION
I was making sure that we only handle the case whereby there is only one qreg but didn't handle the case where the buffer name is different from the default "q".

Tested by: running qcor tests.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>