### PR TITLE
Fock excitations

### DIFF
--- a/python/examples/qeom.py
+++ b/python/examples/qeom.py
@@ -1,0 +1,54 @@
+import xacc
+
+accelerator = xacc.getAccelerator("qpp")
+
+buffer = xacc.qalloc(4)
+
+opstr = '''
+(-0.165606823582,-0)  1^ 2^ 1 2 + (0.120200490713,0)  1^ 0^ 0 1 +
+(-0.0454063328691,-0)  0^ 3^ 1 2 + (0.168335986252,0)  2^ 0^ 0 2 +
+(0.0454063328691,0)  1^ 2^ 3 0 + (0.168335986252,0)  0^ 2^ 2 0 +
+(0.165606823582,0)  0^ 3^ 3 0 + (-0.0454063328691,-0)  3^ 0^ 2 1 +
+(-0.0454063328691,-0)  1^ 3^ 0 2 + (-0.0454063328691,-0)  3^ 1^ 2 0 +
+(0.165606823582,0)  1^ 2^ 2 1 + (-0.165606823582,-0)  0^ 3^ 0 3 +
+(-0.479677813134,-0)  3^ 3 + (-0.0454063328691,-0)  1^ 2^ 0 3 +
+(-0.174072892497,-0)  1^ 3^ 1 3 + (-0.0454063328691,-0)  0^ 2^ 1 3 +
+(0.120200490713,0)  0^ 1^ 1 0 + (0.0454063328691,0)  0^ 2^ 3 1 +
+(0.174072892497,0)  1^ 3^ 3 1 + (0.165606823582,0)  2^ 1^ 1 2 +
+(-0.0454063328691,-0)  2^ 1^ 3 0 + (-0.120200490713,-0)  2^ 3^ 2 3 +
+(0.120200490713,0)  2^ 3^ 3 2 + (-0.168335986252,-0)  0^ 2^ 0 2 +
+(0.120200490713,0)  3^ 2^ 2 3 + (-0.120200490713,-0)  3^ 2^ 3 2 +
+(0.0454063328691,0)  1^ 3^ 2 0 + (-1.2488468038,-0)  0^ 0 +
+(0.0454063328691,0)  3^ 1^ 0 2 + (-0.168335986252,-0)  2^ 0^ 2 0 +
+(0.165606823582,0)  3^ 0^ 0 3 + (-0.0454063328691,-0)  2^ 0^ 3 1 +
+(0.0454063328691,0)  2^ 0^ 1 3 + (-1.2488468038,-0)  2^ 2 +
+(0.0454063328691,0)  2^ 1^ 0 3 + (0.174072892497,0)  3^ 1^ 1 3 +
+(-0.479677813134,-0)  1^ 1 + (-0.174072892497,-0)  3^ 1^ 3 1 +
+(0.0454063328691,0)  3^ 0^ 1 2 + (-0.165606823582,-0)  3^ 0^ 3 0 +
+(0.0454063328691,0)  0^ 3^ 2 1 + (-0.165606823582,-0)  2^ 1^ 2 1 +
+(-0.120200490713,-0)  0^ 1^ 0 1 + (-0.120200490713,-0)  1^ 0^ 1 0 + (0.7080240981,0)
+'''
+H = xacc.getObservable('fermion', opstr)
+
+pool = xacc.quantum.getOperatorPool("singlet-adapted-uccsd")
+pool.optionalParameters({"n-electrons": 2})
+pool.generate(buffer.size())
+provider = xacc.getIRProvider('quantum')
+ansatz = provider.createComposite('initial-state')
+ansatz.addInstruction(provider.createInstruction('X', [0]))
+ansatz.addInstruction(provider.createInstruction('X', [2]))
+ansatz.addVariable("x0")
+for inst in pool.getOperatorInstructions(2, 0).getInstructions():
+    ansatz.addInstruction(inst)
+kernel = ansatz.eval([0.0808])
+
+qeom = xacc.getAlgorithm('qeom', {
+                        'accelerator': accelerator,
+                        'observable': H,
+                        'ansatz': kernel,
+                        'n-electrons': 2
+                        })
+
+qeom.execute(buffer)
+spectrum = buffer.getInformation("excitation-energies")
+print(spectrum)

--- a/quantum/examples/qasm/CMakeLists.txt
+++ b/quantum/examples/qasm/CMakeLists.txt
@@ -48,3 +48,7 @@ target_link_libraries(qaoa_maxcut_qpp PRIVATE xacc xacc-quantum-gate)
 
 add_executable(qaoa_placement qaoa_placement.cpp)
 target_link_libraries(qaoa_placement PRIVATE xacc xacc-quantum-gate)
+
+add_executable(qeom_h2_sto-3g qeom_h2_sto-3g.cpp)
+target_include_directories(qeom_h2_sto-3g PUBLIC ${CMAKE_SOURCE_DIR}/quantum/plugins/utils)
+target_link_libraries(qeom_h2_sto-3g PRIVATE xacc xacc-quantum-gate)

--- a/quantum/examples/qasm/qeom_h2_sto-3g.cpp
+++ b/quantum/examples/qasm/qeom_h2_sto-3g.cpp
@@ -1,0 +1,72 @@
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "xacc_observable.hpp"
+#include "OperatorPool.hpp"
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+
+auto str = std::string(
+      "(-0.165606823582,-0)  1^ 2^ 1 2 + (0.120200490713,0)  1^ 0^ 0 1 + "
+      "(-0.0454063328691,-0)  0^ 3^ 1 2 + (0.168335986252,0)  2^ 0^ 0 2 + "
+      "(0.0454063328691,0)  1^ 2^ 3 0 + (0.168335986252,0)  0^ 2^ 2 0 + "
+      "(0.165606823582,0)  0^ 3^ 3 0 + (-0.0454063328691,-0)  3^ 0^ 2 1 + "
+      "(-0.0454063328691,-0)  1^ 3^ 0 2 + (-0.0454063328691,-0)  3^ 1^ 2 0 + "
+      "(0.165606823582,0)  1^ 2^ 2 1 + (-0.165606823582,-0)  0^ 3^ 0 3 + "
+      "(-0.479677813134,-0)  3^ 3 + (-0.0454063328691,-0)  1^ 2^ 0 3 + "
+      "(-0.174072892497,-0)  1^ 3^ 1 3 + (-0.0454063328691,-0)  0^ 2^ 1 3 + "
+      "(0.120200490713,0)  0^ 1^ 1 0 + (0.0454063328691,0)  0^ 2^ 3 1 + "
+      "(0.174072892497,0)  1^ 3^ 3 1 + (0.165606823582,0)  2^ 1^ 1 2 + "
+      "(-0.0454063328691,-0)  2^ 1^ 3 0 + (-0.120200490713,-0)  2^ 3^ 2 3 + "
+      "(0.120200490713,0)  2^ 3^ 3 2 + (-0.168335986252,-0)  0^ 2^ 0 2 + "
+      "(0.120200490713,0)  3^ 2^ 2 3 + (-0.120200490713,-0)  3^ 2^ 3 2 + "
+      "(0.0454063328691,0)  1^ 3^ 2 0 + (-1.2488468038,-0)  0^ 0 + "
+      "(0.0454063328691,0)  3^ 1^ 0 2 + (-0.168335986252,-0)  2^ 0^ 2 0 + "
+      "(0.165606823582,0)  3^ 0^ 0 3 + (-0.0454063328691,-0)  2^ 0^ 3 1 + "
+      "(0.0454063328691,0)  2^ 0^ 1 3 + (-1.2488468038,-0)  2^ 2 + "
+      "(0.0454063328691,0)  2^ 1^ 0 3 + (0.174072892497,0)  3^ 1^ 1 3 + "
+      "(-0.479677813134,-0)  1^ 1 + (-0.174072892497,-0)  3^ 1^ 3 1 + "
+      "(0.0454063328691,0)  3^ 0^ 1 2 + (-0.165606823582,-0)  3^ 0^ 3 0 + "
+      "(0.0454063328691,0)  0^ 3^ 2 1 + (-0.165606823582,-0)  2^ 1^ 2 1 + "
+      "(-0.120200490713,-0)  0^ 1^ 0 1 + (-0.120200490713,-0)  1^ 0^ 1 0 + "
+      "(0.7080240981,0)");
+  auto H = xacc::quantum::getObservable("fermion", str);
+  auto acc = xacc::getAccelerator("qpp");
+  auto buffer = xacc::qalloc(4);
+
+  auto pool = xacc::getService<xacc::quantum::OperatorPool>("singlet-adapted-uccsd");
+  pool->optionalParameters({{"n-electrons", 2}});
+  pool->generate(buffer->size());
+  auto ansatz = xacc::getIRProvider("quantum")->createComposite("ansatz");
+  ansatz->addInstruction(
+      xacc::getIRProvider("quantum")->createInstruction("X", {0}));
+  ansatz->addInstruction(
+      xacc::getIRProvider("quantum")->createInstruction("X", {2}));
+  ansatz->addVariable("x0");
+  for (auto &k : pool->getOperatorInstructions(2, 0)->getInstructions()) {
+    ansatz->addInstruction(k);
+  }
+  auto kernel = ansatz->operator()({0.0808});
+
+  auto qeom = xacc::getService<xacc::Algorithm>("qeom");
+  qeom->initialize({
+      {"accelerator", acc},
+      {"observable", H},
+      {"n-electrons", 2},
+      {"ansatz", kernel},
+  });
+  qeom->execute(buffer);
+
+  auto e =
+      buffer->getInformation("excitation-energies").as<std::vector<double>>();
+
+  std::cout << "Excitation energies = ";
+  for (int i = 0; i < e.size() - 1; i++) {
+    std::cout << e[i] << ", ";
+  }
+  std::cout << e.back() << "\n";
+
+  xacc::Finalize();
+
+  return 0;
+}

--- a/quantum/plugins/algorithms/adapt/adapt_activator.cpp
+++ b/quantum/plugins/algorithms/adapt/adapt_activator.cpp
@@ -19,6 +19,7 @@
 #include "operator_pools/SinglesDoublesPool.hpp"
 #include "operator_pools/IonizationPotential.hpp"
 #include "operator_pools/ElectronAttachment.hpp"
+#include "operator_pools/SpinFlip.hpp"
 
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
@@ -62,6 +63,9 @@ public:
 
     auto ea = std::make_shared<xacc::quantum::ElectronAttachment>();
     context.RegisterService<xacc::quantum::OperatorPool>(ea); 
+
+    auto sf = std::make_shared<xacc::quantum::SpinFlip>();
+    context.RegisterService<xacc::quantum::OperatorPool>(sf); 
 
   }
 

--- a/quantum/plugins/algorithms/adapt/adapt_activator.cpp
+++ b/quantum/plugins/algorithms/adapt/adapt_activator.cpp
@@ -17,6 +17,8 @@
 #include "operator_pools/MultiQubitQAOA.hpp"
 #include "operator_pools/CustomPool.hpp"
 #include "operator_pools/SinglesDoublesPool.hpp"
+#include "operator_pools/IonizationPotential.hpp"
+#include "operator_pools/ElectronAttachment.hpp"
 
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
@@ -54,6 +56,12 @@ public:
 
     auto sd = std::make_shared<xacc::quantum::SinglesDoublesPool>();
     context.RegisterService<xacc::quantum::OperatorPool>(sd);   
+
+    auto ip = std::make_shared<xacc::quantum::IonizationPotential>();
+    context.RegisterService<xacc::quantum::OperatorPool>(ip);  
+
+    auto ea = std::make_shared<xacc::quantum::ElectronAttachment>();
+    context.RegisterService<xacc::quantum::OperatorPool>(ea); 
 
   }
 

--- a/quantum/plugins/algorithms/adapt/operator_pools/ElectronAttachment.hpp
+++ b/quantum/plugins/algorithms/adapt/operator_pools/ElectronAttachment.hpp
@@ -13,7 +13,6 @@
 #ifndef XACC_ELECTRON_ATTACHMENT_POOL_HPP_
 #define XACC_ELECTRON_ATTACHMENT_POOL_HPP_
 
-#include "adapt.hpp"
 #include "OperatorPool.hpp"
 #include "xacc.hpp"
 #include "xacc_service.hpp"
@@ -64,17 +63,17 @@ public:
     auto _nOccupied = (int)std::ceil(_nElectrons / 2.0);
     auto _nVirtual = nQubits / 2 - _nOccupied;
     auto _nOrbs = _nOccupied + _nVirtual;
+    
+    if (_rank == 1) {
+      for (int a = 0; a < _nVirtual; a++) {
+        int aa = a + _nOccupied;
+        int ab = a + _nOccupied + _nOrbs;
+        operators.push_back(
+            std::make_shared<FermionOperator>(FermionOperator({{aa, 1}}, 2.0)));
 
-    std::shared_ptr<Observable> fermiOp;
-    // i
-    for (int a = 0; a < _nVirtual; a++) {
-      int aa = a + _nOccupied;
-      int ab = a + _nOccupied + _nOrbs;
-      operators.push_back(
-          std::make_shared<FermionOperator>(FermionOperator({{aa, 1}}, 4.0)));
-
-      operators.push_back(
-          std::make_shared<FermionOperator>(FermionOperator({{ab, 1}}, 4.0)));
+        operators.push_back(
+            std::make_shared<FermionOperator>(FermionOperator({{ab, 1}}, 2.0)));
+      }
     }
 
     if (_rank == 2) {
@@ -82,6 +81,10 @@ public:
       for (int a = 0; a < _nVirtual; a++) {
         int aa = a + _nOccupied;
         int ab = a + _nOccupied + _nOrbs;
+
+        operators.push_back(std::make_shared<FermionOperator>(
+            FermionOperator({{aa, 1}, {ab, 1}}, 4.0)));
+
         for (int b = a + 1; b < _nVirtual; b++) {
           int ba = b + _nOccupied;
           int bb = b + _nOccupied + _nOrbs;

--- a/quantum/plugins/algorithms/adapt/operator_pools/ElectronAttachment.hpp
+++ b/quantum/plugins/algorithms/adapt/operator_pools/ElectronAttachment.hpp
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Daniel Claudino - initial API and implementation
+ *******************************************************************************/
+#ifndef XACC_ELECTRON_ATTACHMENT_POOL_HPP_
+#define XACC_ELECTRON_ATTACHMENT_POOL_HPP_
+
+#include "adapt.hpp"
+#include "OperatorPool.hpp"
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "Observable.hpp"
+#include "xacc_observable.hpp"
+#include "FermionOperator.hpp"
+#include "Circuit.hpp"
+#include "ObservableTransform.hpp"
+
+using namespace xacc;
+using namespace xacc::quantum;
+
+namespace xacc {
+namespace quantum {
+
+class ElectronAttachment : public OperatorPool {
+
+protected:
+  int _nElectrons, _rank = 1;
+  std::vector<std::shared_ptr<Observable>> pool, operators;
+
+public:
+  ElectronAttachment() = default;
+
+  bool optionalParameters(const HeterogeneousMap parameters) override {
+
+    if (!parameters.keyExists<int>("n-electrons")) {
+      xacc::info("Pool needs number of electrons.");
+      return false;
+    }
+    _nElectrons = parameters.get<int>("n-electrons");
+
+    if (parameters.keyExists<int>("rank")) {
+      _rank = parameters.get<int>("rank");
+    }
+
+    if (_rank > 2) {
+      xacc::info("Cannot add more than two electrons");
+    }
+
+    return true;
+  }
+
+  // generate the pool
+  std::vector<std::shared_ptr<Observable>>
+  getExcitationOperators(const int &nQubits) override {
+
+    auto _nOccupied = (int)std::ceil(_nElectrons / 2.0);
+    auto _nVirtual = nQubits / 2 - _nOccupied;
+    auto _nOrbs = _nOccupied + _nVirtual;
+
+    std::shared_ptr<Observable> fermiOp;
+    // i
+    for (int a = 0; a < _nVirtual; a++) {
+      int aa = a + _nOccupied;
+      int ab = a + _nOccupied + _nOrbs;
+      operators.push_back(
+          std::make_shared<FermionOperator>(FermionOperator({{aa, 1}}, 4.0)));
+
+      operators.push_back(
+          std::make_shared<FermionOperator>(FermionOperator({{ab, 1}}, 4.0)));
+    }
+
+    if (_rank == 2) {
+
+      for (int a = 0; a < _nVirtual; a++) {
+        int aa = a + _nOccupied;
+        int ab = a + _nOccupied + _nOrbs;
+        for (int b = a + 1; b < _nVirtual; b++) {
+          int ba = b + _nOccupied;
+          int bb = b + _nOccupied + _nOrbs;
+
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{aa, 1}, {ba, 1}}, 4.0)));
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{ab, 1}, {bb, 1}}, 4.0)));
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{aa, 1}, {bb, 1}}, 4.0)));
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{ab, 1}, {ba, 1}}, 4.0)));
+        }
+      }
+    }
+
+    return operators;
+  }
+
+  // generate the pool
+  std::vector<std::shared_ptr<Observable>>
+  generate(const int &nQubits) override {
+
+    auto ops = getExcitationOperators(nQubits);
+    auto jw = xacc::getService<ObservableTransform>("jw");
+    for (auto &op : ops) {
+      auto tmp = *std::dynamic_pointer_cast<FermionOperator>(op);
+      tmp -= tmp.hermitianConjugate();
+      tmp.normalize();
+      pool.push_back(jw->transform(std::make_shared<FermionOperator>(tmp)));
+    }
+    return pool;
+  }
+
+  std::string operatorString(const int index) override {
+
+    return operators[index]->toString();
+  }
+
+  std::shared_ptr<CompositeInstruction>
+  getOperatorInstructions(const int opIdx, const int varIdx) const override {
+
+    // Instruction service for the operator to be added to the ansatz
+    auto gate = std::dynamic_pointer_cast<quantum::Circuit>(
+        xacc::getService<Instruction>("exp_i_theta"));
+
+    // Create instruction for new operator
+    gate->expand({std::make_pair("pauli", pool[opIdx]->toString()),
+                  std::make_pair("param_id", "x" + std::to_string(varIdx))});
+
+    return gate;
+  }
+
+  const std::string name() const override { return "electron-attachment"; }
+  const std::string description() const override { return ""; }
+};
+
+} // namespace quantum
+} // namespace xacc
+
+#endif

--- a/quantum/plugins/algorithms/adapt/operator_pools/IonizationPotential.hpp
+++ b/quantum/plugins/algorithms/adapt/operator_pools/IonizationPotential.hpp
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Daniel Claudino - initial API and implementation
+ *******************************************************************************/
+#ifndef XACC_IONIZATION_POTENTIAL_POOL_HPP_
+#define XACC_IONIZATION_POTENTIAL_POOL_HPP_
+
+#include "adapt.hpp"
+#include "OperatorPool.hpp"
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "Observable.hpp"
+#include "xacc_observable.hpp"
+#include "FermionOperator.hpp"
+#include "Circuit.hpp"
+#include "ObservableTransform.hpp"
+
+using namespace xacc;
+using namespace xacc::quantum;
+
+namespace xacc {
+namespace quantum {
+
+class IonizationPotential : public OperatorPool {
+
+protected:
+  int _nElectrons, _rank = 1;
+  std::vector<std::shared_ptr<Observable>> pool, operators;
+
+public:
+  IonizationPotential() = default;
+
+  bool optionalParameters(const HeterogeneousMap parameters) override {
+
+    if (!parameters.keyExists<int>("n-electrons")) {
+      xacc::info("Pool needs number of electrons.");
+      return false;
+    }
+    _nElectrons = parameters.get<int>("n-electrons");
+
+    if (parameters.keyExists<int>("rank")) {
+      _rank = parameters.get<int>("rank");
+    }
+
+    if (_rank > 2) {
+      xacc::info("Cannot remove more than two electrons");
+    }
+
+    return true;
+  }
+
+  // generate the pool
+  std::vector<std::shared_ptr<Observable>>
+  getExcitationOperators(const int &nQubits) override {
+
+    auto _nOccupied = (int)std::ceil(_nElectrons / 2.0);
+    auto _nVirtual = nQubits / 2 - _nOccupied;
+    auto _nOrbs = _nOccupied + _nVirtual;
+
+    std::shared_ptr<Observable> fermiOp;
+    // i
+    for (int i = 0; i < _nOccupied; i++) {
+      int ia = i;
+      int ib = i + _nOrbs;
+      operators.push_back(
+          std::make_shared<FermionOperator>(FermionOperator({{ia, 0}}, 4.0)));
+
+      operators.push_back(
+          std::make_shared<FermionOperator>(FermionOperator({{ib, 0}}, 4.0)));
+    }
+
+    if (_rank == 2) {
+
+      for (int i = 0; i < _nOccupied; i++) {
+        int ia = i;
+        int ib = i + _nOrbs;
+        for (int j = i + 1; j < _nOccupied; j++) {
+          int ja = j;
+          int jb = j + _nOrbs;
+
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{ia, 0}, {ja, 0}}, 4.0)));
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{ib, 0}, {jb, 0}}, 4.0)));
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{ia, 0}, {jb, 0}}, 4.0)));
+          operators.push_back(std::make_shared<FermionOperator>(
+              FermionOperator({{ib, 0}, {ja, 0}}, 4.0)));
+        }
+      }
+    }
+
+    return operators;
+  }
+
+  // generate the pool
+  std::vector<std::shared_ptr<Observable>>
+  generate(const int &nQubits) override {
+
+    auto ops = getExcitationOperators(nQubits);
+    auto jw = xacc::getService<ObservableTransform>("jw");
+    for (auto &op : ops) {
+      auto tmp = *std::dynamic_pointer_cast<FermionOperator>(op);
+      tmp -= tmp.hermitianConjugate();
+      tmp.normalize();
+      pool.push_back(jw->transform(std::make_shared<FermionOperator>(tmp)));
+    }
+    return pool;
+  }
+
+  std::string operatorString(const int index) override {
+
+    return operators[index]->toString();
+  }
+
+  std::shared_ptr<CompositeInstruction>
+  getOperatorInstructions(const int opIdx, const int varIdx) const override {
+
+    // Instruction service for the operator to be added to the ansatz
+    auto gate = std::dynamic_pointer_cast<quantum::Circuit>(
+        xacc::getService<Instruction>("exp_i_theta"));
+
+    // Create instruction for new operator
+    gate->expand({std::make_pair("pauli", pool[opIdx]->toString()),
+                  std::make_pair("param_id", "x" + std::to_string(varIdx))});
+
+    return gate;
+  }
+
+  const std::string name() const override { return "ionization-potential"; }
+  const std::string description() const override { return ""; }
+};
+
+} // namespace quantum
+} // namespace xacc
+
+#endif

--- a/quantum/plugins/algorithms/qeom/qeom.cpp
+++ b/quantum/plugins/algorithms/qeom/qeom.cpp
@@ -13,6 +13,7 @@
 #include "qeom.hpp"
 
 #include "Observable.hpp"
+#include "Utils.hpp"
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 #include "xacc_plugin.hpp"
@@ -23,6 +24,7 @@
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>
 #include <memory>
+#include <sstream>
 #include "OperatorPool.hpp"
 
 using namespace xacc;
@@ -48,7 +50,8 @@ bool qEOM::initialize(const HeterogeneousMap &parameters) {
   }
 
   if (!parameters.keyExists<std::vector<std::shared_ptr<Observable>>>(
-          "operators") && !parameters.keyExists<int>("n-electrons")) {
+          "operators") &&
+      !parameters.keyExists<int>("n-electrons")) {
     xacc::error("qEOM needs either excitation operators or the number of "
                 "electrons");
     return false;
@@ -70,15 +73,15 @@ bool qEOM::initialize(const HeterogeneousMap &parameters) {
   if (parameters.keyExists<int>("n-electrons")) {
     auto nOrbitals = observable->nBits();
     auto nOccupied = parameters.get<int>("n-electrons");
-    auto nVirtual = nOrbitals - nOccupied;
-  
+
     std::shared_ptr<OperatorPool> pool;
     // check if the name for a pool was given
     // if not, default to singles and doubles
     if (parameters.stringExists("pool")) {
       pool = xacc::getService<OperatorPool>(parameters.getString("pool"));
     } else {
-      xacc::info("Using single and double excitation operators");
+      xacc::warning("No operator pool specified. Defaulting to single and "
+                    "double excitation operators");
       pool = xacc::getService<OperatorPool>("singles-doubles-pool");
     }
 
@@ -89,7 +92,7 @@ bool qEOM::initialize(const HeterogeneousMap &parameters) {
   }
 
   if (observable->toString().find("^") != std::string::npos) {
-    
+
     if (std::dynamic_pointer_cast<FermionOperator>(observable)) {
       observable = jw->transform(observable);
     } else {
@@ -165,28 +168,27 @@ void qEOM::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       // qEOM matrix elements
       auto M_MatOperator = doubleCommutator(bra, ket);
       if (!M_MatOperator->getSubTerms().empty()) {
-        M(i, j) = VQEWrapper(M_MatOperator);
+        M(i, j) = measureOperator(M_MatOperator, buffer);
         M(j, i) = M(i, j);
       }
 
-      auto Q_MatOperator = doubleCommutator(bra, ketConj);      
+      auto Q_MatOperator = doubleCommutator(bra, ketConj);
       if (!Q_MatOperator->getSubTerms().empty()) {
-        Q(i, j) = VQEWrapper(Q_MatOperator);
+        Q(i, j) = measureOperator(Q_MatOperator, buffer);
         Q(j, i) = Q(i, j);
       }
 
-      auto V_MatOperator = bra->commutator(ket);      
+      auto V_MatOperator = bra->commutator(ket);
       if (!V_MatOperator->getSubTerms().empty()) {
-        V(i, j) = VQEWrapper(V_MatOperator);
+        V(i, j) = measureOperator(V_MatOperator, buffer);
         V(j, i) = V(i, j);
       }
 
-      auto W_MatOperator = bra->commutator(ketConj);      
+      auto W_MatOperator = bra->commutator(ketConj);
       if (!W_MatOperator->getSubTerms().empty()) {
-        W(i, j) = VQEWrapper(W_MatOperator);
+        W(i, j) = measureOperator(W_MatOperator, buffer);
         W(j, i) = W(i, j);
       }
-
     }
   }
 
@@ -222,15 +224,44 @@ void qEOM::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
   std::sort(excitationEnergies.begin(), excitationEnergies.end());
   buffer->addExtraInfo("excitation-energies", excitationEnergies);
 
+  // Printing spectrum
+  std::stringstream ss;
+  ss << "QEOM spectrum = ";
+  for (int i = 0; i < excitationEnergies.size() - 1; i++) {
+    ss << excitationEnergies[i] << ", ";
+  }
+  ss << excitationEnergies.back();
+  xacc::info(ss.str());
+
   return;
 }
 
-double qEOM::VQEWrapper(const std::shared_ptr<Observable> obs) const {
-  auto vqe = xacc::getAlgorithm(
-      "vqe",
-      {{"observable", obs}, {"ansatz", kernel}, {"accelerator", accelerator}});
-  auto tmpBuffer = xacc::qalloc(observable->nBits());
-  return vqe->execute(tmpBuffer, {})[0];
+double
+qEOM::measureOperator(const std::shared_ptr<Observable> obs,
+                      const std::shared_ptr<AcceleratorBuffer> buffer) const {
+
+  // observe
+  auto kernels = obs->observe(xacc::as_shared_ptr(kernel));
+  double total = 0.0;
+  // we loop over all measured circuits
+  // and check if that term has been measured
+  // if so, we just multiply the measurement by the coefficient
+  // if not, we measure as usual and store it
+  // Because these are all commutators, we don't need to worry about the I term
+  for (auto &f : kernels) {
+    std::complex<double> coeff = f->getCoefficient();
+    if (cachedMeasurements.find(f->name()) != cachedMeasurements.end()) {
+      total += std::real(coeff * cachedMeasurements[f->name()]);
+    } else {
+      auto tmpBuffer = xacc::qalloc(buffer->size());
+      accelerator->execute(tmpBuffer, f);
+      auto expval = tmpBuffer->getExpectationValueZ();
+      total += std::real(coeff * expval);
+      cachedMeasurements.emplace(f->name(), expval);
+    }
+  }
+
+  return total;
 }
 
 } // namespace algorithm

--- a/quantum/plugins/algorithms/qeom/qeom.hpp
+++ b/quantum/plugins/algorithms/qeom/qeom.hpp
@@ -24,6 +24,8 @@
 
 #include "Algorithm.hpp"
 #include "xacc.hpp"
+#include <unordered_map>
+#include <vector>
 
 namespace xacc {
 namespace algorithm {
@@ -34,8 +36,9 @@ protected:
   Accelerator *accelerator;
   HeterogeneousMap parameters;
   std::vector<std::shared_ptr<Observable>> operators;
+  mutable std::unordered_map<std::string, double> cachedMeasurements;
 
-  double VQEWrapper(const std::shared_ptr<Observable> obs) const;
+  double measureOperator(const std::shared_ptr<Observable> obs, const std::shared_ptr<AcceleratorBuffer> buffer) const;
 
 public:
   bool initialize(const HeterogeneousMap &parameters) override;


### PR DESCRIPTION
This PR implements:

- operator pools that allow particle-number and spin symmetry breaking by attaching electrons (ElectronAttachment.hpp), removing electrons (IonizationPotential.hpp), and flipping spins (SpinFlip.hpp). 
- qEOM measurement caching, only measuring circuits that have not been previously cached.