### PR TITLE
Enhance mid-circuit measurement, reset and conditional if statement

### DIFF
--- a/python/examples/ghz_to_bell.py
+++ b/python/examples/ghz_to_bell.py
@@ -1,0 +1,41 @@
+# Demonstrate mid-circuit measurement support
+# GHZ to Bell conversion
+# Adapted from:
+# https://quantum-computing.ibm.com/docs/manage/systems/midcircuit-measurement/#GHZ-to-Bell-State
+
+import xacc
+
+# Mid-circuit measurement is supportted by:
+# - Simulator: qpp, qsim, aer
+# - Selected IBM backends.
+qpu = xacc.getAccelerator('qpp', {"shots": 1024})
+# qpu = xacc.getAccelerator('aer', {"shots": 1024})
+
+q = xacc.qalloc(3)
+
+xacc.qasm('''
+.compiler xasm
+.circuit ghz_to_bell
+.qbit q
+H(q[2]);
+CX(q[2], q[1]);
+CX(q[1], q[0]);
+// Z -> X basis 
+H(q[0]);
+// Mid-circuit measurement => Bell state
+Measure(q[0]);
+H(q[2]);
+X(q[0]);
+Measure(q[0]);
+Measure(q[1]);
+Measure(q[2]);
+''')
+
+f = xacc.getCompiled('ghz_to_bell')
+qpu.execute(q, f)
+print(q)
+
+sim_counts_ghz_bell_1 = q.getMarginalCounts([0])
+sim_counts_ghz_bell_2 = q.getMarginalCounts([1,2,3])
+print("Sim meas 1 result: ", sim_counts_ghz_bell_1)
+print("Sim meas 2 result: ", sim_counts_ghz_bell_2)

--- a/python/examples/ghz_to_bell.py
+++ b/python/examples/ghz_to_bell.py
@@ -8,8 +8,8 @@ import xacc
 # Mid-circuit measurement is supportted by:
 # - Simulator: qpp, qsim, aer
 # - Selected IBM backends.
-qpu = xacc.getAccelerator('aer', {"shots": 1024})
-
+# qpu = xacc.getAccelerator('aer', {"shots": 1024})
+qpu = xacc.getAccelerator('qpp', {"shots": 1024})
 q = xacc.qalloc(3)
 
 xacc.qasm('''
@@ -34,8 +34,8 @@ Measure(q[2]);
 f = xacc.getCompiled('ghz_to_bell')
 qpu.execute(q, f)
 print(q)
-
-sim_counts_ghz_bell_1 = q.getMarginalCounts([0])
-sim_counts_ghz_bell_2 = q.getMarginalCounts([1,2,3])
+# Note: QPP is using a LSB bit-ordering
+sim_counts_ghz_bell_1 = q.getMarginalCounts([0], xacc.BitOrder.LSB)
+sim_counts_ghz_bell_2 = q.getMarginalCounts([1,2,3], xacc.BitOrder.LSB)
 print("Sim meas 1 result: ", sim_counts_ghz_bell_1)
 print("Sim meas 2 result: ", sim_counts_ghz_bell_2)

--- a/python/examples/ghz_to_bell.py
+++ b/python/examples/ghz_to_bell.py
@@ -8,8 +8,7 @@ import xacc
 # Mid-circuit measurement is supportted by:
 # - Simulator: qpp, qsim, aer
 # - Selected IBM backends.
-qpu = xacc.getAccelerator('qpp', {"shots": 1024})
-# qpu = xacc.getAccelerator('aer', {"shots": 1024})
+qpu = xacc.getAccelerator('aer', {"shots": 1024})
 
 q = xacc.qalloc(3)
 
@@ -24,6 +23,7 @@ CX(q[1], q[0]);
 H(q[0]);
 // Mid-circuit measurement => Bell state
 Measure(q[0]);
+CX(q[2], q[1]);
 H(q[2]);
 X(q[0]);
 Measure(q[0]);

--- a/python/examples/iterative_phase_estimation.py
+++ b/python/examples/iterative_phase_estimation.py
@@ -15,6 +15,7 @@ xacc.qasm('''
 .circuit iterative_qpe
 .qbit q
 H(q[0]);
+X(q[1]);
 // Prepare the state:
 CPhase(q[0], q[1], -5*pi/8);
 CPhase(q[0], q[1], -5*pi/8);
@@ -69,7 +70,12 @@ Measure(q[0], c[3]);
 
 f = xacc.getCompiled('iterative_qpe')
 print(f.toString())
-qpu = xacc.getAccelerator('qpp', {'shots':1014})
+# qpu = xacc.getAccelerator('qpp', {'shots':1024})
+qpu = xacc.getAccelerator('aer', {'shots':1024})
+# With noise
+# Note: IBMQ doesn't support bfunc (conditional) instruction atm,
+# hence, we can only do simulation of the QObj.
+# qpu = xacc.getAccelerator('aer:ibmq_manhattan', {'shots':1024})
 q = xacc.qalloc(2)
 qpu.execute(q, f)
 print(q)

--- a/python/examples/iterative_phase_estimation.py
+++ b/python/examples/iterative_phase_estimation.py
@@ -1,14 +1,21 @@
-# Demonstrating XACC ability to compile circuits witH
+# Demonstrating XACC ability to compile circuits with
 # mid-circuit Measurement, Reset, and conditional statements
-# on IBM backends tHat support tHese instructions.
+# on IBM backends that support tHese instructions.
 
-# Iterative Quantum PHase Estimation:
-# Only use 2 qubits to acHieve 4-bit accuracy (normally require 5 qubits)
-# THe oracle is a -5*pi/8 pHase rotation;
+# IMPORTANT NOTES: IBM hardware backends don't support conditional 
+# statements ('bfunc' instruction) at the moment.
+# Hence, this can only be executed on the simulator.
+# Ref: https://arxiv.org/pdf/2102.01682.pdf
+# The conditional statements executed in the paper seem 
+# not to be available to the public yet.
+
+# Iterative Quantum Phase Estimation:
+# Only use 2 qubits to achieve 4-bit accuracy (normally require 5 qubits)
+# The oracle is a -5*pi/8 pHase rotation;
 # expected to get 4 bits (iteratively) of 1011 = 11(decimal):
-# pHi_est = 11/16 (denom = 16 since we Have 4 bits) 
-# => pHi = 2pi * 11/16 = 11pi/8 = 2pi - 5pi/8 
-# i.e. we estimate tHe -5*pi/8 angle...
+# phi_est = 11/16 (denom = 16 since we have 4 bits) 
+# => phi = 2pi * 11/16 = 11pi/8 = 2pi - 5pi/8 
+# i.e. we estimate the -5*pi/8 angle...
 import xacc
 xacc.qasm('''
 .compiler xasm

--- a/python/examples/iterative_phase_estimation.py
+++ b/python/examples/iterative_phase_estimation.py
@@ -26,7 +26,7 @@ CPhase(q[0], q[1], -5*pi/8);
 CPhase(q[0], q[1], -5*pi/8);
 H(q[0]);
 // Measure and reset
-Measure(q[0], 0);
+Measure(q[0], c[0]);
 Reset(q[0]);
 H(q[0]);
 CPhase(q[0], q[1], -5*pi/8);
@@ -34,37 +34,37 @@ CPhase(q[0], q[1], -5*pi/8);
 CPhase(q[0], q[1], -5*pi/8);
 CPhase(q[0], q[1], -5*pi/8);
 // Conditional rotation
-if(q[0]) {
+if(c[0]) {
     Rz(q[0], -pi/2);
 }
 H(q[0]);
-Measure(q[0], 1);
+Measure(q[0], c[1]);
 Reset(q[0]);
 H(q[0]);
 CPhase(q[0], q[1], -5*pi/8);
 CPhase(q[0], q[1], -5*pi/8);
-if(q[0]) {
+if(c[0]) {
     Rz(q[0], -pi/4);
 }
-if(q[0]) {
+if(c[1]) {
     Rz(q[0], -pi/2);
 }
 H(q[0]);
-Measure(q[0], 2);
+Measure(q[0], c[2]);
 Reset(q[0]);
 H(q[0]);
 CPhase(q[0], q[1], -5*pi/8);
-if(q[0]) {
+if(c[0]) {
     Rz(q[0], -pi/8);
 }
-if(q[0]) {
+if(c[1]) {
     Rz(q[0], -pi/4);
 }
-if(q[0]) {
+if(c[2]) {
     Rz(q[0], -pi/2);
 }
 H(q[0]);
-Measure(q[0], 3);
+Measure(q[0], c[3]);
 ''')
 
 f = xacc.getCompiled('iterative_qpe')

--- a/python/examples/iterative_phase_estimation.py
+++ b/python/examples/iterative_phase_estimation.py
@@ -1,0 +1,75 @@
+# Demonstrating XACC ability to compile circuits witH
+# mid-circuit Measurement, Reset, and conditional statements
+# on IBM backends tHat support tHese instructions.
+
+# Iterative Quantum PHase Estimation:
+# Only use 2 qubits to acHieve 4-bit accuracy (normally require 5 qubits)
+# THe oracle is a -5*pi/8 pHase rotation;
+# expected to get 4 bits (iteratively) of 1011 = 11(decimal):
+# pHi_est = 11/16 (denom = 16 since we Have 4 bits) 
+# => pHi = 2pi * 11/16 = 11pi/8 = 2pi - 5pi/8 
+# i.e. we estimate tHe -5*pi/8 angle...
+import xacc
+xacc.qasm('''
+.compiler xasm
+.circuit iterative_qpe
+.qbit q
+H(q[0]);
+// Prepare the state:
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+H(q[0]);
+// Measure and reset
+Measure(q[0], 0);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+// Conditional rotation
+if(q[0]) {
+    Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], 1);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+if(q[0]) {
+    Rz(q[0], -pi/4);
+}
+if(q[0]) {
+    Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], 2);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+if(q[0]) {
+    Rz(q[0], -pi/8);
+}
+if(q[0]) {
+    Rz(q[0], -pi/4);
+}
+if(q[0]) {
+    Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], 3);
+''')
+
+f = xacc.getCompiled('iterative_qpe')
+print(f.toString())
+qpu = xacc.getAccelerator('qpp', {'shots':1014})
+q = xacc.qalloc(2)
+qpu.execute(q, f)
+print(q)

--- a/python/py_accelerator.cpp
+++ b/python/py_accelerator.cpp
@@ -190,7 +190,14 @@ void bind_accelerator(py::module &m) {
            (std::vector<std::shared_ptr<AcceleratorBuffer>>(
                xacc::AcceleratorBuffer::*)(const std::string, ExtraInfo)) &
                xacc::AcceleratorBuffer::getChildren,
-           "");
+           "")
+      .def(
+          "getMarginalCounts",
+          [](AcceleratorBuffer &b, const std::vector<int> &idxs) {
+            return b.getMarginalCounts(idxs);
+          },
+          "Return the mapping of marginal measure bit strings to their "
+          "counts.");
 
   // Expose xacc::NoiseModel
   py::class_<xacc::NoiseModel, std::shared_ptr<xacc::NoiseModel>, PyNoiseModel>

--- a/python/py_accelerator.cpp
+++ b/python/py_accelerator.cpp
@@ -193,12 +193,19 @@ void bind_accelerator(py::module &m) {
            "")
       .def(
           "getMarginalCounts",
+          // Default to MSB if not explicitly specified
           [](AcceleratorBuffer &b, const std::vector<int> &idxs) {
-            return b.getMarginalCounts(idxs);
+            return b.getMarginalCounts(idxs, AcceleratorBuffer::BitOrder::MSB);
           },
           "Return the mapping of marginal measure bit strings to their "
-          "counts.");
-
+          "counts.")
+      .def("getMarginalCounts", &xacc::AcceleratorBuffer::getMarginalCounts,
+           "Return the mapping of marginal measure bit strings to their "
+           "counts.");
+  py::enum_<xacc::AcceleratorBuffer::BitOrder>(m, "BitOrder")
+      .value("LSB", xacc::AcceleratorBuffer::BitOrder::LSB)
+      .value("MSB", xacc::AcceleratorBuffer::BitOrder::MSB)
+      .export_values();
   // Expose xacc::NoiseModel
   py::class_<xacc::NoiseModel, std::shared_ptr<xacc::NoiseModel>, PyNoiseModel>
       noise_model(m, "NoiseModel", "");

--- a/quantum/gate/GateQuantumActivator.cpp
+++ b/quantum/gate/GateQuantumActivator.cpp
@@ -67,7 +67,7 @@ public:
     auto ch = std::make_shared<xacc::quantum::CH>();
 
     auto ifstmt = std::make_shared<xacc::quantum::IfStmt>();
-
+    auto reset = std::make_shared<xacc::quantum::Reset>();
     auto scheduler = std::make_shared<xacc::quantum::PulseScheduler>();
     context.RegisterService<xacc::Scheduler>(scheduler);
 
@@ -100,7 +100,7 @@ public:
     context.RegisterService<xacc::Instruction>(cy);
     context.RegisterService<xacc::Instruction>(crz);
     context.RegisterService<xacc::Instruction>(ch);
-
+    context.RegisterService<xacc::Instruction>(reset);
   }
 
   /**

--- a/quantum/gate/ir/CommonGates.cpp
+++ b/quantum/gate/ir/CommonGates.cpp
@@ -4,8 +4,10 @@
 namespace xacc {
 namespace quantum {
 bool IfStmt::expand(const HeterogeneousMap &runtimeOptions) {
-  auto buffer = xacc::getBuffer(bufferName);
-  if ((*buffer)[bitIdx]) {
+  auto buffer = xacc::getClassicalRegHostBuffer(bufferName);
+  // Use the generic CReg deref.
+  // this will decay to qreg->operator[] if the bufferName is the buffer name.
+  if (buffer->getCregValue(bufferName, bitIdx)) {
     for (auto &i : instructions) {
       i->enable();
     }

--- a/quantum/gate/ir/CommonGates.cpp
+++ b/quantum/gate/ir/CommonGates.cpp
@@ -32,6 +32,14 @@ const std::string IfStmt::toString() {
     }
     retStr << "}\n";
     return retStr.str();
+}
+void Measure::setBufferNames(
+    const std::vector<std::string> bufferNamesPerIdx) {
+  if (bufferNamesPerIdx.size() > nRequiredBits() + 1) {
+    xacc::error("Invalid number of buffer names for this instruction: " +
+                name() + ", " + std::to_string(bufferNamesPerIdx.size()));
   }
+  buffer_names = bufferNamesPerIdx;
+}
 } // namespace quantum
 } // namespace xacc

--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -345,6 +345,13 @@ public:
 
   int getClassicalBitIndex() { return mpark::get<int>(parameters[0]); }
   const int nRequiredBits() const override { return 1; }
+  bool hasClassicalRegAssignment() const {
+    return buffer_names.size() > nRequiredBits();
+  }
+
+  void
+  setBufferNames(const std::vector<std::string> bufferNamesPerIdx) override;
+
   const std::string toString() override {
     auto bufferVarName = "q";
     auto str = gateName;
@@ -359,6 +366,11 @@ public:
 
     // Remove trailing comma
     str = str.substr(0, str.length() - 1);
+
+    if (hasClassicalRegAssignment()) {
+      str +=
+          (" -> " + getBufferName(1) + std::to_string(getClassicalBitIndex()));
+    }
 
     return str;
   }

--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -514,6 +514,16 @@ public:
   DEFINE_VISITABLE()
 };
 
+class Reset : public Gate {
+public:
+  Reset() : Gate("Reset") {}
+  Reset(std::vector<std::size_t> qbit) : Gate("Reset", qbit) {}
+  Reset(std::size_t qbit) : Reset(std::vector<std::size_t>{qbit}) {}
+  const int nRequiredBits() const override { return 1; }
+  DEFINE_CLONE(Reset)
+  DEFINE_VISITABLE()
+};
+
 } // namespace quantum
 } // namespace xacc
 #endif

--- a/quantum/gate/utils/AllGateVisitor.hpp
+++ b/quantum/gate/utils/AllGateVisitor.hpp
@@ -47,7 +47,8 @@ class AllGateVisitor : public BaseInstructionVisitor,
                        public InstructionVisitor<U>,
                        public InstructionVisitor<U1>,
                        public InstructionVisitor<IfStmt>,
-                       public InstructionVisitor<XY> {
+                       public InstructionVisitor<XY>,
+                       public InstructionVisitor<Reset> {
 public:
   void visit(Hadamard &h) override {}
   void visit(CNOT &h) override {}
@@ -105,6 +106,7 @@ public:
   void visit(T &t) override {}
   void visit(Tdg &tdg) override {}
   void visit(IfStmt &tdg) override {}
+  void visit(Reset &reset) override {}
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -154,6 +154,28 @@ std::vector<xacc::ibm_pulse::Instruction> orderFrameChangeInsts(
   return result;
 }
 
+bool hasMidCircuitMeasurement(
+    std::shared_ptr<CompositeInstruction> &in_circuit) {
+  InstructionIterator it(in_circuit);
+  bool measureEncountered = false;
+  while (it.hasNext()) {
+    auto nextInst = it.next();
+    if (nextInst->isEnabled()) {
+      if (nextInst->name() == "Measure") {
+        // Flag that we have seen a Measure gate.
+        measureEncountered = true;
+      }
+
+      // We have seen a Measure gate but this one is not another Measure gate.
+      if (measureEncountered && nextInst->name() != "Measure") {
+        // This circuit has mid-circuit measurement
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void IBMAccelerator::initialize(const HeterogeneousMap &params) {
   if (!initialized) {
     std::string apiKey = "";
@@ -235,7 +257,8 @@ void IBMAccelerator::initialize(const HeterogeneousMap &params) {
     }
 
     chosenBackend = availableBackends[backend];
-
+    xacc::info("Backend config:\n" + chosenBackend.dump());
+    multi_meas_enabled = chosenBackend["multi_meas_enabled"].get<bool>();
     defaults_response =
         get(IBM_API_URL,
             IBM_CREDENTIALS_PATH + "/devices/" + backend + "/defaults", {},
@@ -792,6 +815,7 @@ HeterogeneousMap IBMAccelerator::getProperties() {
 
     m.insert("p01s", p01s);
     m.insert("p10s", p10s);
+    m.insert("multi_meas_enabled", multi_meas_enabled);
   }
 
   return m;

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -155,7 +155,7 @@ std::vector<xacc::ibm_pulse::Instruction> orderFrameChangeInsts(
 }
 
 bool hasMidCircuitMeasurement(
-    std::shared_ptr<CompositeInstruction> &in_circuit) {
+    const std::shared_ptr<CompositeInstruction> &in_circuit) {
   InstructionIterator it(in_circuit);
   bool measureEncountered = false;
   while (it.hasNext()) {
@@ -498,6 +498,11 @@ void IBMAccelerator::execute(
   // either pulse or qasm
   std::string qobj_type = mode;
   for (auto &c : circuits) {
+    if (hasMidCircuitMeasurement(c) && !multi_meas_enabled) {
+      xacc::error("Circuit '" + c->name() +
+                  "' has mid-circuit measurement instructions but the backend "
+                  "doesn't support multiple measurement");
+    }
     // If there is an analog instruction (pulse),
     // always use 'pulse' mode.
     if (c->isAnalog()) {

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -178,6 +178,7 @@ private:
 
   std::map<std::string, nlohmann::json> availableBackends;
   nlohmann::json chosenBackend;
+  bool multi_meas_enabled = false;
   bool initialized = false;
   nlohmann::json backends_root;
   std::map<std::string, nlohmann::json> backendProperties;

--- a/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
@@ -358,6 +358,14 @@ public:
     // }
   }
 
+  void visit(Reset &reset) override {
+    xacc::ibm::Instruction inst;
+    inst.get_mutable_qubits().push_back(reset.bits()[0]);
+    inst.get_mutable_name() = "reset";
+    setConditional(inst);
+    instructions.push_back(inst);
+  }
+
   void visit(Rx &rx) override {
     xacc::ibm::Instruction inst;
     inst.get_mutable_qubits().push_back(rx.bits()[0]);

--- a/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
+++ b/quantum/plugins/ibm/accelerator/QObjectExperimentVisitor.hpp
@@ -32,6 +32,7 @@ protected:
   int nTotalQubits = 0;
   std::vector<int> usedMemorySlots;
   std::optional<int64_t> conditionalRegId;
+  std::map<std::pair<std::string, std::size_t>, std::size_t> cReg_to_meas_idx;
 
 public:
   int maxMemorySlots = 0;
@@ -346,13 +347,17 @@ public:
           "IBM: Invalid classical bit index for measurement, already used.");
     }
 
-    auto classicalBit = m.getParameter(0).as<int>();
     xacc::ibm::Instruction inst;
     inst.get_mutable_qubits().push_back(m.bits()[0]);
     inst.get_mutable_name() = "measure";
     inst.set_memory({maxMemorySlots});
     instructions.push_back(inst);
-
+    if (m.hasClassicalRegAssignment()) {
+      auto classicalBit = m.getParameter(0).as<int>();
+      auto classicalReg = m.getBufferNames()[1];
+      cReg_to_meas_idx[std::make_pair(classicalReg, classicalBit)] =
+          inst.get_memory()[0];
+    }
     // if (classicalBit > maxMemorySlots) {
     maxMemorySlots++; // = qubit2MemorySlot[m.bits()[0]];
     // }
@@ -411,7 +416,16 @@ public:
 
   void visit(IfStmt &ifStmt) override {
     const auto cregId = ifStmt.bits()[0];
-    auto bfuncInst = xacc::ibm::Instruction::createConditionalInst(cregId);
+    const auto cregName = ifStmt.getParameters()[0].as<std::string>();
+    const auto absRegId = [&]() {
+      auto iter = cReg_to_meas_idx.find(std::make_pair(cregName, cregId));
+      if (iter != cReg_to_meas_idx.end()) {
+        return iter->second;
+      } else {
+        return cregId;
+      }
+    }();
+    auto bfuncInst = xacc::ibm::Instruction::createConditionalInst(absRegId);
     const auto regId = bfuncInst.get_bFunc()->registerId;
     instructions.push_back(bfuncInst);
     // All the instructions that are scoped inside this block must have a

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -324,6 +324,12 @@ public:
   }
 
   int64_t mapMemory(int64_t in_memoryId) {
+    // Don't need to generate new mapping;
+    // e.g. multiple if conditioned on the same measurement.
+    auto iter = memoryToRegister.find(in_memoryId);
+    if (iter != memoryToRegister.end()) {
+      return iter->second;
+    }
     memoryToRegister[in_memoryId] = registerId;
     registerId++;
     return memoryToRegister[in_memoryId];

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -715,11 +715,21 @@ inline void to_json(json &j, const xacc::ibm::QObjectConfig &x) {
   j["memory_slots"] = x.get_memory_slots();
   j["memory"] = x.get_memory();
   j["parameter_binds"] = x.get_parameter_binds();
-  j["meas_lo_freq"] = x.get_meas_lo_freq();
-  j["schedule_los"] = x.get_schedule_los();
-  j["qubit_lo_freq"] = x.get_qubit_lo_freq();
-  j["qubit_lo_range"] = x.get_qubit_lo_range();
-  j["meas_lo_range"] = x.get_meas_lo_range();
+  if (!x.get_meas_lo_freq().empty()) {
+    j["meas_lo_freq"] = x.get_meas_lo_freq();
+  }
+  if (!x.get_schedule_los().empty()) {
+    j["schedule_los"] = x.get_schedule_los();
+  }
+  if (!x.get_qubit_lo_freq().empty()) {
+    j["qubit_lo_freq"] = x.get_qubit_lo_freq();
+  }
+  if (!x.get_qubit_lo_range().empty()) {
+    j["qubit_lo_range"] = x.get_qubit_lo_range();
+  }
+  if (!x.get_meas_lo_range().empty()) {
+    j["meas_lo_range"] = x.get_meas_lo_range();
+  }
   j["meas_return"] = x.get_meas_return();
   j["meas_level"] = x.get_meas_level();
   j["memory_slot_size"] = x.get_memory_slot_size();

--- a/quantum/plugins/ibm/tests/CMakeLists.txt
+++ b/quantum/plugins/ibm/tests/CMakeLists.txt
@@ -28,3 +28,6 @@ target_link_libraries(QObjectCompilerTester CppMicroServices)
 # i.e. the .ibm_config file is valid. 
 # add_xacc_test(IBMPulseRemote)
 # target_link_libraries(IBMPulseRemoteTester xacc-quantum-gate)
+
+add_xacc_test(MidCircuitMeasurement)
+target_link_libraries(MidCircuitMeasurementTester xacc-quantum-gate)

--- a/quantum/plugins/ibm/tests/CMakeLists.txt
+++ b/quantum/plugins/ibm/tests/CMakeLists.txt
@@ -28,8 +28,8 @@ target_link_libraries(QObjectCompilerTester CppMicroServices)
 # i.e. the .ibm_config file is valid. 
 # add_xacc_test(IBMPulseRemote)
 # target_link_libraries(IBMPulseRemoteTester xacc-quantum-gate)
+# add_xacc_test(MidCircuitMeasurement)
+# target_link_libraries(MidCircuitMeasurementTester xacc-quantum-gate)
 
-add_xacc_test(MidCircuitMeasurement)
-target_link_libraries(MidCircuitMeasurementTester xacc-quantum-gate)
 add_xacc_test(ResetInst)
 target_link_libraries(ResetInstTester xacc-quantum-gate)

--- a/quantum/plugins/ibm/tests/CMakeLists.txt
+++ b/quantum/plugins/ibm/tests/CMakeLists.txt
@@ -28,8 +28,8 @@ target_link_libraries(QObjectCompilerTester CppMicroServices)
 # i.e. the .ibm_config file is valid. 
 # add_xacc_test(IBMPulseRemote)
 # target_link_libraries(IBMPulseRemoteTester xacc-quantum-gate)
-# add_xacc_test(MidCircuitMeasurement)
-# target_link_libraries(MidCircuitMeasurementTester xacc-quantum-gate)
+add_xacc_test(MidCircuitMeasurement)
+target_link_libraries(MidCircuitMeasurementTester xacc-quantum-gate)
 
 add_xacc_test(ResetInst)
 target_link_libraries(ResetInstTester xacc-quantum-gate)

--- a/quantum/plugins/ibm/tests/CMakeLists.txt
+++ b/quantum/plugins/ibm/tests/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(QObjectCompilerTester CppMicroServices)
 
 add_xacc_test(MidCircuitMeasurement)
 target_link_libraries(MidCircuitMeasurementTester xacc-quantum-gate)
+add_xacc_test(ResetInst)
+target_link_libraries(ResetInstTester xacc-quantum-gate)

--- a/quantum/plugins/ibm/tests/MidCircuitMeasurementTester.cpp
+++ b/quantum/plugins/ibm/tests/MidCircuitMeasurementTester.cpp
@@ -1,0 +1,32 @@
+#include "xacc_config.hpp"
+#include "xacc_service.hpp"
+#include "IRProvider.hpp"
+#include "xacc.hpp"
+#include <gtest/gtest.h>
+#include <memory>
+
+TEST(MidCircuitMeasurementTester, checkSimple) {
+  xacc::set_verbose(true);
+  auto acc = xacc::getAccelerator("ibm:ibmq_manhattan");
+  auto props = acc->getProperties();
+  EXPECT_TRUE(props.get<bool>("multi_meas_enabled"));
+  auto buffer = xacc::qalloc(2);
+  auto provider = xacc::getService<xacc::IRProvider>("quantum");
+  auto f = provider->createComposite("tmp");
+  f->addInstruction(provider->createInstruction("X", 0));
+  f->addInstruction(provider->createInstruction("Measure", 0));
+  f->addInstruction(provider->createInstruction("Measure", 1));
+  f->addInstruction(provider->createInstruction("X", 1));
+  f->addInstruction(provider->createInstruction("Measure", 0));
+  f->addInstruction(provider->createInstruction("Measure", 1));
+  acc->execute(buffer, f);
+  buffer->print();
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  auto ret = RUN_ALL_TESTS();
+  xacc::Finalize();
+  return ret;
+}

--- a/quantum/plugins/ibm/tests/MidCircuitMeasurementTester.cpp
+++ b/quantum/plugins/ibm/tests/MidCircuitMeasurementTester.cpp
@@ -5,22 +5,89 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-TEST(MidCircuitMeasurementTester, checkSimple) {
-  xacc::set_verbose(true);
-  auto acc = xacc::getAccelerator("ibm:ibmq_manhattan");
-  auto props = acc->getProperties();
-  EXPECT_TRUE(props.get<bool>("multi_meas_enabled"));
+// This test requires remote access
+// TEST(MidCircuitMeasurementTester, checkSimple) {
+//   xacc::set_verbose(true);
+//   auto acc = xacc::getAccelerator("ibm:ibmq_manhattan");
+//   auto props = acc->getProperties();
+//   EXPECT_TRUE(props.get<bool>("multi_meas_enabled"));
+//   auto buffer = xacc::qalloc(2);
+//   auto provider = xacc::getService<xacc::IRProvider>("quantum");
+//   auto f = provider->createComposite("tmp");
+//   f->addInstruction(provider->createInstruction("X", 0));
+//   f->addInstruction(provider->createInstruction("Measure", 0));
+//   f->addInstruction(provider->createInstruction("Measure", 1));
+//   f->addInstruction(provider->createInstruction("X", 1));
+//   f->addInstruction(provider->createInstruction("Measure", 0));
+//   f->addInstruction(provider->createInstruction("Measure", 1));
+//   acc->execute(buffer, f);
+//   buffer->print();
+// }
+
+// Check the QObj with mid-circuit measurements and 
+// if statements.
+TEST(MidCircuitMeasurementTester, checkQObjSim) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void iqpe(qbit q) {
+H(q[0]);
+X(q[1]);
+// Prepare the state:
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+H(q[0]);
+// Measure and reset
+Measure(q[0], cReg[0]);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+// Conditional rotation
+if(cReg[0]) {
+  Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], cReg[1]);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+if(cReg[0]) {
+  Rz(q[0], -pi/4);
+}
+if(cReg[1]) {
+  Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], cReg[2]);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+if(cReg[0]) {
+  Rz(q[0], -pi/8);
+}
+if(cReg[1]) {
+  Rz(q[0], -pi/4);
+}
+if(cReg[2]) {
+  Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], cReg[3]);
+})");
+  auto accelerator = xacc::getAccelerator("aer", {{"shots", 1024}});
   auto buffer = xacc::qalloc(2);
-  auto provider = xacc::getService<xacc::IRProvider>("quantum");
-  auto f = provider->createComposite("tmp");
-  f->addInstruction(provider->createInstruction("X", 0));
-  f->addInstruction(provider->createInstruction("Measure", 0));
-  f->addInstruction(provider->createInstruction("Measure", 1));
-  f->addInstruction(provider->createInstruction("X", 1));
-  f->addInstruction(provider->createInstruction("Measure", 0));
-  f->addInstruction(provider->createInstruction("Measure", 1));
-  acc->execute(buffer, f);
+  accelerator->execute(buffer, ir->getComposites()[0]);
   buffer->print();
+  // Expect: 1011 = 11 (decimal)
+  EXPECT_EQ(buffer->getMeasurementCounts()["1011"], 1024);
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/ibm/tests/ResetInstTester.cpp
+++ b/quantum/plugins/ibm/tests/ResetInstTester.cpp
@@ -1,0 +1,29 @@
+#include <memory>
+#include <gtest/gtest.h>
+#include "xacc.hpp"
+
+TEST(ResetInstTester,checkResetCompile) {
+auto src = R"#(
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+creg c[1];
+h q[0];
+reset q[0];
+reset q[0];
+x q[0];
+measure q[0] -> c[0];)#";
+  auto compiler = xacc::getCompiler("staq");
+  auto IR = compiler->compile(src);
+  auto hello = IR->getComposites()[0];
+  std::cout << "HELLO:\n" << hello->toString() << "\n";
+}
+
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  auto ret = RUN_ALL_TESTS();
+  xacc::Finalize();
+  return ret;
+}

--- a/quantum/plugins/ibm/tests/ResetInstTester.cpp
+++ b/quantum/plugins/ibm/tests/ResetInstTester.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 #include "xacc.hpp"
 
-TEST(ResetInstTester,checkResetCompile) {
-auto src = R"#(
+TEST(ResetInstTester, checkResetCompileStaq) {
+  auto src = R"#(
 OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[1];
@@ -17,8 +17,49 @@ measure q[0] -> c[0];)#";
   auto IR = compiler->compile(src);
   auto hello = IR->getComposites()[0];
   std::cout << "HELLO:\n" << hello->toString() << "\n";
+  EXPECT_EQ(hello->nInstructions(), 5);
+  EXPECT_EQ(hello->getInstruction(1)->name(), "Reset");
+  EXPECT_EQ(hello->getInstruction(2)->name(), "Reset");
 }
 
+TEST(ResetInstTester, checkResetCompileXasm) {
+  auto src = R"#(__qpu__ void reset_test(qbit q) {
+  H(q[0]);
+  Reset(q[0]);
+  Reset(q[0]);
+  X(q[0]);
+  Measure(q[0]);
+})#";
+  auto compiler = xacc::getCompiler("xasm");
+  auto IR = compiler->compile(src);
+  auto hello = IR->getComposites()[0];
+  std::cout << "HELLO:\n" << hello->toString() << "\n";
+  EXPECT_EQ(hello->nInstructions(), 5);
+  EXPECT_EQ(hello->getInstruction(1)->name(), "Reset");
+  EXPECT_EQ(hello->getInstruction(2)->name(), "Reset");
+}
+
+TEST(ResetInstTester, checkQobjRun) {
+  auto acc = xacc::getAccelerator("ibm:ibmq_manhattan");
+  auto src = R"#(__qpu__ void reset_run(qbit q) {
+  H(q[0]);
+  Reset(q[0]);
+  Reset(q[0]);
+  X(q[0]);
+  Measure(q[0]);
+})#";
+  auto compiler = xacc::getCompiler("xasm");
+  auto IR = compiler->compile(src);
+  auto hello = IR->getComposites()[0];
+  std::cout << "HELLO:\n" << hello->toString() << "\n";
+  xacc::set_verbose(true);
+  auto buffer = xacc::qalloc(1);
+  acc->execute(buffer, hello);
+  xacc::set_verbose(false);
+  buffer->print();
+  // Due to reset => back to 0 => become 1 after X...
+  EXPECT_TRUE(buffer->computeMeasurementProbability("1") > 0.8);
+}
 
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);

--- a/quantum/plugins/ibm/tests/ResetInstTester.cpp
+++ b/quantum/plugins/ibm/tests/ResetInstTester.cpp
@@ -39,8 +39,8 @@ TEST(ResetInstTester, checkResetCompileXasm) {
   EXPECT_EQ(hello->getInstruction(2)->name(), "Reset");
 }
 
-TEST(ResetInstTester, checkQobjRun) {
-  auto acc = xacc::getAccelerator("ibm:ibmq_manhattan");
+TEST(ResetInstTester, checkResetSim) {
+  auto acc = xacc::getAccelerator("qpp", {{"shots", 1024}});
   auto src = R"#(__qpu__ void reset_run(qbit q) {
   H(q[0]);
   Reset(q[0]);
@@ -58,8 +58,30 @@ TEST(ResetInstTester, checkQobjRun) {
   xacc::set_verbose(false);
   buffer->print();
   // Due to reset => back to 0 => become 1 after X...
-  EXPECT_TRUE(buffer->computeMeasurementProbability("1") > 0.8);
+  EXPECT_NEAR(buffer->computeMeasurementProbability("1"), 1.0, 1e-9);
 }
+
+// TEST(ResetInstTester, checkQobjRun) {
+//   auto acc = xacc::getAccelerator("ibm:ibmq_manhattan");
+//   auto src = R"#(__qpu__ void reset_run(qbit q) {
+//   H(q[0]);
+//   Reset(q[0]);
+//   Reset(q[0]);
+//   X(q[0]);
+//   Measure(q[0]);
+// })#";
+//   auto compiler = xacc::getCompiler("xasm");
+//   auto IR = compiler->compile(src);
+//   auto hello = IR->getComposites()[0];
+//   std::cout << "HELLO:\n" << hello->toString() << "\n";
+//   xacc::set_verbose(true);
+//   auto buffer = xacc::qalloc(1);
+//   acc->execute(buffer, hello);
+//   xacc::set_verbose(false);
+//   buffer->print();
+//   // Due to reset => back to 0 => become 1 after X...
+//   EXPECT_TRUE(buffer->computeMeasurementProbability("1") > 0.8);
+// }
 
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -144,18 +144,22 @@ namespace {
 
     // Helper to determine if shot count distribution can be simulated by 
     // sampling the final state vector.
-    // Requirements: measure at the very end and nothing after measure.
+    // Requirements: no reset and measure at the very end and nothing after measure.
     bool shotCountFromFinalStateVec(const std::shared_ptr<CompositeInstruction>& in_composite)
     {
         InstructionIterator it(in_composite);
         bool measureAtTheEnd = true;
         bool measureEncountered = false;
-
+        bool hasReset = false;
         while (it.hasNext())
         {
             auto nextInst = it.next();
             if (nextInst->isEnabled())
             {
+                if (nextInst->name() == "Reset") {
+                    hasReset = true;
+                }
+
                 if (isMeasureGate(nextInst))
                 {
                     // Flag that we have seen a Measure gate.
@@ -170,9 +174,9 @@ namespace {
             }
         }
 
-        // If Measure gates are at the very end,
+        // If Measure gates are at the very end and no reset,
         // this Composite can be simulated by random sampling from the state vec.
-        return measureAtTheEnd;
+        return !hasReset && measureAtTheEnd;
     }
 
     Eigen::MatrixXcd convertToEigenMat(const NoiseModelUtils::cMat& in_stdMat)

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -310,6 +310,23 @@ namespace quantum {
         // Add the measurement data to the acceleration buffer (e.g. for conditional execution branching)
         m_buffer->measure(measure.bits()[0], randomSelectedResult);        
     }
+    
+    void QppVisitor::visit(Reset& in_resetGate) 
+    {
+        if (xacc::verbose)
+        {
+            std::cout << ">> Applying Reset @ q[" << in_resetGate.bits()[0] << "] \n";
+            std::cout << ">> State before reset: " << qpp::disp(m_stateVec, ", ") << "\n";
+        }
+
+        const auto qubitIdx = xaccIdxToQppIdx(in_resetGate.bits()[0]);
+        m_stateVec = qpp::reset(m_stateVec, { qubitIdx });
+        
+        if (xacc::verbose)
+        {
+            std::cout << ">> State after reset: " << qpp::disp(m_stateVec, ", ") << "\n";
+        }
+    }
 
     void QppVisitor::visit(IfStmt& ifStmt)
     {

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -307,8 +307,19 @@ namespace quantum {
             std::cout << ">> State after measurement: " << qpp::disp(m_stateVec, ", ") << "\n";
         }
 
-        // Add the measurement data to the acceleration buffer (e.g. for conditional execution branching)
-        m_buffer->measure(measure.bits()[0], randomSelectedResult);        
+        if (measure.hasClassicalRegAssignment()) 
+        {
+          // Store the measurement to the corresponding classical buffer.
+          m_buffer->measure(measure.getBufferNames()[1],
+                            measure.getClassicalBitIndex(),
+                            randomSelectedResult);
+        } 
+        else 
+        {
+          // Add the measurement data to the acceleration buffer (e.g. for
+          // conditional execution branching)
+          m_buffer->measure(measure.bits()[0], randomSelectedResult);
+        }
     }
     
     void QppVisitor::visit(Reset& in_resetGate) 

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -52,7 +52,7 @@ public:
   void visit(IfStmt& ifStmt) override;
   void visit(iSwap& in_iSwapGate) override;
   void visit(fSim& in_fsimGate) override;
-  
+  void visit(Reset& in_resetGate) override;
   virtual std::shared_ptr<QppVisitor> clone() { return std::make_shared<QppVisitor>(); }
   const KetVectorType& getStateVec() const { return m_stateVec; }
   static double calcExpectationValueZ(const KetVectorType& in_stateVec, const std::vector<qpp::idx>& in_bits);

--- a/quantum/plugins/staq/utils/staq_visitors.hpp
+++ b/quantum/plugins/staq/utils/staq_visitors.hpp
@@ -116,7 +116,10 @@ public:
   void visit(IntExpr &) override {}
   void visit(RealExpr &r) override {}
   void visit(VarExpr &v) override {}
-  void visit(ResetStmt &) override {}
+  void visit(ResetStmt &reset) override {
+    ss << "Reset(" << reset.arg().var() << "["
+       << reset.arg().offset().value() << "]);\n";
+  }
   void visit(IfStmt &) override {}
   void visit(BarrierGate &) override {}
   void visit(GateDecl &) override {}
@@ -177,7 +180,10 @@ public:
   void visit(IntExpr &) override {}
   void visit(RealExpr &r) override {}
   void visit(VarExpr &v) override {}
-  void visit(ResetStmt &) override {}
+  void visit(ResetStmt &reset) override {
+    m_runtimeInsts.emplace_back(
+        std::make_shared<xacc::quantum::Reset>(reset.arg().offset().value()));
+  }
   void visit(IfStmt &) override {}
   void visit(BarrierGate &) override {}
   void visit(GateDecl &) override {}

--- a/quantum/plugins/xasm/xasm_listener.cpp
+++ b/quantum/plugins/xasm/xasm_listener.cpp
@@ -409,7 +409,6 @@ void XASMListener::enterBufferList(xasmParser::BufferListContext *ctx) {
         auto bit = std::stoi(bit_idx_str);
         measure_cReg = std::make_pair(name, bit);
         currentBufferNames.push_back(name);
-        std::cout << "Measure: " << name << ":" << bit << "\n";
         return;
       }
       xacc::debug("[XasmCompiler] Found parameter in buffer list. " + name,debug_predicate);

--- a/quantum/plugins/xasm/xasm_listener.cpp
+++ b/quantum/plugins/xasm/xasm_listener.cpp
@@ -393,6 +393,25 @@ void XASMListener::enterBufferList(xasmParser::BufferListContext *ctx) {
     // we assume it is a parameter
     if (!functionBufferNames.empty() &&
         !xacc::container::contains(functionBufferNames, name)) {
+
+      // Measure instructions which have explicit classical register indexing:
+      // e.g. Measure(q[0], cReg[2]);
+      if (currentInstructionName == "Measure") {
+        xacc::debug("[XasmCompiler] Found classical buffer bit in Measure gate expression.");
+
+        if (nBits > 2) {
+          xacc::error("[XasmCompiler] Illegal Measure  gate variable list. Max "
+                      "number of arguments = 2; Received " +
+                      std::to_string(nBits));
+        }
+        // TODO: support for loops...
+        auto bit_idx_str = ctx->bufferIndex(i)->idx->getText();
+        auto bit = std::stoi(bit_idx_str);
+        measure_cReg = std::make_pair(name, bit);
+        currentBufferNames.push_back(name);
+        std::cout << "Measure: " << name << ":" << bit << "\n";
+        return;
+      }
       xacc::debug("[XasmCompiler] Found parameter in buffer list. " + name,debug_predicate);
 
       // FIXME HANDLE things like x[i] or x[i+1]
@@ -436,6 +455,12 @@ void XASMListener::enterBufferList(xasmParser::BufferListContext *ctx) {
       auto bit_idx_str = ctx->bufferIndex(i)->idx->getText();
       std::size_t bit = std::stoi(bit_idx_str);
       currentBits.push_back(bit);
+      // By default, measure cReg data is uninitialized:
+      // i.e. assuming user is using the form Measure(q[0]);
+      // using an empty 
+      if (currentInstructionName == "Measure") {
+        measure_cReg = std::make_pair("", -1);
+      }
     } else {
       // this was a variable bit for a forstmt, add a -1
       currentBits.push_back(-1);
@@ -549,6 +574,11 @@ void XASMListener::exitInstruction(xasmParser::InstructionContext *ctx) {
     if_stmt->addInstruction(inst);
   } else {
     function->addInstruction(inst);
+  }
+
+  if (currentInstructionName == "Measure" && !measure_cReg.first.empty() &&
+      measure_cReg.second > 0) {
+    inst->setParameter(0, measure_cReg.second);
   }
 
   // clear all current data

--- a/quantum/plugins/xasm/xasm_listener.cpp
+++ b/quantum/plugins/xasm/xasm_listener.cpp
@@ -576,7 +576,7 @@ void XASMListener::exitInstruction(xasmParser::InstructionContext *ctx) {
   }
 
   if (currentInstructionName == "Measure" && !measure_cReg.first.empty() &&
-      measure_cReg.second > 0) {
+      measure_cReg.second >= 0) {
     inst->setParameter(0, measure_cReg.second);
   }
 

--- a/quantum/plugins/xasm/xasm_listener.hpp
+++ b/quantum/plugins/xasm/xasm_listener.hpp
@@ -45,7 +45,7 @@ protected:
   std::vector<std::string> currentBufferNames;
   std::vector<InstructionParameter> currentParameters;
   std::map<int, std::string> currentBitIdxExpressions;
-
+  std::pair<std::string, int> measure_cReg;
   std::map<std::string, int> new_var_to_vector_idx;
 
   std::string currentCompositeName;

--- a/xacc/accelerator/AcceleratorBuffer.cpp
+++ b/xacc/accelerator/AcceleratorBuffer.cpp
@@ -343,6 +343,21 @@ bool AcceleratorBuffer::operator[](const std::size_t &i) {
   return single_measurements[i];
 }
 
+bool AcceleratorBuffer::getCregValue(const std::string &cregName,
+                                     const std::size_t &i) {
+  if (cregName == bufferId) {
+    return operator[](i);
+  }
+  auto iter = cReg_to_single_measurements.find(std::make_pair(cregName, i));
+  if (iter != cReg_to_single_measurements.end()) {
+    return operator[](iter->second);
+  } else {
+    std::cout << "This creg bit " << cregName << "[" << i
+              << "] has not been assigned any value yet. Default = false.\n";
+    return false;
+  }
+}
+
 std::string
 AcceleratorBuffer::single_measurements_to_bitstring(BitOrder bitOrder,
                                                     bool shouldClear) {

--- a/xacc/accelerator/AcceleratorBuffer.cpp
+++ b/xacc/accelerator/AcceleratorBuffer.cpp
@@ -448,6 +448,33 @@ std::map<std::string, int> AcceleratorBuffer::getMeasurementCounts() {
   return bitStringToCounts;
 }
 
+std::map<std::string, int>
+AcceleratorBuffer::getMarginalCounts(const std::vector<int> &measIdxs,
+                                     BitOrder bitOrder) {
+  std::map<std::string, int> result;
+
+  const auto bitMask = [&](const std::string &bitString) {
+    std::string marginalBitString;
+    for (const auto &bit : measIdxs) {
+      if (bitOrder == BitOrder::MSB) {
+        marginalBitString.push_back(bitString[bitString.size() - bit - 1]);
+      } else {
+        marginalBitString.push_back(bitString[bit]);
+      }
+    }
+    return marginalBitString;
+  };
+  for (const auto &[bitString, count] : bitStringToCounts) {
+    auto marginalBitStr = bitMask(bitString);
+    if (result.find(marginalBitStr) != result.end()) {
+      result[marginalBitStr] += count;
+    } else {
+      result[marginalBitStr] = count;
+    }
+  }
+
+  return result;
+}
 /**
  * Print information about this AcceleratorBuffer to standard out.
  *

--- a/xacc/accelerator/AcceleratorBuffer.hpp
+++ b/xacc/accelerator/AcceleratorBuffer.hpp
@@ -189,6 +189,11 @@ public:
 
   virtual const std::vector<std::string> getMeasurements();
   virtual std::map<std::string, int> getMeasurementCounts();
+  // Get the marginal counts bitstring for a list of bit indices.
+  virtual std::map<std::string, int>
+  getMarginalCounts(const std::vector<int> &measIdxs,
+                    BitOrder bitOrder = BitOrder::MSB);
+
   virtual void clearMeasurements() {
     // measurements.clear();
     bitStringToCounts.clear();

--- a/xacc/accelerator/AcceleratorBuffer.hpp
+++ b/xacc/accelerator/AcceleratorBuffer.hpp
@@ -14,6 +14,7 @@
 #define XACC_ACCELERATOR_ACCELERATORBUFFER_HPP_
 
 #include <string>
+#include <set>
 #include <sstream>
 #include <iostream>
 #include "Utils.hpp"
@@ -126,6 +127,7 @@ protected:
   std::map<int, int> bit2IndexMap;
 
   std::map<std::size_t, bool> single_measurements;
+  std::map<std::pair<std::string, std::size_t>, std::size_t> cReg_to_single_measurements;
 
 public:
   enum BitOrder {LSB, MSB};
@@ -214,7 +216,41 @@ public:
     }
   }
 
-  void reset_single_measurements() { single_measurements.clear(); }
+  void measure(const std::string &cRegName, std::size_t bit_idx, int bit) {
+    std::size_t absBitIdx = [&]() -> std::size_t {
+      auto iter =
+          cReg_to_single_measurements.find(std::make_pair(cRegName, bit_idx));
+      if (iter != cReg_to_single_measurements.end()) {
+        return iter->second;
+      } else {
+        if (single_measurements.empty()) {
+          cReg_to_single_measurements[std::make_pair(cRegName, bit_idx)] = 0;
+          return 0;
+        } else {
+          auto nextIdx = single_measurements.rbegin()->first + 1;
+          cReg_to_single_measurements[std::make_pair(cRegName, bit_idx)] =
+              nextIdx;
+          return nextIdx;
+        }
+      }
+    }();
+
+    measure(absBitIdx, bit);
+  }
+
+  std::vector<std::string> getClassicalRegs() const {
+    std::set<std::string> cRegNames;
+    for (const auto &[cReg, measBitIdx] : cReg_to_single_measurements) {
+      cRegNames.emplace(cReg.first);
+    }
+    std::vector<std::string> result(cRegNames.begin(), cRegNames.end());
+    return result;
+  }
+
+  void reset_single_measurements() {
+    single_measurements.clear();
+    cReg_to_single_measurements.clear();
+  }
 
   std::string
   single_measurements_to_bitstring(BitOrder bitOrder = BitOrder::MSB,
@@ -226,6 +262,7 @@ public:
   virtual void load(std::istream &stream);
 
   bool operator[](const std::size_t &i);
+  bool getCregValue(const std::string &cregName, const std::size_t &i);
 
   const ExtraInfo operator[](const std::string &key) {
     return getInformation(key);

--- a/xacc/accelerator/tests/AcceleratorBufferTester.cpp
+++ b/xacc/accelerator/tests/AcceleratorBufferTester.cpp
@@ -219,6 +219,63 @@ TEST(AcceleratorBufferTester, checkEmptyParametersBug) {
 
   b.print();
 }
+
+TEST(AcceleratorBufferTester, checkMarginalCount) {
+  {
+    const std::string buffer_str = R"({
+    "AcceleratorBuffer": {
+        "name": "qreg_0x7fde3f773710",
+        "size": 2,
+        "Information": {},
+        "Measurements": {
+            "00": 499,
+            "11": 525
+        }
+    }
+    }
+  )";
+
+    AcceleratorBuffer buffer;
+    std::istringstream s(buffer_str);
+    buffer.load(s);
+    buffer.print();
+    auto marginal_count_q0 = buffer.getMarginalCounts({0});
+    auto marginal_count_q1 = buffer.getMarginalCounts({1});
+    EXPECT_EQ(marginal_count_q0["0"], marginal_count_q1["0"]);
+    EXPECT_EQ(marginal_count_q0["1"], marginal_count_q1["1"]);
+    EXPECT_EQ(marginal_count_q0["0"] + marginal_count_q0["1"], 1024);
+    EXPECT_EQ(marginal_count_q1["0"] + marginal_count_q1["1"], 1024);
+  }
+
+  {
+    const std::string buffer_str = R"({
+    "AcceleratorBuffer": {
+        "name": "qreg_0x7fde3f773710",
+        "size": 3,
+        "Information": {},
+        "Measurements": {
+            "001": 499,
+            "111": 525
+        }
+    }
+    }
+  )";
+
+    AcceleratorBuffer buffer;
+    std::istringstream s(buffer_str);
+    buffer.load(s);
+    buffer.print();
+    auto marginal_count_q0 = buffer.getMarginalCounts({0});
+    auto marginal_count_q1q2 = buffer.getMarginalCounts({1, 2});
+    EXPECT_EQ(marginal_count_q0.size(), 1);
+    EXPECT_EQ(marginal_count_q0["1"], 1024);
+    EXPECT_EQ(marginal_count_q1q2.size(), 2);
+
+    EXPECT_EQ(marginal_count_q1q2["00"], 499);
+    EXPECT_EQ(marginal_count_q1q2["11"], 525);
+  }
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -206,6 +206,22 @@ std::shared_ptr<AcceleratorBuffer> getBuffer(const std::string &name) {
 bool hasBuffer(const std::string &name) {
   return allocated_buffers.count(name);
 }
+std::shared_ptr<AcceleratorBuffer>
+getClassicalRegHostBuffer(const std::string &cRegName) {
+  if (hasBuffer(cRegName)) {
+    return getBuffer(cRegName);
+  }
+
+  for (auto &[bufferName, allocated_buffer] : allocated_buffers) {
+    if (xacc::container::contains(allocated_buffer->getClassicalRegs(),
+                                  cRegName)) {
+      return allocated_buffer;
+    }
+  }
+
+  error("Invalid classical register name: " + cRegName);
+  return nullptr;
+}
 
 void addCommandLineOption(const std::string &optionName,
                           const std::string &optionDescription) {

--- a/xacc/xacc.hpp
+++ b/xacc/xacc.hpp
@@ -130,6 +130,8 @@ void storeBuffer(const std::string name,
                  std::shared_ptr<AcceleratorBuffer> buffer);
 std::shared_ptr<AcceleratorBuffer> getBuffer(const std::string &name);
 bool hasBuffer(const std::string &name);
+std::shared_ptr<AcceleratorBuffer>
+getClassicalRegHostBuffer(const std::string &cRegName);
 
 void setAccelerator(const std::string &acceleratorName);
 std::shared_ptr<Accelerator>


### PR DESCRIPTION
- Support new the Reset instruction (IBM `reset`).

- Add support for marginal count to analyze multi-measurement bitcount.

- Enhance Measure and IfStmt to handle generic classical register bit reference. 

- Support QObj and runtime IfStmt with custom classical register bit reference.

- Add tests and examples.