### PR TITLE
Adapt to return the final circuit so that we can see how much it grew

### DIFF
--- a/python/py_heterogeneous_map.cpp
+++ b/python/py_heterogeneous_map.cpp
@@ -78,6 +78,9 @@ void bind_heterogeneous_map(py::module &m) {
               return m.get<std::vector<std::string>>(key);
             } else if (m.keyExists<Eigen::MatrixXcd>(key)) {
               return m.get<Eigen::MatrixXcd>(key);
+            } else if (m.pointerLikeExists<CompositeInstruction>(key)) {
+              return xacc::as_shared_ptr(
+                  m.getPointerLike<CompositeInstruction>(key));
             } else {
               xacc::error("Invalid key for heterogeneous map");
               return 0;
@@ -95,7 +98,8 @@ void bind_heterogeneous_map(py::module &m) {
                    m.keyExists<std::vector<std::string>>(key) ||
                    m.keyExists<std::shared_ptr<Observable>>(key) ||
                    m.keyExists<std::shared_ptr<Optimizer>>(key) ||
-                   m.keyExists<std::shared_ptr<Eigen::MatrixXcd>>(key);
+                   m.keyExists<std::shared_ptr<Eigen::MatrixXcd>>(key) ||
+                   m.pointerLikeExists<CompositeInstruction>(key);
           },
           "");
 

--- a/quantum/plugins/algorithms/adapt/adapt.cpp
+++ b/quantum/plugins/algorithms/adapt/adapt.cpp
@@ -317,6 +317,9 @@ void ADAPT::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       xacc::info("Final ADAPT-" + subAlgo + " circuit\n" +
                  ansatzInstructions->toString());
 
+      // Add the ansatz to the compilation database for later retrieval
+      xacc::appendCompiled(ansatzInstructions, true);
+      buffer->addExtraInfo("final-ansatz", ExtraInfo(ansatzInstructions->name()));
       return;
 
     } else if (iter < _maxIter) { // Add operator and reoptimize


### PR DESCRIPTION
The final Composite is registered to the compilation database and its name string is added to the AcceleratorBuffer. 

Also, support retrieving CompositeInstruction from PyHetMap so that we can retrieve a CompositeInstruction from C++ HetMap.
