### PR TITLE
Fixes for LLVM toolchain (clang + libcpp)

### DIFF
--- a/quantum/observable/pauli/PauliOperator.cpp
+++ b/quantum/observable/pauli/PauliOperator.cpp
@@ -492,7 +492,7 @@ PauliOperator &PauliOperator::operator-=(const PauliOperator &v) noexcept {
 
 PauliOperator &PauliOperator::operator*=(const PauliOperator &v) noexcept {
 
-  std::unordered_map<std::string, Term> newTerms;
+  std::map<std::string, Term> newTerms;
   for (auto &kv : terms) {
     for (auto &vkv : v.terms) {
       auto multTerm = kv.second * vkv.second;

--- a/quantum/observable/pauli/PauliOperator.hpp
+++ b/quantum/observable/pauli/PauliOperator.hpp
@@ -219,17 +219,17 @@ class PauliOperator
       public tao::operators::commutative_multipliable<PauliOperator,
                                                       std::complex<double>> {
 protected:
-  std::unordered_map<std::string, Term> terms;
+  std::map<std::string, Term> terms;
 
 public:
   std::shared_ptr<Observable> clone() override {
     return std::make_shared<PauliOperator>();
   }
 
-  std::unordered_map<std::string, Term>::iterator begin() {
+  std::map<std::string, Term>::iterator begin() {
     return terms.begin();
   }
-  std::unordered_map<std::string, Term>::iterator end() { return terms.end(); }
+  std::map<std::string, Term>::iterator end() { return terms.end(); }
 
   PauliOperator();
   PauliOperator(std::complex<double> c);
@@ -313,7 +313,7 @@ public:
   }
   void clear();
 
-  std::unordered_map<std::string, Term> getTerms() const { return terms; }
+  std::map<std::string, Term> getTerms() const { return terms; }
 
   std::vector<SparseTriplet> getSparseMatrixElements() {return to_sparse_matrix();}
   std::vector<std::complex<double>> toDenseMatrix(const int nQubits);

--- a/quantum/plugins/circuits/exp/exp.cpp
+++ b/quantum/plugins/circuits/exp/exp.cpp
@@ -49,7 +49,7 @@ bool Exp::expand(const HeterogeneousMap &parameters) {
     paramLetter = parameters.getString("param_id");
   }
 
-  std::unordered_map<std::string, xacc::quantum::Term> terms;
+  std::map<std::string, xacc::quantum::Term> terms;
   if (pauli_or_fermion == "fermion") {
     auto fermionStr = parameters.getString("fermion");
     auto op = std::make_shared<FermionOperator>(fermionStr);
@@ -196,7 +196,7 @@ void Exp::applyRuntimeArguments() {
 
   // Have to make sure this wasn't already expanded
   if (nInstructions() == 0) {
-    std::unordered_map<std::string, xacc::quantum::Term> terms;
+    std::map<std::string, xacc::quantum::Term> terms;
     if (dynamic_cast<FermionOperator *>(observable)) {
       terms = std::dynamic_pointer_cast<PauliOperator>(
                   xacc::getService<ObservableTransform>("jw")->transform(

--- a/quantum/plugins/circuits/uccsd/uccsd.cpp
+++ b/quantum/plugins/circuits/uccsd/uccsd.cpp
@@ -47,7 +47,7 @@ bool UCCSD::expand(const xacc::HeterogeneousMap &runtimeOptions) {
   auto _nVirtual = nQubits / 2 - _nOccupied;
   auto _nOrbitals = _nOccupied + _nVirtual;
 
-  std::unordered_map<std::string, Term> terms;
+  std::map<std::string, Term> terms;
   std::vector<xacc::InstructionParameter> variables;
 
   if (runtimeOptions.stringExists("pool")) {

--- a/xacc/utils/heterogeneous.hpp
+++ b/xacc/utils/heterogeneous.hpp
@@ -34,6 +34,17 @@
 // We need to fix for < 7.5, < 8.4, and < 9.2
 #if (( __GNUC__ == 7 && __GNUC_MINOR__ < 5 ) || ( __GNUC__ == 8 && __GNUC_MINOR__ < 4 ) || ( __GNUC__ == 9 && __GNUC_MINOR__ < 2 ))
 #define APPLY_RTTI_ANY_CAST_FIX
+#define STD_ANY_ALIGNED_STORAGE_SIZE 1
+#endif
+#endif
+
+// Fix for LLVM libc++: it also has a problem with typeinfo comparison.
+#ifndef APPLY_RTTI_ANY_CAST_FIX
+#ifdef _LIBCPP_VERSION
+#if !defined(_LIBCPP_NO_RTTI)
+#define APPLY_RTTI_ANY_CAST_FIX
+#define STD_ANY_ALIGNED_STORAGE_SIZE 3
+#endif
 #endif
 #endif
 
@@ -43,7 +54,7 @@
 namespace __internal {
 union Storage {
   void *_M_ptr;
-  std::aligned_storage<sizeof(_M_ptr), alignof(void *)>::type _M_buffer;
+  std::aligned_storage<STD_ANY_ALIGNED_STORAGE_SIZE*sizeof(_M_ptr), alignof(void *)>::type _M_buffer;
 };
 typedef void (*funcPtr)(void);
 
@@ -60,6 +71,14 @@ template <typename T> T force_cast(std::any in_any) {
     auto val = reinterpret_cast<T *>(storage._M_ptr);
     return *val;
   }
+}
+
+template <typename T> bool isType(std::any in_any) {
+  if ((in_any.type() == typeid(T)) ||
+      (strcmp(in_any.type().name(), typeid(T).name()) == 0)) {
+    return true;
+  }
+  return false;
 }
 } // namespace __internal
 #endif
@@ -214,7 +233,7 @@ public:
         std::any_cast<T>(items.at(key));
       } catch (std::exception &e) {
 #ifdef APPLY_RTTI_ANY_CAST_FIX
-        return items.at(key).type() == typeid(T);
+        return __internal::isType<T>(items.at(key));
 #else
         return false;
 #endif

--- a/xacc/utils/heterogeneous.hpp
+++ b/xacc/utils/heterogeneous.hpp
@@ -21,6 +21,7 @@
 #include <functional>
 #include <iostream>
 #include <experimental/type_traits>
+#include <cstring>
 
 // mpark variant
 #include "variant.hpp"


### PR DESCRIPTION
- Extends the HetMap fix to cover `libcpp` edge case as well.

- Use `std::map` for `PauliOperator` terms to enforce a consistent ordering. Downstream code may assume the list of terms be consistent.