### PR TITLE
Support IBM new gateset

### DIFF
--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -267,13 +267,19 @@ std::string QasmQObjGenerator::getQObjJsonStr(
   qobj.set_type("QASM");
   qobj.set_header(QObjectHeader());
 
+  const auto basis_gates =
+      backend["basis_gates"].get<std::vector<std::string>>();
+  // If the gate set has "u3" -> old gateset.
+  const auto gateSet = (xacc::container::contains(basis_gates, "u3"))
+                           ? QObjectExperimentVisitor::GateSet::U_CX
+                           : QObjectExperimentVisitor::GateSet::RZ_SX_CX;
   // Create the Experiments
   std::vector<xacc::ibm::Experiment> experiments;
   int maxMemSlots = 0;
   for (auto &kernel : circuits) {
 
     auto visitor = std::make_shared<QObjectExperimentVisitor>(
-        kernel->name(), backend["n_qubits"].get<int>());
+        kernel->name(), backend["n_qubits"].get<int>(), gateSet);
 
     InstructionIterator it(kernel);
     int memSlots = 0;

--- a/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
@@ -43,8 +43,12 @@ public:
     return "Map XACC IR to QObject.";
   }
 
-  QObjectExperimentVisitor(const std::string expName, const int nQubits)
-      : experimentName(expName), nTotalQubits(nQubits) {
+  // Temporary fix to handle new {rz, sx, x, cx} gate set
+  enum class GateSet { U_CX, RZ_SX_CX };
+  GateSet gateSet;
+  QObjectExperimentVisitor(const std::string expName, const int nQubits,
+                           GateSet nativeGateSet = GateSet::U_CX)
+      : experimentName(expName), nTotalQubits(nQubits), gateSet(nativeGateSet) {
     int counter = 0;
     for (int b = 0; b < nQubits; b++) {
       qubit2MemorySlot.insert({b, counter});
@@ -95,7 +99,91 @@ public:
       experiment.set_config(config);
       experiment.set_header(header);
       //   xacc::info("Adding insts " + std::to_string(instructions.to))
-      experiment.set_instructions(instructions);
+      // U + CX gate set
+      if (gateSet == GateSet::U_CX) {
+        experiment.set_instructions(instructions);
+      } else if (gateSet == GateSet::RZ_SX_CX) {
+        std::vector<xacc::ibm::Instruction> new_instructions;
+        for (const auto &inst : instructions) {
+          if (inst.get_name() == "u1") {
+            auto newInst = inst;
+            newInst.get_mutable_name() = "rz";
+            new_instructions.emplace_back(newInst);
+          } else if (inst.get_name() == "u2") {
+            // Copy the instruction and only update the name + params
+            const auto u2_params = inst.get_params();
+            assert(u2_params.size() == 2);
+            const double phi = u2_params[0];
+            const double lam = u2_params[1];
+            {
+              // u2_to_u1sx.append(U1Gate(lam - pi/2), [0])
+              auto newInst = inst;
+              newInst.get_mutable_name() = "rz";
+              newInst.set_params({lam - M_PI / 2.0});
+              new_instructions.emplace_back(newInst);
+            }
+            {
+              // u2_to_u1sx.sx(0)
+              auto newInst = inst;
+              newInst.get_mutable_name() = "sx";
+              newInst.set_params({});
+              new_instructions.emplace_back(newInst);
+            }
+            {
+              // u2_to_u1sx.append(U1Gate(phi + pi/2), [0])
+              auto newInst = inst;
+              newInst.get_mutable_name() = "rz";
+              newInst.set_params({phi + M_PI / 2.0});
+              new_instructions.emplace_back(newInst);
+            }
+          } else if (inst.get_name() == "u3") {
+            const auto u3_params = inst.get_params();
+            assert(u3_params.size() == 3);
+            const double theta = u3_params[0];
+            const double phi = u3_params[1];
+            const double lam = u3_params[2];
+            {
+              // u3_qasm_def.rz(lam, 0)
+              auto newInst = inst;
+              newInst.get_mutable_name() = "rz";
+              newInst.set_params({lam});
+              new_instructions.emplace_back(newInst);
+            }
+            {
+              // u3_qasm_def.sx(0)
+              auto newInst = inst;
+              newInst.get_mutable_name() = "sx";
+              newInst.set_params({});
+              new_instructions.emplace_back(newInst);
+            }
+            {
+              // u3_qasm_def.rz(theta+pi, 0)
+              auto newInst = inst;
+              newInst.get_mutable_name() = "rz";
+              newInst.set_params({theta + M_PI});
+              new_instructions.emplace_back(newInst);
+            }
+            {
+              // u3_qasm_def.sx(0)
+              auto newInst = inst;
+              newInst.get_mutable_name() = "sx";
+              newInst.set_params({});
+              new_instructions.emplace_back(newInst);
+            }
+            {
+              // u3_qasm_def.rz(phi+3*pi, 0)
+              auto newInst = inst;
+              newInst.get_mutable_name() = "rz";
+              newInst.set_params({phi + 3.0 * M_PI});
+              new_instructions.emplace_back(newInst);
+            }
+          } else {
+            new_instructions.emplace_back(inst);
+          }
+        }
+
+        experiment.set_instructions(new_instructions);
+      }
     }
     //   xacc::info("Returning Experiment " + experimentName + ", " +
     //   std::to_string(experiment.get_instructions().size()));

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -527,7 +527,7 @@ IbmqNoiseModel::getUniversalGateEquiv(xacc::quantum::Gate &in_gate) const {
     // If cannot find the gate, just treat that as a noiseless u1 op.
     const std::string universalGateName =
         (iter == SINGLE_QUBIT_GATE_MAP.end()) ? "u1" : iter->second;
-    return universalGateName + "_" + std::to_string(in_gate.bits()[0]);
+    return universalGateName + std::to_string(in_gate.bits()[0]);
   }
 
   if (in_gate.bits().size() == 2) {
@@ -535,7 +535,7 @@ IbmqNoiseModel::getUniversalGateEquiv(xacc::quantum::Gate &in_gate) const {
            std::to_string(in_gate.bits()[1]);
   }
 
-  return "id_" + std::to_string(in_gate.bits()[0]);
+  return "id" + std::to_string(in_gate.bits()[0]);
 }
 
 // Return gate time, T1, T2


### PR DESCRIPTION
Resolved https://github.com/eclipse/xacc/issues/360

- Decompose u gates (u1, u2, u3) into (rz, sx) if the backend uses the new gate set.

- `IbmqNoiseModel` to support the new gate set when parsing device properties. 