### PR TITLE
Removed deprecated NoiseModel interfaces

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_noise_model.hpp
@@ -18,9 +18,9 @@ public:
     // errors.
     return m_roErrors.empty() ? std::make_pair(0.0, 0.0) : m_roErrors[qubitIdx];
   }
+  virtual std::vector<NoiseChannelKraus>
+  getNoiseChannels(xacc::quantum::Gate &gate) const override;
   std::vector<RoErrors> readoutErrors() const override { return m_roErrors; }
-
-  std::vector<KrausOp> gateError(xacc::quantum::Gate &gate) const override;
   double gateErrorProb(xacc::quantum::Gate &gate) const override;
   size_t nQubits() const override { return m_nbQubits; }
   std::vector<double> averageSingleQubitGateFidelity() const override;

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -342,13 +342,6 @@ public:
     return result;
   }
 
-  virtual std::vector<KrausOp>
-  gateError(xacc::quantum::Gate &gate) const override {
-    // To be removed!
-    xacc::error("!!!Deprecated!!! Do not use!");
-    return {};
-  }
-
   virtual std::vector<NoiseChannelKraus>
   getNoiseChannels(xacc::quantum::Gate &gate) const {
     std::string gateKey = gate.name() + "_" + std::to_string(gate.bits()[0]);

--- a/xacc/accelerator/NoiseModel.hpp
+++ b/xacc/accelerator/NoiseModel.hpp
@@ -27,17 +27,6 @@ using RoErrors = std::pair<double, double>;
 // The LSB, MSB bit-order that Kraus matrices are defined in.
 enum class KrausMatBitOrder { LSB, MSB };
 
-// !!!Deprecated!!!
-// To be removed: this was developed to target TNQVM's noisy simulator,
-// hence was limited to single-qubit channels...
-// We'll eventually remove this.
-struct KrausOp {
-  size_t qubit;
-  // Choi matrix
-  std::vector<std::vector<std::complex<double>>> mats;
-};
-
-
 // Represent a generic noise channel in terms of
 // Kraus operator matrices to be applied *post-operation*.
 // The list of matrices always satisfies CPTP condition.
@@ -68,21 +57,6 @@ public:
   // Readout errors:
   virtual RoErrors readoutError(size_t qubitIdx) const = 0;
   virtual std::vector<RoErrors> readoutErrors() const = 0;
-  
-  // !!! DEPRECATED !!!!
-  // --- This API to be removed----
-  // Need to update TNQVM to *not* use this anymore.
-  // Gate errors:
-  // Returns a list of Kraus operators represent quantum noise processes
-  // associated with a quantum gate.
-  // Note: we use Kraus operators to capture generic noise processes.
-  // Any probabilistic gate-based noise representations must be converted to
-  // the equivalent Kraus operators.
-  virtual std::vector<KrausOp> gateError(xacc::quantum::Gate &gate) const {
-    return {};
-  }
-  // !!! END - DEPRECATED !!!!
-
   // Returns a list of noise channels (in terms of Kraus matrices)
   // for an XACC gate.
   virtual std::vector<NoiseChannelKraus>


### PR DESCRIPTION
These API's were marked deprecated since the last update but were kept to wait for the TNQVM update.

Removing now. Also, update the `IbmqNoiseModel` (derived from `NoiseModel`) as well: using the generic Kraus channels rather than single-site Choi matrices. 