### PR TITLE
Fixes Apple native build

### DIFF
--- a/quantum/plugins/algorithms/gradient_strategies/autodiff/Autodiff.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/autodiff/Autodiff.hpp
@@ -4,6 +4,26 @@
 #include <autodiff/forward/eigen.hpp>
 #include "AlgorithmGradientStrategy.hpp"
 
+#if defined(__clang__)
+namespace std {
+template <>
+complex<autodiff::dual> operator*(const complex<autodiff::dual> &__z,
+                                  const complex<autodiff::dual> &__w) {
+  autodiff::dual __a = __z.real();
+  autodiff::dual __b = __z.imag();
+  autodiff::dual __c = __w.real();
+  autodiff::dual __d = __w.imag();
+  autodiff::dual __ac = __a * __c;
+  autodiff::dual __bd = __b * __d;
+  autodiff::dual __ad = __a * __d;
+  autodiff::dual __bc = __b * __c;
+  autodiff::dual __x = __ac - __bd;
+  autodiff::dual __y = __ad + __bc;
+  return complex<autodiff::dual>(__x, __y);
+}
+} // namespace std
+#endif
+
 // Extend autodiff to support complex type.
 namespace autodiff::forward::traits {
 template <typename T> struct isArithmetic<std::complex<T>> : std::true_type {};

--- a/quantum/plugins/algorithms/qcmx/CMakeLists.txt
+++ b/quantum/plugins/algorithms/qcmx/CMakeLists.txt
@@ -25,6 +25,16 @@ target_include_directories(
 
 target_link_libraries(${LIBRARY_NAME} PUBLIC xacc CppMicroServices PRIVATE xacc-pauli)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  include(CheckSymbolExists)
+  # Check for function std::beta
+  check_cxx_symbol_exists(std::beta "cmath" HAVE_STD_BETA)
+  if (NOT HAVE_STD_BETA)
+    add_compile_definitions(_XACC_NO_STD_BETA)
+    target_include_directories(${LIBRARY_NAME} PRIVATE ${BOOST_SOURCE})
+  endif()
+endif()
+
 set(_bundle_name xacc_algorithm_qcmx)
 set_target_properties(${LIBRARY_NAME}
                       PROPERTIES COMPILE_DEFINITIONS

--- a/quantum/plugins/algorithms/qcmx/CMakeLists.txt
+++ b/quantum/plugins/algorithms/qcmx/CMakeLists.txt
@@ -24,8 +24,7 @@ target_include_directories(
   PUBLIC .)
 
 target_link_libraries(${LIBRARY_NAME} PUBLIC xacc CppMicroServices PRIVATE xacc-pauli)
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
   include(CheckSymbolExists)
   # Check for function std::beta
   check_cxx_symbol_exists(std::beta "cmath" HAVE_STD_BETA)

--- a/quantum/plugins/algorithms/qcmx/qcmx.cpp
+++ b/quantum/plugins/algorithms/qcmx/qcmx.cpp
@@ -23,6 +23,13 @@
 using namespace xacc;
 using namespace xacc::quantum;
 
+#ifdef _XACC_NO_STD_BETA
+#include "boost/math/special_functions/beta.hpp"
+namespace std {
+double beta(double x, double y) { return boost::math::beta(x, y); }
+} // namespace std
+#endif
+
 namespace xacc {
 namespace algorithm {
 

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.in.cpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.in.cpp
@@ -546,7 +546,9 @@ void QlmAccelerator::initialize(const HeterogeneousMap &params) {
     }();
 
     pybind11::dict gates_noise;
-    for (const auto &[aqasmGate, errorRate] : QLM_GATE_ERRORS) {
+    for (const auto &iter : QLM_GATE_ERRORS) {
+      auto aqasmGate = iter.first;
+      auto errorRate = iter.second;
       // std::cout << aqasmGate << ": " << errorRate << "\n";
       if (aqasmGate == "RX" || aqasmGate == "RY" || aqasmGate == "RZ") {
         gates_noise[aqasmGate.c_str()] = pybind11::cpp_function(

--- a/quantum/plugins/circuits/qfast/qfast.cpp
+++ b/quantum/plugins/circuits/qfast/qfast.cpp
@@ -147,7 +147,7 @@ void softmax(Iter iterBegin, Iter iterEnd)
         return std::exp(500.0 * (x - maxElement)); 
     });
     const ValueType expTol = std::accumulate(iterBegin, iterEnd, 0.0);
-    std::transform(iterBegin, iterEnd, iterBegin, std::bind2nd(std::divides<ValueType>(), expTol));  
+    std::transform(iterBegin, iterEnd, iterBegin, std::bind(std::divides<ValueType>(), std::placeholders::_1, expTol));  
 }
 }
 

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -19,7 +19,7 @@
 // #include <optional>
 #include <stdexcept>
 #include <regex>
-
+#include <unordered_map>
 #ifndef NLOHMANN_OPT_HELPER
 #define NLOHMANN_OPT_HELPER
 namespace nlohmann {

--- a/tpls/CMakeLists.txt
+++ b/tpls/CMakeLists.txt
@@ -62,6 +62,13 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 install( DIRECTORY "${CMAKE_SOURCE_DIR}/tpls/cpr/opt/googletest/include/gtest" DESTINATION include/gtest )
 if (APPLE)
+   set(GTEST_LIB_OUTPUT_DIR "${CMAKE_BINARY_DIR}/tpls/cpr/opt/googletest/") 
+   set_target_properties(gtest PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${GTEST_LIB_OUTPUT_DIR}
+                                          LIBRARY_OUTPUT_DIRECTORY_DEBUG ${GTEST_LIB_OUTPUT_DIR}
+                                          LIBRARY_OUTPUT_DIRECTORY_RELEASE ${GTEST_LIB_OUTPUT_DIR})
+   set_target_properties(gtest_main PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${GTEST_LIB_OUTPUT_DIR}
+                                               LIBRARY_OUTPUT_DIRECTORY_DEBUG ${GTEST_LIB_OUTPUT_DIR}
+                                               LIBRARY_OUTPUT_DIRECTORY_RELEASE ${GTEST_LIB_OUTPUT_DIR})
    install(FILES ${CMAKE_BINARY_DIR}/tpls/cpr/opt/googletest/libgtest.dylib DESTINATION lib)
    install(FILES ${CMAKE_BINARY_DIR}/tpls/cpr/opt/googletest/libgtest_main.dylib DESTINATION lib)
 else()

--- a/tpls/CMakeLists.txt
+++ b/tpls/CMakeLists.txt
@@ -12,7 +12,10 @@
 # *******************************************************************************/
 set(BUILD_SHARED_LIBS TRUE)
 if(APPLE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPATH_MAX=4096 -Wno-deprecated-copy")
+    # Apple Clang doesn't have this Wno-deprecated-copy flag
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPATH_MAX=4096 -Wno-deprecated-copy")
+    endif()
 endif()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9.0.0")

--- a/tpls/antlr/runtime/CMakeLists.txt
+++ b/tpls/antlr/runtime/CMakeLists.txt
@@ -75,6 +75,8 @@ set_target_properties(antlr4_shared
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME antlr4-runtime
                                  LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+                                 LIBRARY_OUTPUT_DIRECTORY_DEBUG ${LIB_OUTPUT_DIR}
+                                 LIBRARY_OUTPUT_DIRECTORY_RELEASE ${LIB_OUTPUT_DIR}
                                  # TODO: test in windows. DLL is treated as runtime.
                                  # see https://cmake.org/cmake/help/v3.0/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html
                                  RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}

--- a/xacc/utils/heterogeneous.hpp
+++ b/xacc/utils/heterogeneous.hpp
@@ -29,6 +29,17 @@
 #include <complex>
 #include <any>
 
+// If this is a GNU compiler
+#if defined(__GNUC__) || defined(__GNUG__)
+// We need to fix for < 7.5, < 8.4, and < 9.2
+#if (( __GNUC__ == 7 && __GNUC_MINOR__ < 5 ) || ( __GNUC__ == 8 && __GNUC_MINOR__ < 4 ) || ( __GNUC__ == 9 && __GNUC_MINOR__ < 2 ))
+#define APPLY_RTTI_ANY_CAST_FIX
+#endif
+#endif
+
+// Wrap the force_cast fixes in conditional block, seems like
+// Clang may try to instantiate force_cast<T> even if no one uses it.
+#ifdef APPLY_RTTI_ANY_CAST_FIX
 namespace __internal {
 union Storage {
   void *_M_ptr;
@@ -51,13 +62,6 @@ template <typename T> T force_cast(std::any in_any) {
   }
 }
 } // namespace __internal
-
-// If this is a GNU compiler
-#if defined(__GNUC__) || defined(__GNUG__)
-// We need to fix for < 7.5, < 8.4, and < 9.2
-#if (( __GNUC__ == 7 && __GNUC_MINOR__ < 5 ) || ( __GNUC__ == 8 && __GNUC_MINOR__ < 4 ) || ( __GNUC__ == 9 && __GNUC_MINOR__ < 2 ))
-#define APPLY_RTTI_ANY_CAST_FIX
-#endif
 #endif
 
 namespace xacc {


### PR DESCRIPTION
This fixes build on Apple Platform using Apple Clang compiler as well as (optionally) using Apple build system (XCode).

Resolves https://github.com/eclipse/xacc/issues/371

Tested by: 

- compiling on my Macbook with GCC and Apple Clang w/ Ninja build as well as Clang with XCode (`-G Xcode`).

- using a CI runner with this YAML:
```
pool:
  vmImage: 'macOS-10.14'

steps:
- script: |
    mkdir source
    cd source
    git clone -b tnguyen/fix-clang-compile https://github.com/tnguyen-ornl/xacc.git
    cd xacc
    mkdir build
    cd build
    cmake .. -DXACC_BUILD_EXAMPLES=TRUE -DXACC_BUILD_TESTS=TRUE -G Xcode
    cmake --build . --target install
  displayName: 'Build XACC'
```

