### PR TITLE
Added ability to get density matrix in noisy sim and state vector of pulse sim

### DIFF
--- a/python/examples/aer_pulse_sim.py
+++ b/python/examples/aer_pulse_sim.py
@@ -3,6 +3,7 @@
 
 import xacc, sys, numpy as np
 
+# Helper to create a centered Gaussian pulse:
 def gaussianCalc(in_time, in_amp, in_center, in_sigma):
     return in_amp*np.exp(-(in_time - in_center)**2/ 2.0 / (in_sigma**2.0))
 
@@ -38,6 +39,12 @@ qpu = xacc.getAccelerator("aer:ibmq_bogota", {"sim-type": "pulse"})
 buffer = xacc.qalloc(5)
 qpu.execute(buffer, program)
 
-print(buffer)
+# print(buffer)
+
+# Aer simulator will also return the state vector:
+# Note: it looks like the state-vector is in the qutrit space...
+# and the leaked state |2> is measured as 0.
+state_vec = buffer.getInformation("state")
+print(len(state_vec))
 
 

--- a/python/examples/aer_pulse_sim.py
+++ b/python/examples/aer_pulse_sim.py
@@ -1,0 +1,43 @@
+# This example demonstrates XACC pulse utility: 
+# assembling pulse programs (schedules) and running simulation.
+
+import xacc, sys, numpy as np
+
+def gaussianCalc(in_time, in_amp, in_center, in_sigma):
+    return in_amp*np.exp(-(in_time - in_center)**2/ 2.0 / (in_sigma**2.0))
+
+# Construct a sample pulse
+nbSamples = 160
+my_pulse = np.zeros(nbSamples)
+amp = 0.1
+for i in range(nbSamples):
+    my_pulse[i] = gaussianCalc(i, amp, nbSamples/2, nbSamples/4)
+
+provider = xacc.getIRProvider("quantum")
+program = provider.createComposite("gaussian")
+# Create the pulse instructions
+gaussian = provider.createInstruction("gaussian", [0], [], { "channel" : "d0", "samples": my_pulse})
+program.addInstruction(gaussian)
+
+
+# Measure instructions (to be lowered to pulses)
+m0 = provider.createInstruction("Measure", [0])
+m1 = provider.createInstruction("Measure", [1])
+m2 = provider.createInstruction("Measure", [2])
+m3 = provider.createInstruction("Measure", [3])
+m4 = provider.createInstruction("Measure", [4])
+
+program.addInstruction(m0)
+program.addInstruction(m1)
+program.addInstruction(m2)
+program.addInstruction(m3)
+program.addInstruction(m4)
+
+# Execute on the Aer simulator (bogota 5-qubit device)
+qpu = xacc.getAccelerator("aer:ibmq_bogota", {"sim-type": "pulse"})
+buffer = xacc.qalloc(5)
+qpu.execute(buffer, program)
+
+print(buffer)
+
+

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -53,14 +53,32 @@ std::vector<xacc::ibm_pulse::Instruction> alignMeasurePulseInstructions(
   // Align stimulus measure pulses and combine acquire instructions.
   // IBM can only handle 1 acquire instruction at the momemt.
   std::optional<int> firstMeasureT0;
+  // A measurement pulse can contain multiple pulses!!!
+  std::string firstMeasChannel;
+  std::unordered_map<std::string, int> mChannelOffset;
   for (const auto &ibmInst : in_originalPulseSchedule) {
     if (ibmInst.get_name() != "acquire") {
       if (!ibmInst.get_ch().empty() && ibmInst.get_ch()[0] == 'm') {
         if (!firstMeasureT0.has_value()) {
           firstMeasureT0 = ibmInst.get_t0();
+          firstMeasChannel = ibmInst.get_ch();
+          // This is the first one, hence offset = 0
+          mChannelOffset.emplace(ibmInst.get_ch(), 0);
         }
+
+        auto offsetIter = mChannelOffset.find(ibmInst.get_ch());
+        if (offsetIter == mChannelOffset.end()) {
+          const auto offset = ibmInst.get_t0() - firstMeasureT0.value();
+          mChannelOffset.emplace(ibmInst.get_ch(), offset);
+        }
+        const auto t0_offset = mChannelOffset[ibmInst.get_ch()];
         auto alignedMeasPulse = ibmInst;
-        alignedMeasPulse.set_t0(firstMeasureT0.value());
+        // A measure composite is a set of pulses on the meas channel,
+        // we need to shift all of them according to the offset.
+        if (ibmInst.get_ch() != firstMeasChannel) {
+          const auto shiftT0 = ibmInst.get_t0() - t0_offset;
+          alignedMeasPulse.set_t0(shiftT0);
+        }
         result.emplace_back(alignedMeasPulse);
       } else {
         result.emplace_back(ibmInst);
@@ -882,6 +900,12 @@ void IBMAccelerator::contributeInstructions(
               pulseParams["duration"].get<int>();
           inst->setDuration(parametricPulseDuration);
         }
+        
+        // Delay pulse has a duration
+        if (inst_name == "delay") {
+          inst->setDuration((*seq_iter)["duration"].get<int>());
+        }
+
         if ((*seq_iter).find("phase") != (*seq_iter).end()) {
           // we have phase too
           auto p = (*seq_iter)["phase"];

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -806,6 +806,8 @@ void IBMAccelerator::contributeInstructions(
   xacc::contributeService("fc", fc);
   auto aq = std::make_shared<Pulse>("acquire");
   xacc::contributeService("acquire", aq);
+  auto dl = std::make_shared<Pulse>("delay");
+  xacc::contributeService("delay", dl);
 
   // Add "parametric_pulse"
   auto parametricPulse = std::make_shared<Pulse>("parametric_pulse");

--- a/quantum/plugins/ibm/accelerator/OpenPulseVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/OpenPulseVisitor.hpp
@@ -107,6 +107,10 @@ public:
             inst.set_duration(i.duration());
         }
 
+        if (i.name() == "delay") {
+            inst.set_duration(i.duration());
+        }
+
         if (i.channel()[0] == 'm') {
             // this is a measure channel
 

--- a/quantum/plugins/ibm/accelerator/OpenPulseVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/OpenPulseVisitor.hpp
@@ -90,7 +90,7 @@ public:
         inst.set_phase(i.getParameter(0).as<double>());
         inst.set_t0(i.start());
 
-        std::vector<std::string> builtIns {"fc", "acquire", "parametric_pulse"};
+        std::vector<std::string> builtIns {"fc", "acquire", "parametric_pulse", "delay" };
         if (std::find(builtIns.begin(), builtIns.end(), i.name()) == std::end(builtIns)) {
             // add to default libr
             xacc::ibm_pulse::PulseLibrary lib;

--- a/quantum/plugins/ibm/accelerator/json/PulseQObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/PulseQObject.hpp
@@ -473,6 +473,10 @@ inline void to_json(json &j, const xacc::ibm_pulse::Instruction &x) {
     j["pulse_shape"] = x.get_pulse_shape();
     j["parameters"] = x.get_pulse_params();
   }
+
+  if (x.get_name() == "delay") {
+    j["duration"] = x.get_duration();
+  }
 }
 
 inline void from_json(const json &j, xacc::ibm_pulse::Experiment &x) {

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -227,8 +227,8 @@ void AerAccelerator::execute(
     // Run the simulation via Python
     const std::string resultJson =
         xacc::aer::runPulseSim(hamiltonianJson.dump(), dt, qubitFreqEst, uLoRefs, qobjJsonStr);
-    auto count_json =
-        nlohmann::json::parse(resultJson).get<std::map<std::string, int>>();
+    auto result_json = nlohmann::json::parse(resultJson);
+    auto count_json = result_json["counts"].get<std::map<std::string, int>>();
     for (const auto &[hexStr, nOccurrences] : count_json) {
       auto bitStr = hex_string_to_binary_string(hexStr);
       // Process bitStr to be an n-Measure string in msb
@@ -244,6 +244,9 @@ void AerAccelerator::execute(
 
       buffer->appendMeasurement(actual, nOccurrences);
     }
+
+    auto state_vector = result_json["statevector"].get<std::vector<std::pair<double, double>>>();
+    buffer->addExtraInfo("state", state_vector);
   } else if (m_simtype == "density_matrix") {
     // remove all measures, don't need them
     auto tmp = xacc::ir::asComposite(program->clone());

--- a/quantum/plugins/ibm/aer/py-aer/aer_python_adapter.in.cpp
+++ b/quantum/plugins/ibm/aer/py-aer/aer_python_adapter.in.cpp
@@ -21,7 +21,14 @@ std::string runPulseSim(const std::string &hamJsonStr, double dt,
       auto libPythonPreload =
           dlopen("@PYTHON_LIB_NAME@", RTLD_LAZY | RTLD_GLOBAL);
     }
-    pybind11::initialize_interpreter();
+    try {
+      // This is implemented as a free-function,
+      // hence just try to start an interpreter,
+      // and ignore if the interpreter has been started.
+      pybind11::initialize_interpreter();
+    } catch (std::exception &e) {
+      // std::cout << e.what();
+    }
     PythonInit = true;
   }
   auto py_src = R"#(

--- a/quantum/plugins/ibm/aer/py-aer/aer_python_adapter.in.cpp
+++ b/quantum/plugins/ibm/aer/py-aer/aer_python_adapter.in.cpp
@@ -80,7 +80,9 @@ result = backend_sim.run(pulse_qobj, system_model=system_model).result().to_dict
 hex_to_count = result["results"][0]["data"]["counts"]
 for hex_val in hex_to_count:
     hex_to_count[hex_val] = int(hex_to_count[hex_val])
-count_json = json.dumps(hex_to_count)
+state_vec = result["results"][0]["data"]["statevector"]
+result_data = {"counts": hex_to_count, "statevector": state_vec }
+result_json = json.dumps(result_data)
 )#";
   // Check if Qiskit present.
   try {
@@ -105,7 +107,7 @@ count_json = json.dumps(hex_to_count)
   locals["qobj_json"] = qObjJson;
   // Run the simulator:
   pybind11::exec(py_src, pybind11::globals(), locals);
-  const auto result = locals["count_json"].cast<std::string>();
+  const auto result = locals["result_json"].cast<std::string>();
   return result;
 }
 } // namespace aer


### PR DESCRIPTION
- The mode "density_matrix" (gate-based simulation) will return the underlying density matrix.

- Retrieve the state vector in pulse simulation.

- Support the new "delay" pulse instruction. Some backends have already been using them; hence we need to handle it when assembling the pulse QObj.

- Add a python example for pulse simulation with Aer.