### PR TITLE
Improve Aer noise sim and fix XACC -> IBM noise model conversion

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
@@ -66,6 +66,10 @@ private:
       const std::vector<std::pair<double, double>> &in_stateVec,
       const std::vector<std::size_t> &in_bits);
 
+  static double calcExpectationValueZFromDensityMatrix(
+      const std::vector<std::vector<std::pair<double, double>>> &in_densityMat,
+      const std::vector<std::size_t> &in_bits);
+
   std::shared_ptr<Compiler> xacc_to_qobj;
   int m_shots = 1024;
   std::string m_simtype = "qasm";

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -253,14 +253,8 @@ public:
           }
           nlohmann::json instruction;
           instruction["name"] = "kraus";
-          if (m_bitOrder == KrausMatBitOrder::MSB) {
-            instruction["qubits"] = errorChannel.noise_qubits;
-          } else {
-            auto bitsRev = errorChannel.noise_qubits;
-            std::reverse(bitsRev.begin(), bitsRev.end());
-            instruction["qubits"] = bitsRev;
-          }
           instruction["params"] = kraus_list;
+          instruction["qubits"] = std::vector<int> {0};
           krausOps.emplace_back(instruction);
           element["instructions"] =
               std::vector<std::vector<nlohmann::json>>{krausOps};
@@ -292,12 +286,11 @@ public:
           nlohmann::json instruction;
           instruction["name"] = "kraus";
           if (m_bitOrder == KrausMatBitOrder::MSB) {
-            instruction["qubits"] = errorChannel.noise_qubits;
+            instruction["qubits"] = std::vector<int> {0 , 1};
           } else {
-            auto bitsRev = errorChannel.noise_qubits;
-            std::reverse(bitsRev.begin(), bitsRev.end());
-            instruction["qubits"] = bitsRev;
+            instruction["qubits"] = std::vector<int> {1 , 0};
           }
+
           instruction["params"] = kraus_list;
           krausOps.emplace_back(instruction);
           element["instructions"] =


### PR DESCRIPTION
- Added exp-val-z computation for density matrix simulation in Aer. We got the density matrix using snapshot at the end of the simulation, just need to compute the exp-val-z from the diagonal elements.


- Fixed a bug when converting from the custom XACC noise model Json to IBM Json. We need to be using relative indexing in the IBM Json. 