### PR TITLE
Added ability to specify noise on Id gates

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -287,8 +287,11 @@ void AerAccelerator::execute(
         measured_bits.push_back(next->bits()[0]);
       }
     }
-    auto qobj_str = xacc_to_qobj->translate(tmp);
+    // In "density_matrix" simulation mode, always include Id gates
+    // if they are explicitly added to the Composite.
+    auto qobj_str = xacc_to_qobj->translate(tmp, {{"skip-id-gates", false}});
     nlohmann::json j = nlohmann::json::parse(qobj_str)["qObject"];
+    xacc::info("Qobj:\n" + j.dump());
     j["config"]["noise_model"] = noise_model;
     j["config"]["method"] = "density_matrix";
     auto snapshotInst = nlohmann::json::object();
@@ -725,8 +728,8 @@ std::string IbmqNoiseModel::toJson() const {
     // For mapping purposes:
     // U2 == Hadamard gate
     // U3 == X gate
-    Hadamard gateU2({qIdx});
-    X gateU3({qIdx});
+    Hadamard gateU2(qIdx);
+    X gateU3(qIdx);
     const std::unordered_map<std::string, xacc::quantum::Gate *> gateMap{
         {"u2", &gateU2}, {"u3", &gateU3}};
 

--- a/quantum/plugins/ibm/compiler/QObjectCompiler.hpp
+++ b/quantum/plugins/ibm/compiler/QObjectCompiler.hpp
@@ -28,7 +28,8 @@ public:
   std::shared_ptr<xacc::IR> compile(const std::string &src) override;
 
   const std::string translate(std::shared_ptr<CompositeInstruction> function) override;
-
+  const std::string translate(std::shared_ptr<CompositeInstruction> function,
+                              HeterogeneousMap &options) override;
   const std::string name() const override { return "qobj"; }
   const std::string description() const override {
     return "The QObject Compiler compiles an IBM QObject (represented as a "

--- a/quantum/plugins/noise_model/noise_model.cpp
+++ b/quantum/plugins/noise_model/noise_model.cpp
@@ -233,10 +233,11 @@ public:
       // For mapping purposes:
       // U2 == Hadamard gate
       // U3 == X gate
-      xacc::quantum::Hadamard gateU2({qIdx});
-      xacc::quantum::X gateU3({qIdx});
+      xacc::quantum::Hadamard gateU2(qIdx);
+      xacc::quantum::X gateU3(qIdx);
+      xacc::quantum::Identity gateId(qIdx);
       const std::unordered_map<std::string, xacc::quantum::Gate *> gateMap{
-          {"u2", &gateU2}, {"u3", &gateU3}};
+          {"u2", &gateU2}, {"u3", &gateU3}, {"id", &gateId}};
 
       for (const auto &[gateName, gate] : gateMap) {
         const auto errorChannels = getNoiseChannels(*gate);
@@ -336,7 +337,7 @@ public:
   }
 
   virtual std::vector<NoiseChannelKraus>
-  getNoiseChannels(xacc::quantum::Gate &gate) const {
+  getNoiseChannels(xacc::quantum::Gate &gate) const override {
     std::string gateKey = gate.name() + "_" + std::to_string(gate.bits()[0]);
     if (gate.bits().size() > 1) {
       for (int i = 1; i < gate.bits().size(); ++i) {

--- a/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
+++ b/quantum/plugins/noise_model/tests/JsonNoiseModelTester.cpp
@@ -28,6 +28,9 @@ const std::string ro_error_noise_model =
 // Testing to IBM JSON conversion whereby the noise qubit indexing is relative.
 const std::string depol_json_2q =
     R"({"gate_noise": [{"gate_name": "H", "register_location": ["0"], "noise_channels": [{"matrix": [[[[0.999499874937461, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.999499874937461, 0.0]]], [[[0.0, 0.0], [0.018257418583505537, 0.0]], [[0.018257418583505537, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.018257418583505537]], [[0.0, 0.018257418583505537], [0.0, 0.0]]], [[[0.018257418583505537, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.018257418583505537, 0.0]]]]}]}, {"gate_name": "H", "register_location": ["1"], "noise_channels": [{"matrix": [[[[0.999499874937461, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.999499874937461, 0.0]]], [[[0.0, 0.0], [0.018257418583505537, 0.0]], [[0.018257418583505537, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.018257418583505537]], [[0.0, 0.018257418583505537], [0.0, 0.0]]], [[[0.018257418583505537, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.018257418583505537, 0.0]]]]}]}], "bit_order": "MSB"})";
+
+const std::string depol_json_id =
+    R"({"gate_noise": [{"gate_name": "I", "register_location": ["0"], "noise_channels": [{"matrix": [[[[0.99498743710662, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.99498743710662, 0.0]]], [[[0.0, 0.0], [0.05773502691896258, 0.0]], [[0.05773502691896258, 0.0], [0.0, 0.0]]], [[[0.0, 0.0], [0.0, -0.05773502691896258]], [[0.0, 0.05773502691896258], [0.0, 0.0]]], [[[0.05773502691896258, 0.0], [0.0, 0.0]], [[0.0, 0.0], [-0.05773502691896258, 0.0]]]]}]}], "bit_order": "MSB"})";
 } // namespace
 
 TEST(JsonNoiseModelTester, checkSimple) {
@@ -346,6 +349,63 @@ TEST(JsonNoiseModelTester, testVqe) {
 
   // Expected result: -1.74886
   EXPECT_NEAR((*buffer)["opt-val"].as<double>(), -1.74886, 0.1);
+}
+
+TEST(JsonNoiseModelTester, checkIdNoise) {
+  xacc::set_verbose(true);
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void testRzz(qbit q) {
+        H(q[0]);
+        H(q[1]);
+        CX(q[0], q[1]);
+        Rz(q[1], pi/2);   
+        CX(q[0], q[1]);
+        I(q[0]);
+        I(q[1]);
+      })");
+  auto program = ir->getComposites()[0];
+  std::cout << "HOWDY: \n" << program->toString() << "\n";
+  // Test no noise
+  {
+    auto accelerator =
+        xacc::getAccelerator("aer", {{"sim-type", "density_matrix"}});
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    auto densityMatrix = (*buffer)["density_matrix"]
+                             .as<std::vector<std::pair<double, double>>>();
+    for (int row = 0; row < 4; ++row) {
+      for (int col = 0; col < 4; ++col) {
+        const int idx = row * 4 + col;
+        std::cout << "(" << densityMatrix[idx].first << ", "
+                  << densityMatrix[idx].second << ") ";
+      }
+      std::cout << "\n";
+    }
+  }
+
+  // Test with noise in Id gates
+  {
+    auto noiseModel = xacc::getService<xacc::NoiseModel>("json");
+    noiseModel->initialize({{"noise-model", depol_json_id}});
+    const std::string ibmNoiseJson = noiseModel->toJson();
+    std::cout << "IBM Equiv: \n" << ibmNoiseJson << "\n";
+    auto accelerator = xacc::getAccelerator(
+        "aer", {{"noise-model", ibmNoiseJson}, {"sim-type", "density_matrix"}});
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, program);
+    buffer->print();
+    auto densityMatrix = (*buffer)["density_matrix"]
+                             .as<std::vector<std::pair<double, double>>>();
+    for (int row = 0; row < 4; ++row) {
+      for (int col = 0; col < 4; ++col) {
+        const int idx = row * 4 + col;
+        std::cout << "(" << densityMatrix[idx].first << ", "
+                  << densityMatrix[idx].second << ") ";
+      }
+      std::cout << "\n";
+    }
+  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
- QObj generator can *optionally* include id instructions when visiting Identity gates.

- Aer accelerator to turn on this option when simulating noisy circuits in density matrix mode.

- Noise model converter (to IBM format) also looks for Identity gate and adds a corresponding IBM noise term.

