### PR TITLE
Added ability to merge another HetMap into the another HetMap

### DIFF
--- a/xacc/tests/HeterogeneousTester.cpp
+++ b/xacc/tests/HeterogeneousTester.cpp
@@ -145,6 +145,34 @@ TEST(HeterogeneousMapTester, checkVQE) {
 
   vqe->initialize(options);
 }
+
+TEST(HeterogeneousMapTester, checkMerge) {
+  xacc::HeterogeneousMap c;
+  c.insert("intkey", 1);
+  c.insert("intkey2", 2);
+  c.insert("doublekey", 2.2);
+  c.insert("variable", std::string("t0"));
+  const auto cSizeBefore = c.size();
+  xacc::HeterogeneousMap otherMap;
+  // Update a key
+  otherMap.insert("intkey", 3);
+  // Add some other keys
+  otherMap.insert("variable1", std::string("t1"));
+  const auto otherSize = otherMap.size();
+  // Merge:
+  c.merge(otherMap);
+  // There is one key updated:
+  EXPECT_EQ(c.size(), cSizeBefore + otherSize - 1);
+  // Check map content:
+  EXPECT_EQ(c.get<int>("intkey"), 3);
+  EXPECT_EQ(c.get<int>("intkey2"), 2);
+  EXPECT_EQ(c.get<double>("doublekey"), 2.2);
+  EXPECT_EQ(c.getString("variable"), "t0");
+  EXPECT_EQ(c.getString("variable1"), "t1");
+  print_visitor v;
+  c.visit(v);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize();
   ::testing::InitGoogleTest(&argc, argv);

--- a/xacc/utils/heterogeneous.hpp
+++ b/xacc/utils/heterogeneous.hpp
@@ -184,6 +184,13 @@ public:
     visit_impl(visitor, typename std::decay_t<T>::types{});
   }
 
+  // Merge another map to this.
+  void merge(const HeterogeneousMap &_other) {
+    for (const auto &[key, item] : _other.items) {
+      items[key] = item;
+    }
+  }
+
 private:
   std::map<std::string, std::any> items;
 


### PR DESCRIPTION
Use case: sometimes we need to cache the initialize configs but also support update configs.


Note: this is unrelated to the RTTI issue, I just found out that TNQVM needs this functionality to support HPC-Virt.
i.e. the updated configs set by the decorator need to be combined with any other configs that were given to the decorated accelerator.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>