### PR TITLE
Added ExecutionInfo API

### DIFF
--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -313,6 +313,8 @@ namespace quantum {
                     generateMeasureBitString(buffer, measureBitIdxs, stateVec, m_shots, multiThreadEnabled);
                 }
             }
+            // Note: must save the state-vector before finalizing the visitor.
+            cacheExecutionInfo();
             m_visitor->finalize();
         }
     }
@@ -383,6 +385,18 @@ namespace quantum {
             assert(gateCast);
             m_visitor->applyGate(*gateCast);
         }
+    }
+
+    void QppAccelerator::cacheExecutionInfo() {
+      // Cache the state-vector:
+      // Note: qpp stores wavefunction in Eigen vectors,
+      // hence, maps to std::vector.
+      auto stateVec = m_visitor->getStateVec();
+      ExecutionInfo::WaveFuncType waveFunc(stateVec.data(),
+                                           stateVec.data() + stateVec.size());
+      m_executionInfo = {
+          {ExecutionInfo::WaveFuncKey,
+           std::make_shared<ExecutionInfo::WaveFuncType>(std::move(waveFunc))}};
     }
 
     NoiseModelUtils::cMat DefaultNoiseModelUtils::krausToChoi(const std::vector<NoiseModelUtils::cMat>& in_krausMats) const

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -33,16 +33,21 @@ public:
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<std::shared_ptr<CompositeInstruction>> compositeInstructions) override;
     virtual void apply(std::shared_ptr<AcceleratorBuffer> buffer, std::shared_ptr<Instruction> inst) override;
     std::vector<std::pair<int, int>> getConnectivity() override {
-        return m_connectivity;
+      return m_connectivity;
     }
-    
-private:
+    // ExecutionInfo implementation:
+    virtual xacc::HeterogeneousMap getExecutionInfo() const override { return m_executionInfo; }
+  
+  private:
+    // Cache execution info after execution
+    void cacheExecutionInfo();
     std::shared_ptr<QppVisitor> m_visitor;
     // Number of 'shots' if random sampling simulation is enabled.
     // -1 means disabled (no shots, just expectation value)
     int m_shots = -1;
     bool m_vqeMode;
     std::vector<std::pair<int,int>> m_connectivity;
+    xacc::HeterogeneousMap m_executionInfo;
 };
 
 class DefaultNoiseModelUtils : public NoiseModelUtils 

--- a/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
+++ b/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
@@ -538,6 +538,34 @@ TEST(QppAcceleratorTester, testVqeMode)
     EXPECT_NEAR((*buffer)["opt-val"].as<double>(), -1.74886, 1e-4);
 }
 
+TEST(QppAcceleratorTester, testExecutionInfo)
+{
+    auto accelerator = xacc::getAccelerator("qpp");
+    xacc::qasm(R"(
+        .compiler xasm
+        .circuit test_bell_exe
+        .qbit q
+        H(q[0]);
+        CNOT(q[0],q[1]);
+    )");
+    auto bell = xacc::getCompiled("test_bell_exe");
+
+    // Allocate some qubits and execute
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, bell);
+
+    auto exeInfo = accelerator->getExecutionInfo();
+    EXPECT_GT(exeInfo.size(), 0);
+    auto waveFn =
+        accelerator->getExecutionInfo<xacc::ExecutionInfo::WaveFuncPtrType>(
+            xacc::ExecutionInfo::WaveFuncKey);
+    // for (const auto &elem : *waveFn) {
+    //   std::cout << elem << "\n";
+    // }
+    // 2 qubits => 4 elements
+    EXPECT_EQ(waveFn->size(), 4);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize();
 

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -101,6 +101,21 @@ public:
     throw std::logic_error("Accelerator '" + name() +
                            "' doesn't support single gate application.");
   }
+
+  // Custom execution-related information (specific to each Acc implementation)
+  virtual HeterogeneousMap getExecutionInfo() const { return {}; }
+
+  // Retrieve a particular execution-related information.
+  template <typename T> T getExecutionInfo(const std::string &key) {
+    if (!getExecutionInfo().keyExists<T>(key)) {
+      XACCLogger::instance()->error(
+          "getExecutionInfo() error - Invalid information key (" + key + ").");
+    } else {
+      return getExecutionInfo().get<T>(key);
+    }
+    return T();
+  }
+
   virtual ~Accelerator() {}
 };
 

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -24,6 +24,23 @@
 
 namespace xacc {
 
+// Common typedefs and keys for ExecutionInfo:
+// Accelerator sub-types should use these keys and types
+// for ExecutionInformation HetMap for consistency.
+namespace ExecutionInfo {
+// Wavefunction
+const std::string WaveFuncKey = "wave-function";
+// Note: we use shared_ptr to prevent copies of these potentially large vectors.
+using WaveFuncType = std::vector<std::complex<double>>;
+using WaveFuncPtrType = std::shared_ptr<WaveFuncType>;
+
+// Density matrix
+const std::string DmKey = "density-matrix";
+// Row-by-row matrix
+using DensityMatrixType = std::vector<WaveFuncType>;
+using DensityMatrixPtrType = std::shared_ptr<DensityMatrixType>;
+} // namespace ExecutionInfo
+
 // The Accelerator is the primary interface connecting programmers/clients
 // with an available post-Moore's law co-processor (or accelerator, think GPU).
 // Accelerators primarily expose execution functionality, which takes


### PR DESCRIPTION
Addresses https://github.com/eclipse/xacc/issues/353

`ExecutionInfo` is stored in a HetMap. Adding typedefs and standard keys for state vector and density matrix.

Adding preliminary support in the `qpp` acclerator for testing and will be using it in TNQVM.