### PR TITLE
Connect IBM noise model with QLM Noisy Simulator

### DIFF
--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -471,7 +471,7 @@ public:
       : CH(std::vector<std::size_t>{sqbit, tqbit}) {}
 
   const std::string description() const override { return ""; }
-  const int nRequiredBits() const override { return 1; }
+  const int nRequiredBits() const override { return 2; }
 
   DEFINE_CLONE(CH)
   DEFINE_VISITABLE()

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
@@ -16,6 +16,8 @@
 #include <pybind11/embed.h>
 
 namespace xacc {
+class NoiseModel;
+
 namespace quantum {
 class QlmCircuitVisitor : public AllGateVisitor {
 public:
@@ -91,6 +93,7 @@ private:
 private:
   int m_shots;
   pybind11::object m_qlmQpuServer;
+  std::shared_ptr<NoiseModel> m_noiseModel;
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
@@ -73,6 +73,9 @@ public:
   virtual const std::vector<std::string> configurationKeys() override {
     return {};
   }
+  
+  virtual std::vector<std::pair<int, int>> getConnectivity() override;
+
   virtual BitOrder getBitOrder() override { return BitOrder::MSB; }
   virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer,
                        const std::shared_ptr<CompositeInstruction>

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
@@ -88,7 +88,8 @@ private:
       std::shared_ptr<AcceleratorBuffer> buffer,
       std::shared_ptr<CompositeInstruction> compositeInstruction) const;
   void persistResultToBuffer(std::shared_ptr<AcceleratorBuffer> buffer,
-                             pybind11::object &result) const;
+                             pybind11::object &result,
+                             pybind11::object &job) const;
 
 private:
   int m_shots;

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.in.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.in.cpp
@@ -394,6 +394,27 @@ void QlmAccelerator::initialize(const HeterogeneousMap &params) {
   }
 }
 
+std::vector<std::pair<int, int>> QlmAccelerator::getConnectivity() {
+  if (m_noiseModel) {
+    // There is a hardware model, i.e. IBM backend.
+    // Note: the noise model has noise data for both directions of the pair,
+    // hence, we use set to return non-directional coupling map.
+    std::set<std::pair<int, int>> couplingMap;
+    auto twoQubitPairs = m_noiseModel->averageTwoQubitGateFidelity();
+    for (const auto &[q1, q2, err] : twoQubitPairs) {
+      if (q1 < q2) {
+        couplingMap.emplace(q1, q2);
+      } else {
+        couplingMap.emplace(q2, q1);
+      }
+    }
+    std::vector<std::pair<int, int>> result(couplingMap.begin(),
+                                            couplingMap.end());
+    return result;
+  }
+  return {};
+}
+
 pybind11::object QlmAccelerator::constructQlmJob(
     std::shared_ptr<AcceleratorBuffer> buffer,
     std::shared_ptr<CompositeInstruction> compositeInstruction) const {

--- a/quantum/plugins/atos_qlm/accelerator/tests/CMakeLists.txt
+++ b/quantum/plugins/atos_qlm/accelerator/tests/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_xacc_test(QlmAccelerator)
 target_link_libraries(QlmAcceleratorTester xacc xacc-quantum-gate)
+
+add_xacc_test(QlmNoisyAccelerator)
+target_link_libraries(QlmNoisyAcceleratorTester xacc xacc-quantum-gate)

--- a/quantum/plugins/atos_qlm/accelerator/tests/QlmNoisyAcceleratorTester.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/tests/QlmNoisyAcceleratorTester.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include "xacc.hpp"
+#include "Optimizer.hpp"
+#include "xacc_service.hpp"
+#include "Algorithm.hpp"
+#include "xacc_observable.hpp"
+
+TEST(QlmNoisyAcceleratorTester, testBell) {
+  auto accelerator = xacc::getAccelerator("atos-qlm:ibmq_casablanca", {{"shots", 1024}});
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto program1 = xasmCompiler
+                      ->compile(R"(__qpu__ void bell(qbit q) {
+      H(q[0]);
+      CX(q[0], q[1]);
+      Measure(q[0]);
+      Measure(q[1]);
+    })",
+                                accelerator)
+                      ->getComposites()[0];
+
+  auto buffer1 = xacc::qalloc(2);
+  accelerator->execute(buffer1, program1);
+  // Due to noise, we should get all 4 possible states:
+  EXPECT_EQ(buffer1->getMeasurementCounts().size(), 4);
+  buffer1->print();
+  EXPECT_NEAR(buffer1->computeMeasurementProbability("00"), 0.5, 0.1);
+  EXPECT_NEAR(buffer1->computeMeasurementProbability("11"), 0.5, 0.1);
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize();
+  ::testing::InitGoogleTest(&argc, argv);
+  const auto result = RUN_ALL_TESTS();
+  xacc::Finalize();
+  return result;
+}

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -547,6 +547,12 @@ double IbmqNoiseModel::averageGateFidelity(
   return 1.0;
 }
 
+double IbmqNoiseModel::gateErrorProb(xacc::quantum::Gate &gate) const {
+  const auto universalGateName = getUniversalGateEquiv(gate);
+  const auto gateErrorIter = m_gateErrors.find(universalGateName);
+  return (gateErrorIter == m_gateErrors.end()) ? 0.0 : gateErrorIter->second;
+}
+
 std::vector<KrausOp>
 IbmqNoiseModel::gateError(xacc::quantum::Gate &gate) const {
   std::vector<KrausOp> krausOps;

--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -20,8 +20,8 @@ public:
   }
   std::vector<RoErrors> readoutErrors() const override { return m_roErrors; }
 
-  std::vector<KrausOp>
-  gateError(xacc::quantum::Gate &gate) const override;
+  std::vector<KrausOp> gateError(xacc::quantum::Gate &gate) const override;
+  double gateErrorProb(xacc::quantum::Gate &gate) const override;
   size_t nQubits() const override { return m_nbQubits; }
   std::vector<double> averageSingleQubitGateFidelity() const override;
   std::vector<std::tuple<size_t, size_t, double>>

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -45,6 +45,9 @@ public:
   // the equivalent Kraus operators.
   virtual std::vector<KrausOp>
   gateError(xacc::quantum::Gate &gate) const = 0;
+  // Get gate error probability:
+  virtual double
+  gateErrorProb(xacc::quantum::Gate &gate) const = 0;
   // Query Fidelity information:
   virtual size_t nQubits() const = 0;
   virtual std::vector<double> averageSingleQubitGateFidelity() const = 0;


### PR DESCRIPTION
- Handle IBM backends, e.g. `atos-qlm:ibmq_xyz`

- Use gate error information from the IBM noise model to configure QLM gate noise.
 
Notes: the QLM gate noise model seems to be uniform (i.e. using gate name look-up, not gate + qubit), hence just pick one gate error atm. I'm following up with the support engineer for instructions. 

Related to https://github.com/eclipse/xacc/issues/337