### PR TITLE
Moved find_package(LAPACK) to top level to prevent code duplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,9 @@ IF(CMAKE_BUILD_TYPE MATCHES "Debug" OR CMAKE_BUILD_TYPE MATCHES "DEBUG")
   add_compile_definitions(_XACC_DEBUG)
 ENDIF()
 
+# Find LAPACK (optional) 
+find_package(LAPACK)
+
 add_subdirectory(xacc)
 add_subdirectory(quantum)
 

--- a/python/plugins/mitiq/mitiq_zne_decorator.hpp
+++ b/python/plugins/mitiq/mitiq_zne_decorator.hpp
@@ -25,7 +25,7 @@ namespace python {
 class MitiqZNE : public AcceleratorDecorator {
 protected:
   std::unique_ptr<py::scoped_interpreter> guard;
-  void * libpython_handle;
+  void * libpython_handle = nullptr;
   py::module xacc;
   py::module qiskit;
   py::module mitiq;

--- a/python/plugins/scikit-quant/scikit_quant_optimizer.hpp
+++ b/python/plugins/scikit-quant/scikit_quant_optimizer.hpp
@@ -26,7 +26,7 @@ class ScikitQuantOptimizer : public Optimizer {
 protected: 
   void initialize();
   std::unique_ptr<py::scoped_interpreter> guard;
-  void * libpython_handle;
+  void * libpython_handle = nullptr;
   bool initialized = false;
   
 public:

--- a/quantum/plugins/algorithms/gradient_strategies/CMakeLists.txt
+++ b/quantum/plugins/algorithms/gradient_strategies/CMakeLists.txt
@@ -49,7 +49,6 @@ else()
                         PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
   set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")
   # Armadillo solver (QNG strategy) needs LAPACK
-  find_package(LAPACK)
   if(LAPACK_FOUND)
    target_link_libraries(${LIBRARY_NAME} PRIVATE ${LAPACK_LIBRARIES})
   else()

--- a/quantum/plugins/algorithms/gradient_strategies/tests/CMakeLists.txt
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/CMakeLists.txt
@@ -15,7 +15,6 @@ add_xacc_test(GradientStrategies)
 target_link_libraries(GradientStrategiesTester xacc xacc-quantum-gate xacc-pauli) 
 
 # Only test QNG module if LAPACK was installed.
-find_package(LAPACK)
 if(LAPACK_FOUND)
     add_xacc_test(QuantumNatualGradient)
     target_link_libraries(QuantumNatualGradientTester xacc xacc-pauli xacc-gradient-strategies) 

--- a/quantum/plugins/algorithms/qite/CMakeLists.txt
+++ b/quantum/plugins/algorithms/qite/CMakeLists.txt
@@ -50,7 +50,6 @@ else()
                         PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
   set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")
   # Armadillo solver needs LAPACK
-  find_package(LAPACK)
   if(LAPACK_FOUND)
    target_link_libraries(${LIBRARY_NAME} PRIVATE ${LAPACK_LIBRARIES})
   else()

--- a/quantum/plugins/circuits/py-qsearch/py_qsearch.hpp
+++ b/quantum/plugins/circuits/py-qsearch/py_qsearch.hpp
@@ -26,7 +26,7 @@ class PyQsearch : public xacc::quantum::Circuit {
 protected:
   bool initialized = false;
   std::shared_ptr<py::scoped_interpreter> guard;
-  void *libpython_handle;
+  void *libpython_handle = nullptr;
 public:
   PyQsearch() : Circuit("qsearch") {}
   void initialize();

--- a/quantum/plugins/ibm/aer/CMakeLists.txt
+++ b/quantum/plugins/ibm/aer/CMakeLists.txt
@@ -41,7 +41,6 @@ if(APPLE)
   set_target_properties(${LIBRARY_NAME}
                         PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 else()
-  find_package(LAPACK)
   if(LAPACK_FOUND)
    target_link_libraries(${LIBRARY_NAME} PRIVATE ${LAPACK_LIBRARIES})
   else()

--- a/quantum/plugins/observable_transforms/qubit-tapering/CMakeLists.txt
+++ b/quantum/plugins/observable_transforms/qubit-tapering/CMakeLists.txt
@@ -19,7 +19,11 @@ usfunctionembedresources(TARGET ${LIBRARY_NAME}
                          FILES manifest.json)
 
 # Link library with XACC
-target_link_libraries(${LIBRARY_NAME} PUBLIC xacc xacc-quantum-gate lapack)
+target_link_libraries(${LIBRARY_NAME} PUBLIC xacc xacc-quantum-gate)
+# and with LAPACK
+if(LAPACK_FOUND)
+  target_link_libraries(${LIBRARY_NAME} PRIVATE ${LAPACK_LIBRARIES})
+endif()
 
 # Configure RPATH
 if(APPLE)

--- a/xacc/optimizer/mlpack/CMakeLists.txt
+++ b/xacc/optimizer/mlpack/CMakeLists.txt
@@ -20,7 +20,6 @@ target_include_directories(${LIBRARY_NAME}
                            PUBLIC . ${CMAKE_SOURCE_DIR}/tpls/ensmallen
                                   ${CMAKE_SOURCE_DIR}/tpls/armadillo)
 
-find_package(LAPACK)
 if(LAPACK_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAS_LAPACK")
   target_link_libraries(${LIBRARY_NAME} PUBLIC xacc ${LAPACK_LIBRARIES})


### PR DESCRIPTION
- qubit-tapering to use CMAKE LAPACK lib rather than hardcoded.

- init some pointers to nullptr. For some reason, it may contain garbages when compiling on Summit, causing shutdown issues.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>