### PR TITLE
Optimize backend job submission for QITE

### DIFF
--- a/quantum/plugins/algorithms/qite/qite.hpp
+++ b/quantum/plugins/algorithms/qite/qite.hpp
@@ -35,15 +35,18 @@ protected:
   std::shared_ptr<CompositeInstruction> constructPropagateCircuit() const;
   // Calculate the current energy, i.e.
   // the value of the observable at the current Trotter step.
-  double calcCurrentEnergy(int in_nbQubits) const;
+  double calcCurrentEnergy(int in_nbQubits, double in_identityCoeff,
+                           const std::vector<double> &in_coefficients,
+                           const std::vector<std::shared_ptr<AcceleratorBuffer>>
+                               &in_resultBuffers) const;
 
-  // Calculate approximate A operator observable at the current Trotter step.
+  // Calculate the current energy value and approximate A operator observable at the current Trotter step.
   // Params:
   // in_kernel: the kernel to evolve the system to this time step
   // in_hmTerm: the H term to be approximate by the A term 
   // i.e. emulate the imaginary time evolution of that H term.
-  // Returns the norm (as a double) and the A operator (Pauli observable)
-  std::pair<double, std::shared_ptr<Observable>> calcAOps(const std::shared_ptr<AcceleratorBuffer>& in_buffer, std::shared_ptr<CompositeInstruction> in_kernel, std::shared_ptr<Observable> in_hmTerm) const;
+  // Returns energy value (double), the norm (as a double) and the A operator (Pauli observable)
+  std::tuple<double, double, std::shared_ptr<Observable>> calcQiteEvolve(const std::shared_ptr<AcceleratorBuffer>& in_buffer, std::shared_ptr<CompositeInstruction> in_kernel, std::shared_ptr<Observable> in_hmTerm, bool energyOnly = false) const;
   // Internal helper function:
   std::pair<double, std::shared_ptr<Observable>>
   internalCalcAOps(const std::vector<std::string> &pauliOps, const std::vector<double> &sigmaExpectation, std::shared_ptr<Observable> in_hmTerm) const;


### PR DESCRIPTION
Combined all backend `execute` calls at each time step into one call, then segregate the result child buffers to compute the energy and tomography independently.
 
Related to https://github.com/eclipse/xacc/issues/349