### PR TITLE
Ability to use all QLM simulators

### DIFF
--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.in.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.in.cpp
@@ -396,11 +396,60 @@ void QlmAccelerator::initialize(const HeterogeneousMap &params) {
     // (4) BDD (Quantum Multi-valued Decision Diagrams)
     // Default is LinAlg, which is the most versatile (consistent perf. in most cases)
     // User can switch between them using the "sim-type" option:
-    static const std::unordered_map<std::string, pybind11::object> SIM_REGISTRY{
-        {"LinAlg", pybind11::module::import("qat.qpus").attr("LinAlg")},
-        {"MPS", pybind11::module::import("qat.qpus").attr("MPS")},
-        {"Feynman", pybind11::module::import("qat.qpus").attr("Feynman")},
-        {"Bdd", pybind11::module::import("qat.qpus").attr("Bdd")},
+    using SimFactory =
+        std::function<pybind11::object(const HeterogeneousMap &)>;
+    const SimFactory createMpsSim = [](const HeterogeneousMap &configs) {
+      auto simClass = pybind11::module::import("qat.qpus").attr("MPS");
+      // Default MPS settings:
+      // lnnize=True, no_merge=False, threshold=None, n_trunc=None
+      // Supported users-options (that we exposed to XACC):
+      // mps-threshold: specify threshold below which Schmidt coefficients are
+      // truncated. 
+      // max-bond: specify maximum number of non-zero Schmidt
+      // coefficients.
+      std::optional<double> threshold;
+      if (configs.keyExists<double>("mps-threshold")) {
+        threshold = configs.get<double>("mps-threshold");
+      }
+
+      std::optional<double> n_trunc;
+      if (configs.keyExists<int>("max-bond")) {
+        n_trunc = configs.get<int>("max-bond");
+      }
+
+      auto kwargs = pybind11::dict("lnnize"_a=true, "no_merge"_a=false, "threshold"_a=threshold, "n_trunc"_a=n_trunc);
+      return simClass(kwargs);
+    };
+
+    const SimFactory createFeynmanSim = [](const HeterogeneousMap &configs) {
+      // Support changing number of threads:
+      int nbThreads = 1;
+      if (configs.keyExists<int>("threads")) {
+        nbThreads = configs.get<int>("threads");
+      }
+      auto simClass = pybind11::module::import("qat.qpus").attr("Feynman");
+      return simClass(nbThreads);
+    };
+
+    const SimFactory createBddSim = [](const HeterogeneousMap &configs) {
+      // Support changing number of threads:
+      int nbThreads = 1;
+      if (configs.keyExists<int>("threads")) {
+        nbThreads = configs.get<int>("threads");
+      }
+      auto simClass = pybind11::module::import("qat.qpus").attr("Bdd");
+      return simClass(nbThreads);
+    };
+
+    static const std::unordered_map<std::string, SimFactory> SIM_REGISTRY{
+        // LinAlg doesn't have any extra runtime params
+        {"LinAlg",
+         [](const HeterogeneousMap &configs) {
+           return pybind11::module::import("qat.qpus").attr("LinAlg")();
+         }},
+        {"MPS", createMpsSim},
+        {"Feynman", createFeynmanSim},
+        {"Bdd", createBddSim},
     };
 
     // Default:
@@ -414,7 +463,7 @@ void QlmAccelerator::initialize(const HeterogeneousMap &params) {
       xacc::error("The requested sim-type of '" + simType + "' is invalid.");
     }
 
-    m_qlmQpuServer = (iter->second)();
+    m_qlmQpuServer = (iter->second)(params);
 
     // Important notes: Feynman and BDD don't support Observable mode,
     // hence, must use shots.

--- a/quantum/plugins/atos_qlm/accelerator/tests/QlmAcceleratorTester.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/tests/QlmAcceleratorTester.cpp
@@ -281,6 +281,93 @@ TEST(QlmAcceleratorTester, testOtherSimExpVal) {
   }
 }
 
+TEST(QlmAcceleratorTester, testMpsNonLocal) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto program = xasmCompiler
+                     ->compile(R"(__qpu__ void bellTestNonLocal(qbit q) {
+      H(q[0]);
+      CX(q[0], q[1]);
+      CX(q[0], q[2]);
+      Measure(q[0]);
+      Measure(q[1]);
+      Measure(q[2]);
+    })",
+                               nullptr)
+                     ->getComposites()[0];
+
+  auto accelerator =
+      xacc::getAccelerator("atos-qlm", {{"sim-type", "MPS"}, {"shots", 1024}});
+  auto buffer = xacc::qalloc(3);
+  accelerator->execute(buffer, program);
+  EXPECT_EQ(buffer->getMeasurementCounts().size(), 2);
+  buffer->print();
+  EXPECT_NEAR(buffer->computeMeasurementProbability("000"), 0.5, 0.1);
+  EXPECT_NEAR(buffer->computeMeasurementProbability("111"), 0.5, 0.1);
+}
+
+TEST(QlmAcceleratorTester, testMpsOptions) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto program = xasmCompiler
+                     ->compile(R"(__qpu__ void bellTestBig(qbit q) {
+       H(q[0]);
+        CX(q[0], q[1]);
+        CX(q[1], q[2]);
+        CX(q[2], q[3]);
+        CX(q[3], q[4]);
+        CX(q[4], q[5]);
+        CX(q[5], q[6]);
+        CX(q[6], q[7]);
+        CX(q[7], q[8]);
+        CX(q[8], q[9]);
+        CX(q[9], q[10]);
+        CX(q[10], q[11]);
+        CX(q[11], q[12]);
+        CX(q[12], q[13]);
+        CX(q[13], q[14]);
+        CX(q[14], q[15]);
+        CX(q[15], q[16]);
+        CX(q[16], q[17]);
+        CX(q[17], q[18]);
+        CX(q[18], q[19]);
+        CX(q[19], q[20]);
+        CX(q[20], q[21]);
+        CX(q[21], q[22]);
+        CX(q[22], q[23]);
+        CX(q[23], q[24]);
+        CX(q[24], q[25]);
+        CX(q[25], q[26]);
+        CX(q[26], q[27]);
+        CX(q[27], q[28]);
+        CX(q[28], q[29]);
+        CX(q[29], q[30]);
+        CX(q[30], q[31]);
+        CX(q[31], q[32]);
+        CX(q[32], q[33]);
+        CX(q[33], q[34]);
+        CX(q[34], q[35]);
+        CX(q[35], q[36]);
+        CX(q[36], q[37]);
+        CX(q[37], q[38]);
+        CX(q[38], q[39]);
+        // Measure two random qubits
+        // should only get entangled bitstrings:
+        // i.e. 00 or 11
+        Measure(q[2]);
+        Measure(q[37]);
+    })",
+                               nullptr)
+                     ->getComposites()[0];
+
+  auto accelerator =
+      xacc::getAccelerator("atos-qlm", {{"sim-type", "MPS"}, {"max-bond", 512},  {"shots", 1024}});
+  auto buffer = xacc::qalloc(40);
+  accelerator->execute(buffer, program);
+  EXPECT_EQ(buffer->getMeasurementCounts().size(), 2);
+  buffer->print();
+  EXPECT_NEAR(buffer->computeMeasurementProbability("00"), 0.5, 0.1);
+  EXPECT_NEAR(buffer->computeMeasurementProbability("11"), 0.5, 0.1);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize();
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Resolved https://github.com/eclipse/xacc/issues/341

For perfect simulation, users can select:
- LinAlg (default)
- MPS
- Feynman
- BDD (based on Quantum Multi-valued Decision Diagrams)

The stabilizer simulator is not exposed since it cannot handle universal circuits.