### PR TITLE
First pass of generic JSON-based noise model implementation 

### DIFF
--- a/quantum/plugins/CMakeLists.txt
+++ b/quantum/plugins/CMakeLists.txt
@@ -37,5 +37,6 @@ endif()
 add_subdirectory(optimal_control)
 add_subdirectory(qsim)
 add_subdirectory(atos_qlm)
+add_subdirectory(noise_model)
 
 install (FILES utils/OperatorPool.hpp DESTINATION include/quantum/gate)

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
@@ -90,6 +90,9 @@ private:
   pybind11::object constructQlmJob(
       std::shared_ptr<AcceleratorBuffer> buffer,
       std::shared_ptr<CompositeInstruction> compositeInstruction) const;
+  pybind11::object constructQlmCirc(
+      std::shared_ptr<AcceleratorBuffer> buffer,
+      std::shared_ptr<CompositeInstruction> compositeInstruction) const;
   void persistResultToBuffer(std::shared_ptr<AcceleratorBuffer> buffer,
                              pybind11::object &result,
                              pybind11::object &job) const;

--- a/quantum/plugins/atos_qlm/accelerator/tests/CMakeLists.txt
+++ b/quantum/plugins/atos_qlm/accelerator/tests/CMakeLists.txt
@@ -3,3 +3,6 @@ target_link_libraries(QlmAcceleratorTester xacc xacc-quantum-gate)
 
 add_xacc_test(QlmNoisyAccelerator)
 target_link_libraries(QlmNoisyAcceleratorTester xacc xacc-quantum-gate)
+
+add_xacc_test(QlmNoiseModel)
+target_link_libraries(QlmNoiseModelTester xacc xacc-quantum-gate)

--- a/quantum/plugins/atos_qlm/accelerator/tests/QlmNoiseModelTester.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/tests/QlmNoiseModelTester.cpp
@@ -29,7 +29,7 @@ TEST(QlmNoiseModelTester, checkSimple) {
     auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
     noiseModel->initialize({{"noise-model", depol_json}});
     auto accelerator = xacc::getAccelerator(
-        "atos-qlm", {{"noise-model", noiseModel}, {"sim-type", "density_matrix"}});
+        "atos-qlm", {{"noise-model", noiseModel}});
     auto xasmCompiler = xacc::getCompiler("xasm");
     auto program = xasmCompiler
                        ->compile(R"(__qpu__ void testX(qbit q) {
@@ -65,7 +65,7 @@ TEST(QlmNoiseModelTester, checkSimple) {
     auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
     noiseModel->initialize({{"noise-model", ad_json}});
     auto accelerator =
-        xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel}});
+        xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel}, {"shots", 1024}});
     auto xasmCompiler = xacc::getCompiler("xasm");
     auto program = xasmCompiler
                        ->compile(R"(__qpu__ void testX_ad(qbit q) {
@@ -100,7 +100,7 @@ TEST(QlmNoiseModelTester, checkBitOrdering) {
     auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
     noiseModel->initialize({{"noise-model", msb_noise_model}});
     auto accelerator = xacc::getAccelerator(
-        "atos-qlm", {{"noise-model", noiseModel}, {"sim-type", "density_matrix"}});
+        "atos-qlm", {{"noise-model", noiseModel}});
 
     auto buffer = xacc::qalloc(2);
     accelerator->execute(buffer, program);
@@ -113,8 +113,7 @@ TEST(QlmNoiseModelTester, checkBitOrdering) {
     auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
     noiseModel->initialize({{"noise-model", lsb_noise_model}});
     auto accelerator =
-        xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel},
-                                     {"sim-type", "density_matrix"}});
+        xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel}});
     auto buffer = xacc::qalloc(2);
     accelerator->execute(buffer, program);
     densityMatrix_lsb = (*buffer)["density_matrix"]

--- a/quantum/plugins/atos_qlm/accelerator/tests/QlmNoiseModelTester.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/tests/QlmNoiseModelTester.cpp
@@ -1,0 +1,229 @@
+#include <gtest/gtest.h>
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "NoiseModel.hpp"
+
+namespace {
+// A sample Json for testing
+// Single-qubit depolarizing:
+const std::string depol_json =
+    R"({"gate_noise": [{"gate_name": "X", "register_location": ["0"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
+// Single-qubit amplitude damping (25% rate):
+const std::string ad_json =
+    R"({"gate_noise": [{"gate_name": "X", "register_location": ["0"], "noise_channels": [{"matrix": [[[[1.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.8660254037844386, 0.0]]], [[[0.0, 0.0], [0.5, 0.0]], [[0.0, 0.0], [0.0, 0.0]]]]}]}], "bit_order": "MSB"})";
+// Two-qubit noise channel (on a CNOT gate) in MSB and LSB order convention
+// (matrix representation)
+const std::string msb_noise_model =
+    R"({"gate_noise": [{"gate_name": "CNOT", "register_location": ["0", "1"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0], [0.0, 0.0], [-0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.0, 0.0], [0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
+const std::string lsb_noise_model =
+    R"({"gate_noise": [{"gate_name": "CNOT", "register_location": ["0", "1"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [-0.05773502691896258, 0.0], [-0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [-0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "LSB"})";
+// Noise model that only has readout errors for validation:
+// P(1|0) = 0.1; P(0|1) = 0.2
+const std::string ro_error_noise_model =
+    R"({"gate_noise": [], "bit_order": "MSB", "readout_errors": [{"register_location": "0", "prob_meas0_prep1": 0.2, "prob_meas1_prep0": 0.1}]})";
+} // namespace
+
+TEST(QlmNoiseModelTester, checkSimple) {
+  // Check depolarizing channels
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", depol_json}});
+    auto accelerator = xacc::getAccelerator(
+        "atos-qlm", {{"noise-model", noiseModel}, {"sim-type", "density_matrix"}});
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testX(qbit q) {
+        X(q[0]);
+        Measure(q[0]);
+      })",
+                                 accelerator)
+                       ->getComposite("testX");
+    auto buffer = xacc::qalloc(1);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    auto densityMatrix = (*buffer)["density_matrix"]
+                             .as<std::vector<std::pair<double, double>>>();
+    EXPECT_EQ(densityMatrix.size(), 4);
+    // Check trace
+    EXPECT_NEAR(densityMatrix[0].first + densityMatrix[3].first, 1.0, 1e-6);
+    // Expected result:
+    // 0.00666667+0.j 0.        +0.j
+    // 0.        +0.j 0.99333333+0.j
+    // Check real part
+    EXPECT_NEAR(densityMatrix[0].first, 0.00666667, 1e-6);
+    EXPECT_NEAR(densityMatrix[1].first, 0.0, 1e-6);
+    EXPECT_NEAR(densityMatrix[2].first, 0.0, 1e-6);
+    EXPECT_NEAR(densityMatrix[3].first, 0.99333333, 1e-6);
+    // Check imag part
+    for (const auto &[real, imag] : densityMatrix) {
+      EXPECT_NEAR(imag, 0.0, 1e-6);
+    }
+  }
+
+  // Check amplitude damping channels
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", ad_json}});
+    auto accelerator =
+        xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel}});
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testX_ad(qbit q) {
+        X(q[0]);
+        Measure(q[0]);
+      })",
+                                 accelerator)
+                       ->getComposites()[0];
+    auto buffer = xacc::qalloc(1);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // Verify the distribution (25% amplitude damping)
+    EXPECT_NEAR(buffer->computeMeasurementProbability("0"), 0.25, 0.1);
+    EXPECT_NEAR(buffer->computeMeasurementProbability("1"), 0.75, 0.1);
+  }
+}
+
+TEST(QlmNoiseModelTester, checkBitOrdering) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto program = xasmCompiler
+                     ->compile(R"(__qpu__ void testCX(qbit q) {
+        CX(q[0], q[1]);
+        Measure(q[0]);
+        Measure(q[1]);
+      })",
+                               nullptr)
+                     ->getComposites()[0];
+
+  std::vector<std::pair<double, double>> densityMatrix_msb, densityMatrix_lsb;
+  // Check MSB:
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", msb_noise_model}});
+    auto accelerator = xacc::getAccelerator(
+        "atos-qlm", {{"noise-model", noiseModel}, {"sim-type", "density_matrix"}});
+
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, program);
+    densityMatrix_msb = (*buffer)["density_matrix"]
+                            .as<std::vector<std::pair<double, double>>>();
+  }
+
+  // Check LSB:
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", lsb_noise_model}});
+    auto accelerator =
+        xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel},
+                                     {"sim-type", "density_matrix"}});
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, program);
+    densityMatrix_lsb = (*buffer)["density_matrix"]
+                            .as<std::vector<std::pair<double, double>>>();
+  }
+
+  // Check:
+  EXPECT_EQ(densityMatrix_lsb.size(), 16);
+  EXPECT_EQ(densityMatrix_msb.size(), 16);
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_NEAR(densityMatrix_lsb[i].first, densityMatrix_msb[i].first, 1e-6);
+    EXPECT_NEAR(densityMatrix_lsb[i].second, densityMatrix_msb[i].second, 1e-6);
+  }
+
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) {
+      const int idx = row * 4 + col;
+      std::cout << "(" << densityMatrix_msb[idx].first << ", "
+                << densityMatrix_msb[idx].second << ") ";
+    }
+    std::cout << "\n";
+  }
+}
+
+TEST(QlmNoiseModelTester, checkBitOrderingMeasure) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  {
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testCX_Q0(qbit q) {
+        CX(q[0], q[1]);
+        Measure(q[0]);
+      })",
+                                 nullptr)
+                       ->getComposites()[0];
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", msb_noise_model}});
+    auto accelerator = xacc::getAccelerator(
+        "atos-qlm", {{"noise-model", noiseModel}, {"shots", 8192}});
+
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // We have depolarization on Q0.
+    EXPECT_EQ(buffer->getMeasurements().size(), 2);
+    EXPECT_TRUE(buffer->getMeasurementCounts()["1"] > 0);
+  }
+  {
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testCX_Q1(qbit q) {
+        CX(q[0], q[1]);
+        Measure(q[1]);
+      })",
+                                 nullptr)
+                       ->getComposites()[0];
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", msb_noise_model}});
+    auto accelerator = xacc::getAccelerator(
+        "atos-qlm", {{"noise-model", noiseModel}, {"shots", 8192}});
+
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // No effect on Q1 (in this noise model)
+    EXPECT_EQ(buffer->getMeasurements().size(), 1);
+    EXPECT_EQ(buffer->getMeasurementCounts()["0"], 8192);
+  }
+}
+
+TEST(QlmNoiseModelTester, checkRoError) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+  noiseModel->initialize({{"noise-model", ro_error_noise_model}});
+  auto accelerator = xacc::getAccelerator(
+      "atos-qlm", {{"noise-model", noiseModel}, {"shots", 8192}});
+  {
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testId(qbit q) {
+        Measure(q[0]);
+      })",
+                                 nullptr)
+                       ->getComposites()[0];
+
+    auto buffer = xacc::qalloc(1);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // P(1|0) = 0.1
+    EXPECT_NEAR(buffer->computeMeasurementProbability("1"), 0.1, 0.05);
+  }
+  {
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testFlip(qbit q) {
+        X(q[0]);
+        Measure(q[0]);
+      })",
+                                 nullptr)
+                       ->getComposites()[0];
+
+    auto buffer = xacc::qalloc(1);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // P(0|1) = 0.2
+    EXPECT_NEAR(buffer->computeMeasurementProbability("0"), 0.2, 0.05);
+  }
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  auto ret = RUN_ALL_TESTS();
+  xacc::Finalize();
+  return ret;
+}

--- a/quantum/plugins/atos_qlm/accelerator/tests/QlmNoiseModelTester.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/tests/QlmNoiseModelTester.cpp
@@ -104,6 +104,7 @@ TEST(QlmNoiseModelTester, checkBitOrdering) {
 
     auto buffer = xacc::qalloc(2);
     accelerator->execute(buffer, program);
+    buffer->print();
     densityMatrix_msb = (*buffer)["density_matrix"]
                             .as<std::vector<std::pair<double, double>>>();
   }
@@ -115,6 +116,7 @@ TEST(QlmNoiseModelTester, checkBitOrdering) {
     auto accelerator =
         xacc::getAccelerator("atos-qlm", {{"noise-model", noiseModel}});
     auto buffer = xacc::qalloc(2);
+    buffer->print();
     accelerator->execute(buffer, program);
     densityMatrix_lsb = (*buffer)["density_matrix"]
                             .as<std::vector<std::pair<double, double>>>();
@@ -191,12 +193,13 @@ TEST(QlmNoiseModelTester, checkRoError) {
   {
     auto program = xasmCompiler
                        ->compile(R"(__qpu__ void testId(qbit q) {
+        CX(q[0], q[1]);
         Measure(q[0]);
       })",
                                  nullptr)
                        ->getComposites()[0];
 
-    auto buffer = xacc::qalloc(1);
+    auto buffer = xacc::qalloc(2);
     accelerator->execute(buffer, program);
     buffer->print();
     // P(1|0) = 0.1

--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -57,6 +57,7 @@ private:
   std::unordered_map<std::string, double> m_gateDurations;
   std::vector<std::pair<double, double>> m_roErrors;
   std::vector<std::pair<int, int>> m_connectivity;
+  std::string m_backendPropertiesJson;
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/ibm/aer/py-aer/aer_python_adapter.hpp
+++ b/quantum/plugins/ibm/aer/py-aer/aer_python_adapter.hpp
@@ -8,5 +8,7 @@ std::string runPulseSim(const std::string &hamJsonStr, double dt,
                         const std::vector<double> &freqEst,
                         const std::vector<int> &uChanLoRefs,
                         const std::string &qObjJson);
+std::string
+noiseModelFromBackendProperties(const std::string &backendPropertiesJson);
 } // namespace AER
 } // namespace xacc

--- a/quantum/plugins/noise_model/CMakeLists.txt
+++ b/quantum/plugins/noise_model/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(LIBRARY_NAME xacc-noise-model-json)
+file(GLOB SRC noise_model.cpp)
+usfunctiongetresourcesource(TARGET ${LIBRARY_NAME} OUT SRC)
+usfunctiongeneratebundleinit(TARGET ${LIBRARY_NAME} OUT SRC)
+add_library(${LIBRARY_NAME} SHARED ${SRC})
+
+target_include_directories(${LIBRARY_NAME} PUBLIC . ${CMAKE_SOURCE_DIR}/tpls/nlohmann ${CMAKE_SOURCE_DIR}/tpls/eigen)
+
+set(_bundle_name xacc_json_noise_model)
+set_target_properties(${LIBRARY_NAME}
+                      PROPERTIES COMPILE_DEFINITIONS
+                                 US_BUNDLE_NAME=${_bundle_name}
+                                 US_BUNDLE_NAME ${_bundle_name})
+usfunctionembedresources(TARGET ${LIBRARY_NAME} 
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                         FILES manifest.json)
+
+target_link_libraries(${LIBRARY_NAME} PUBLIC xacc xacc-quantum-gate)
+
+# Configure RPATH
+if(APPLE)
+  set_target_properties(${LIBRARY_NAME} PROPERTIES INSTALL_RPATH 
+                            "${XACC_ROOT}/lib")
+  set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS 
+                            "-undefined dynamic_lookup")
+else()
+  set_target_properties(${LIBRARY_NAME} PROPERTIES INSTALL_RPATH 
+                        "${XACC_ROOT}/lib")
+  set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-shared")
+endif()
+
+if(XACC_BUILD_TESTS)
+ add_subdirectory(tests)
+endif()
+
+# Install to Plugins directory
+install(TARGETS ${LIBRARY_NAME} DESTINATION plugins)

--- a/quantum/plugins/noise_model/manifest.json
+++ b/quantum/plugins/noise_model/manifest.json
@@ -1,0 +1,6 @@
+{
+    "bundle.symbolic_name" : "xacc_json_noise_model",
+    "bundle.activator" : true,
+    "bundle.name" : "Noise Model JSON Input",
+    "bundle.description" : "This plugin provides a way to load noise model as a JSON file."
+  }

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -1,0 +1,38 @@
+#include "NoiseModel.hpp"
+#include "xacc_plugin.hpp"
+#include "json.hpp"
+
+namespace xacc {
+class JsonNoiseModel : public NoiseModel {
+public:
+  // Identifiable interface impls
+  const std::string name() const override { return "json"; }
+  const std::string description() const override {
+    return "Noise model whose noise channel Kraus operators are provided in a "
+           "JSON input file.";
+  }
+
+  virtual void initialize(const HeterogeneousMap &params) override {}
+  virtual std::string toJson() const override { return ""; }
+  virtual RoErrors readoutError(size_t qubitIdx) const override { return {}; }
+  virtual std::vector<RoErrors> readoutErrors() const override { return {}; }
+  virtual std::vector<KrausOp>
+  gateError(xacc::quantum::Gate &gate) const override {
+    return {};
+  }
+  virtual double gateErrorProb(xacc::quantum::Gate &gate) const override {
+    return 0.0;
+  }
+  // Query Fidelity information:
+  virtual size_t nQubits() const override { return 0; }
+  virtual std::vector<double> averageSingleQubitGateFidelity() const override {
+    return {};
+  }
+  virtual std::vector<std::tuple<size_t, size_t, double>>
+  averageTwoQubitGateFidelity() const override {
+    return {};
+  }
+};
+} // namespace xacc
+
+REGISTER_PLUGIN(xacc::JsonNoiseModel, xacc::NoiseModel)

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -148,7 +148,7 @@ public:
           }
         }
 
-        std::cout << "Process: " << gateKey << "\n";
+        // std::cout << "Process: " << gateKey << "\n";
         auto noise_channels = noise_info["noise_channels"];
         std::vector<KrausChannel> noise_ops;
         for (auto channel_iter = noise_channels.begin();

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -2,10 +2,55 @@
 #include "xacc_plugin.hpp"
 #include "json.hpp"
 #include "xacc.hpp"
+#include <Eigen/Dense>
+
+namespace {
+constexpr double NUM_TOL = 1e-9;
+bool allClose(const Eigen::MatrixXcd &in_mat1, const Eigen::MatrixXcd &in_mat2,
+              double in_tol = NUM_TOL) {
+  if (in_mat1.rows() == in_mat2.rows() && in_mat1.cols() == in_mat2.cols()) {
+    for (int i = 0; i < in_mat1.rows(); ++i) {
+      for (int j = 0; j < in_mat1.cols(); ++j) {
+        if (std::abs(in_mat1(i, j) - in_mat2(i, j)) > in_tol) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+  return false;
+}
+
+bool isIdentity(const Eigen::MatrixXcd &mat, double threshold = NUM_TOL) {
+  Eigen::MatrixXcd idMat = Eigen::MatrixXcd::Identity(mat.rows(), mat.cols());
+  return allClose(mat, idMat, threshold);
+}
+
+bool validateKrausCPTP(const std::vector<Eigen::MatrixXcd> &mats,
+                       double threshold = NUM_TOL) {
+  if (mats.empty()) {
+    return true;
+  }
+  Eigen::MatrixXcd cptp =
+      Eigen::MatrixXcd::Zero(mats[0].rows(), mats[0].cols());
+  for (const auto &mat : mats) {
+    cptp = cptp + mat.adjoint() * mat;
+  }
+  return isIdentity(cptp, threshold);
+}
+} // namespace
 
 namespace xacc {
 class JsonNoiseModel : public NoiseModel {
 public:
+  enum class BitOrder { MSB, LSB };
+
+  struct NoiseKrausOp {
+    std::vector<std::string> bit_locs;
+    Eigen::MatrixXcd matrix;
+  };
+
   // Identifiable interface impls
   const std::string name() const override { return "json"; }
   const std::string description() const override {
@@ -29,7 +74,73 @@ public:
 
     // Debug:
     std::cout << "HOWDY: \n" << m_noiseModel.dump() << "\n";
+    const auto bit_order = m_noiseModel["bit_order"].get<std::string>();
+    if (bit_order == "MSB") {
+      m_bitOrder = BitOrder::MSB;
+    } else if (bit_order == "LSB") {
+      m_bitOrder = BitOrder::LSB;
+    } else {
+      xacc::error("Unknown value: " + bit_order);
+    }
+
+    auto gate_noise = m_noiseModel["gate_noise"];
+    for (auto iter = gate_noise.begin(); iter != gate_noise.end(); ++iter) {
+      auto noise_info = *iter;
+      const auto gate_name = noise_info["gate_name"].get<std::string>();
+      const auto register_location =
+          noise_info["register_location"].get<std::vector<std::string>>();
+      const auto gateKey = createGateLookupKey(gate_name, register_location);
+      std::cout << "Process: " << gateKey << "\n";
+      auto noise_kraus_ops = noise_info["noise_kraus_ops"];
+      std::vector<NoiseKrausOp> noise_ops;
+      std::vector<Eigen::MatrixXcd>  kraus_mats;
+      for (auto kraus_iter = noise_kraus_ops.begin();
+           kraus_iter != noise_kraus_ops.end(); ++kraus_iter) {
+        NoiseKrausOp newOp;
+        auto kraus_op = *kraus_iter;
+        if (kraus_op.find("total_count") != kraus_op.end()) {
+          newOp.bit_locs =
+              kraus_op["total_count"].get<std::vector<std::string>>();
+        } else {
+          newOp.bit_locs = register_location;
+        }
+
+        const auto op_mat =
+            kraus_op["matrix"]
+                .get<std::vector<std::vector<std::pair<double, double>>>>();
+        const auto nbRows = op_mat.size();
+        if (nbRows != (1ULL << newOp.bit_locs.size())) {
+          xacc::error("Kraus operator matrix dimension doesn't match the "
+                      "number of qubits.");
+        }
+
+        Eigen::MatrixXcd mat = Eigen::MatrixXcd::Zero(nbRows, nbRows);
+        for (int row = 0; row < nbRows; ++row) {
+          const auto &rowVec = op_mat[row];
+          if (rowVec.size() != nbRows) {
+            xacc::error("Kraus operator matrix must be square.");
+          }
+
+          for (int col = 0; col < rowVec.size(); ++col) {
+            auto elemPair = rowVec[col];
+            mat(row, col) =
+                std::complex<double>{elemPair.first, elemPair.second};
+          }
+        }
+        newOp.matrix = mat;
+        noise_ops.emplace_back(newOp);
+        kraus_mats.emplace_back(mat);
+        std::cout << "Parsed Kraus op:\n" << mat << "\n";
+      }
+
+      if (!validateKrausCPTP(kraus_mats)) {
+        xacc::error("The list of Kraus operators for gate " + gateKey +
+                    " don't satisfy the CPTP condition.");
+      }
+      m_gateNoise.emplace(gateKey, noise_ops);
+    }
   }
+
   virtual std::string toJson() const override { return ""; }
   virtual RoErrors readoutError(size_t qubitIdx) const override { return {}; }
   virtual std::vector<RoErrors> readoutErrors() const override { return {}; }
@@ -51,7 +162,20 @@ public:
   }
 
 private:
+  std::string
+  createGateLookupKey(const std::string &in_gateName,
+                      const std::vector<std::string> &in_qubitLocs) {
+    std::string result = in_gateName + "_" + in_qubitLocs[0];
+    for (int i = 1; i < in_qubitLocs.size(); ++i) {
+      result = result + "_" + in_qubitLocs[i];
+    }
+    return result;
+  }
+
+private:
   nlohmann::json m_noiseModel;
+  BitOrder m_bitOrder;
+  std::unordered_map<std::string, std::vector<NoiseKrausOp>> m_gateNoise;
 };
 } // namespace xacc
 

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -335,17 +335,24 @@ public:
     }
     return result;
   }
-
+  
+  // Query Fidelity information:
+  virtual size_t nQubits() const override { return m_qubitLabels.size(); }
+  
+  // These methods are used for TriQ placement.
+  // We don't support them in this noise model impl.
   virtual double gateErrorProb(xacc::quantum::Gate &gate) const override {
     return 0.0;
   }
-  // Query Fidelity information:
-  virtual size_t nQubits() const override { return 0; }
+
   virtual std::vector<double> averageSingleQubitGateFidelity() const override {
+    xacc::error("Unsupported");
     return {};
   }
+  
   virtual std::vector<std::tuple<size_t, size_t, double>>
   averageTwoQubitGateFidelity() const override {
+    xacc::error("Unsupported");
     return {};
   }
 

--- a/quantum/plugins/noise_model/tests/CMakeLists.txt
+++ b/quantum/plugins/noise_model/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_xacc_test(JsonNoiseModel)
+target_link_libraries(JsonNoiseModelTester xacc xacc-quantum-gate)

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -15,7 +15,7 @@ TEST(JsonNoiseModelTester, checkSimple) {
   const std::string ibmNoiseJson = noiseModel->toJson();
   std::cout << "IBM Equiv: \n" << ibmNoiseJson << "\n";
   auto accelerator = xacc::getAccelerator(
-      "aer", {{"noise-model", ibmNoiseJson}, {"shots", 8192}});
+      "aer", {{"noise-model", ibmNoiseJson}, {"sim-type", "density_matrix"}});
   // auto accelerator = xacc::getAccelerator("aer", {{"shots", 8192}});
   auto xasmCompiler = xacc::getCompiler("xasm");
   auto program = xasmCompiler
@@ -28,6 +28,10 @@ TEST(JsonNoiseModelTester, checkSimple) {
   auto buffer = xacc::qalloc(1);
   accelerator->execute(buffer, program);
   buffer->print();
+  auto densityMatrix = (*buffer)["density_matrix"].as<std::vector<std::pair<double, double>>>();
+  EXPECT_EQ(densityMatrix.size(), 4);
+  // Check trace
+  EXPECT_NEAR(densityMatrix[0].first + densityMatrix[3].first, 1.0, 1e-6);
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -5,46 +5,81 @@
 
 namespace {
 // A sample Json for testing
-const std::string test_json =
+// Single-qubit depolarizing:
+const std::string depol_json =
     R"({"gate_noise": [{"gate_name": "X", "register_location": ["0"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
-// Two-qubit noise channel (on a CNOT gate) in MSB and LSB order convention (matrix representation)
-const std::string msb_noise_model = R"({"gate_noise": [{"gate_name": "CNOT", "register_location": ["0", "1"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0], [0.0, 0.0], [-0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.0, 0.0], [0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
-const std::string lsb_noise_model = R"({"gate_noise": [{"gate_name": "CNOT", "register_location": ["0", "1"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [-0.05773502691896258, 0.0], [-0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [-0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "LSB"})";
+// Single-qubit amplitude damping (25% rate):
+const std::string ad_json =
+    R"({"gate_noise": [{"gate_name": "X", "register_location": ["0"], "noise_channels": [{"matrix": [[[[1.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.8660254037844386, 0.0]]], [[[0.0, 0.0], [0.5, 0.0]], [[0.0, 0.0], [0.0, 0.0]]]]}]}], "bit_order": "MSB"})";
+// Two-qubit noise channel (on a CNOT gate) in MSB and LSB order convention
+// (matrix representation)
+const std::string msb_noise_model =
+    R"({"gate_noise": [{"gate_name": "CNOT", "register_location": ["0", "1"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0], [0.0, 0.0], [-0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.0, 0.0], [0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
+const std::string lsb_noise_model =
+    R"({"gate_noise": [{"gate_name": "CNOT", "register_location": ["0", "1"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.05773502691896258], [0.0, 0.0], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.05773502691896258, 0.0], [0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [-0.05773502691896258, 0.0], [-0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0], [-0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "LSB"})";
 } // namespace
 
 TEST(JsonNoiseModelTester, checkSimple) {
-  auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
-  noiseModel->initialize({{"noise-model", test_json}});
-  const std::string ibmNoiseJson = noiseModel->toJson();
-  std::cout << "IBM Equiv: \n" << ibmNoiseJson << "\n";
-  auto accelerator = xacc::getAccelerator(
-      "aer", {{"noise-model", ibmNoiseJson}, {"sim-type", "density_matrix"}});
-  auto xasmCompiler = xacc::getCompiler("xasm");
-  auto program = xasmCompiler
-                     ->compile(R"(__qpu__ void testX(qbit q) {
+  // Check depolarizing channels
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", depol_json}});
+    const std::string ibmNoiseJson = noiseModel->toJson();
+    std::cout << "IBM Equiv: \n" << ibmNoiseJson << "\n";
+    auto accelerator = xacc::getAccelerator(
+        "aer", {{"noise-model", ibmNoiseJson}, {"sim-type", "density_matrix"}});
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testX(qbit q) {
         X(q[0]);
         Measure(q[0]);
       })",
-                               accelerator)
-                     ->getComposite("testX");
-  auto buffer = xacc::qalloc(1);
-  accelerator->execute(buffer, program);
-  buffer->print();
-  auto densityMatrix = (*buffer)["density_matrix"].as<std::vector<std::pair<double, double>>>();
-  EXPECT_EQ(densityMatrix.size(), 4);
-  // Check trace
-  EXPECT_NEAR(densityMatrix[0].first + densityMatrix[3].first, 1.0, 1e-6);
-  // Expected result:
-  // 0.00666667+0.j 0.        +0.j
-  // 0.        +0.j 0.99333333+0.j
-  // Check real part
-  EXPECT_NEAR(densityMatrix[0].first, 0.00666667, 1e-6);
-  EXPECT_NEAR(densityMatrix[1].first, 0.0, 1e-6);
-  EXPECT_NEAR(densityMatrix[2].first, 0.0, 1e-6);
-  EXPECT_NEAR(densityMatrix[3].first, 0.99333333, 1e-6);
-  // Check imag part
-  for (const auto &[real, imag] : densityMatrix) {
-    EXPECT_NEAR(imag, 0.0, 1e-6);
+                                 accelerator)
+                       ->getComposite("testX");
+    auto buffer = xacc::qalloc(1);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    auto densityMatrix = (*buffer)["density_matrix"]
+                             .as<std::vector<std::pair<double, double>>>();
+    EXPECT_EQ(densityMatrix.size(), 4);
+    // Check trace
+    EXPECT_NEAR(densityMatrix[0].first + densityMatrix[3].first, 1.0, 1e-6);
+    // Expected result:
+    // 0.00666667+0.j 0.        +0.j
+    // 0.        +0.j 0.99333333+0.j
+    // Check real part
+    EXPECT_NEAR(densityMatrix[0].first, 0.00666667, 1e-6);
+    EXPECT_NEAR(densityMatrix[1].first, 0.0, 1e-6);
+    EXPECT_NEAR(densityMatrix[2].first, 0.0, 1e-6);
+    EXPECT_NEAR(densityMatrix[3].first, 0.99333333, 1e-6);
+    // Check imag part
+    for (const auto &[real, imag] : densityMatrix) {
+      EXPECT_NEAR(imag, 0.0, 1e-6);
+    }
+  }
+
+  // Check amplitude damping channels
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", ad_json}});
+    const std::string ibmNoiseJson = noiseModel->toJson();
+    std::cout << "IBM Equiv: \n" << ibmNoiseJson << "\n";
+    auto accelerator =
+        xacc::getAccelerator("aer", {{"noise-model", ibmNoiseJson}});
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    auto program = xasmCompiler
+                       ->compile(R"(__qpu__ void testX_ad(qbit q) {
+        X(q[0]);
+        Measure(q[0]);
+      })",
+                                 accelerator)
+                       ->getComposites()[0];
+    auto buffer = xacc::qalloc(1);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    // Verify the distribution (25% amplitude damping)
+    EXPECT_NEAR(buffer->computeMeasurementProbability("0"), 0.25, 0.1);
+    EXPECT_NEAR(buffer->computeMeasurementProbability("1"), 0.75, 0.1);
   }
 }
 
@@ -85,9 +120,8 @@ TEST(JsonNoiseModelTester, checkBitOrdering) {
     auto buffer = xacc::qalloc(2);
     accelerator->execute(buffer, program);
     densityMatrix_lsb = (*buffer)["density_matrix"]
-                             .as<std::vector<std::pair<double, double>>>();
+                            .as<std::vector<std::pair<double, double>>>();
   }
-
 
   // Check:
   EXPECT_EQ(densityMatrix_lsb.size(), 16);

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "NoiseModel.hpp"
+
+TEST(JsonNoiseModelTester, checkSimple) {
+  auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  auto ret = RUN_ALL_TESTS();
+  xacc::Finalize();
+  return ret;
+}

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -6,7 +6,7 @@
 namespace {
 // A sample Json for testing
 const std::string test_json =
-    R"({"gate_noise": [{"gate_name": "H", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}, {"gate_name": "X", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}], "bit_order": "MSB"})";
+    R"({"gate_noise": [{"gate_name": "X", "register_location": ["0"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
 } // namespace
 
 TEST(JsonNoiseModelTester, checkSimple) {
@@ -32,6 +32,18 @@ TEST(JsonNoiseModelTester, checkSimple) {
   EXPECT_EQ(densityMatrix.size(), 4);
   // Check trace
   EXPECT_NEAR(densityMatrix[0].first + densityMatrix[3].first, 1.0, 1e-6);
+  // Expected result:
+  // 0.00666667+0.j 0.        +0.j
+  // 0.        +0.j 0.99333333+0.j
+  // Check real part
+  EXPECT_NEAR(densityMatrix[0].first, 0.00666667, 1e-6);
+  EXPECT_NEAR(densityMatrix[1].first, 0.0, 1e-6);
+  EXPECT_NEAR(densityMatrix[2].first, 0.0, 1e-6);
+  EXPECT_NEAR(densityMatrix[3].first, 0.99333333, 1e-6);
+  // Check imag part
+  for (const auto &[real, imag] : densityMatrix) {
+    EXPECT_NEAR(imag, 0.0, 1e-6);
+  }
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -3,8 +3,14 @@
 #include "xacc_service.hpp"
 #include "NoiseModel.hpp"
 
+namespace {
+    // A sample Json for testing
+    const std::string test_json = R"({"gate_noise": [{"gate_name": "H", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}, {"gate_name": "X", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}], "bit_order": "MSB"})";
+}
+
 TEST(JsonNoiseModelTester, checkSimple) {
   auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+  noiseModel->initialize({{"noise-model", test_json}});
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -4,13 +4,30 @@
 #include "NoiseModel.hpp"
 
 namespace {
-    // A sample Json for testing
-    const std::string test_json = R"({"gate_noise": [{"gate_name": "H", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}, {"gate_name": "X", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}], "bit_order": "MSB"})";
-}
+// A sample Json for testing
+const std::string test_json =
+    R"({"gate_noise": [{"gate_name": "H", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}, {"gate_name": "X", "register_location": ["0"], "noise_kraus_ops": [{"matrix": [[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], "noise_qubits": ["0"]}, {"matrix": [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]], "noise_qubits": ["0"]}]}], "bit_order": "MSB"})";
+} // namespace
 
 TEST(JsonNoiseModelTester, checkSimple) {
   auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
   noiseModel->initialize({{"noise-model", test_json}});
+  const std::string ibmNoiseJson = noiseModel->toJson();
+  std::cout << "IBM Equiv: \n" << ibmNoiseJson << "\n";
+  auto accelerator = xacc::getAccelerator(
+      "aer", {{"noise-model", ibmNoiseJson}, {"shots", 8192}});
+  // auto accelerator = xacc::getAccelerator("aer", {{"shots", 8192}});
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto program = xasmCompiler
+                     ->compile(R"(__qpu__ void testX(qbit q) {
+        X(q[0]);
+        Measure(q[0]);
+      })",
+                               accelerator)
+                     ->getComposite("testX");
+  auto buffer = xacc::qalloc(1);
+  accelerator->execute(buffer, program);
+  buffer->print();
 }
 
 int main(int argc, char **argv) {

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -13,6 +13,7 @@
 #pragma once
 #include "Identifiable.hpp"
 #include "heterogeneous.hpp"
+#include <cassert>
 
 namespace xacc {
 namespace quantum {
@@ -23,10 +24,40 @@ class Gate;
 // Readout error: pair of meas0Prep1, meas1Prep0
 using RoErrors = std::pair<double, double>;
 
+// The LSB, MSB bit-order that Kraus matrices are defined in.
+enum class KrausMatBitOrder { LSB, MSB };
+
+// !!!Deprecated!!!
+// To be removed: this was developed to target TNQVM's noisy simulator,
+// hence was limited to single-qubit channels...
+// We'll eventually remove this.
 struct KrausOp {
   size_t qubit;
   // Choi matrix
   std::vector<std::vector<std::complex<double>>> mats;
+};
+
+
+// Represent a generic noise channel in terms of
+// Kraus operator matrices to be applied *post-operation*.
+// The list of matrices always satisfies CPTP condition.
+struct NoiseChannelKraus {
+  using KrausMatType = std::vector<std::vector<std::complex<double>>>;
+  std::vector<size_t> noise_qubits;
+  std::vector<KrausMatType> mats;
+  KrausMatBitOrder bit_order;
+  NoiseChannelKraus(const std::vector<size_t> &in_qubits,
+                    const std::vector<KrausMatType> &in_mats,
+                    KrausMatBitOrder in_bitOrder)
+      : noise_qubits(in_qubits), mats(in_mats), bit_order(in_bitOrder) {
+    const auto expectedDim = 1ULL << in_qubits.size();
+    for (const auto &mat : mats) {
+      assert(mat.size() == expectedDim);
+      for (const auto &row : mat) {
+        assert(row.size() == expectedDim);
+      }
+    }
+  }
 };
 
 class NoiseModel : public Identifiable {
@@ -37,17 +68,30 @@ public:
   // Readout errors:
   virtual RoErrors readoutError(size_t qubitIdx) const = 0;
   virtual std::vector<RoErrors> readoutErrors() const = 0;
+  
+  // !!! DEPRECATED !!!!
+  // --- This API to be removed----
+  // Need to update TNQVM to *not* use this anymore.
   // Gate errors:
   // Returns a list of Kraus operators represent quantum noise processes
   // associated with a quantum gate.
   // Note: we use Kraus operators to capture generic noise processes.
   // Any probabilistic gate-based noise representations must be converted to
   // the equivalent Kraus operators.
-  virtual std::vector<KrausOp>
-  gateError(xacc::quantum::Gate &gate) const = 0;
+  virtual std::vector<KrausOp> gateError(xacc::quantum::Gate &gate) const {
+    return {};
+  }
+  // !!! END - DEPRECATED !!!!
+
+  // Returns a list of noise channels (in terms of Kraus matrices)
+  // for an XACC gate.
+  virtual std::vector<NoiseChannelKraus>
+  getNoiseChannels(xacc::quantum::Gate &gate) const {
+    return {};
+  }
+
   // Get gate error probability:
-  virtual double
-  gateErrorProb(xacc::quantum::Gate &gate) const = 0;
+  virtual double gateErrorProb(xacc::quantum::Gate &gate) const = 0;
   // Query Fidelity information:
   virtual size_t nQubits() const = 0;
   virtual std::vector<double> averageSingleQubitGateFidelity() const = 0;


### PR DESCRIPTION
- Passing gate noise (Kraus op matrices) and readout error information.

- This generic noise model can generate an IBM-compatible noise model JSON, hence we can use Aer to validate the noise model (density matrix, readout distribution).

- Add test cases for single-qubit depolarizing and amplitude damping channels, multi-qubit channels, and readout errors. Use Aer to validate that the results matched the theory.

- Enhance the existing IBM noise model to look for Qiskit first when doing `toJson()` before trying to derive the noise model by itself.

Next step: making sure QLM and TNQVM can also use this noise model input, i.e. adding the same set of unit tests but using QLM and TNQVM.