### PR TITLE
Better Qrack 'layer' selection; remove deprecated 'min_norm'

### DIFF
--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
@@ -45,6 +45,11 @@ namespace quantum {
             m_use_opencl_multi = params.get<bool>("use_opencl_multi");
         }
 
+        if (params.keyExists<bool>("use_stabilizer"))
+        {
+            m_use_stabilizer = params.get<bool>("use_stabilizer");
+        }
+
         if (params.keyExists<int>("device_id"))
         {
             m_device_id = params.get<int>("device_id");
@@ -106,7 +111,7 @@ namespace quantum {
         }
 
         const auto runCircuit = [&](int shots){
-            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_opencl_multi, m_device_id, m_do_normalize, m_zero_threshold);
+            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_opencl_multi, m_use_stabilizer, m_device_id, m_do_normalize, m_zero_threshold);
 
             // Walk the IR tree, and visit each node
             InstructionIterator it(compositeInstruction);

--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
@@ -37,8 +37,9 @@ private:
     bool m_use_opencl = true;
     bool m_use_qunit = true;
     bool m_use_opencl_multi = false;
+    bool m_use_stabilizer = true;
     int m_device_id = -1;
-    bool m_do_normalize = true;
-    double m_zero_threshold = min_norm;
+    bool m_do_normalize = false;
+    double m_zero_threshold = REAL1_EPSILON;
 };
 }}

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
@@ -15,19 +15,27 @@
 #include "QrackVisitor.hpp"
 #include "xacc.hpp"
 
-#define MAKE_ENGINE(num_qubits, perm) Qrack::CreateQuantumInterface(qIType1, qIType2, num_qubits, perm, nullptr, Qrack::CMPLX_DEFAULT_ARG, doNormalize, false, false, device_id, true, zero_threshold)
+#define MAKE_ENGINE(num_qubits, perm) Qrack::CreateQuantumInterface(qIType1, qIType2, qIType3, num_qubits, perm, nullptr, Qrack::CMPLX_DEFAULT_ARG, doNormalize, false, false, device_id, true, zero_threshold)
 
 namespace xacc {
 namespace quantum {
-    void QrackVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, int device_id, bool doNormalize, double zero_threshold)
+    void QrackVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, bool use_stabilizer, int device_id, bool doNormalize, double zero_threshold)
     {
         m_buffer = std::move(buffer);
         m_measureBits.clear();
         m_shots = shots;
         m_shotsMode = shots > 1;
 
-        Qrack::QInterfaceEngine qIType2 = use_opencl ? Qrack::QINTERFACE_OPTIMAL : Qrack::QINTERFACE_CPU;
-        Qrack::QInterfaceEngine qIType1 = use_qunit ? (use_opencl_multi ? Qrack::QINTERFACE_QUNIT_MULTI : Qrack::QINTERFACE_QUNIT) : qIType2;
+        Qrack::QInterfaceEngine qIType1, qIType2, qIType3;
+        if (use_qunit) {
+            qIType1 = use_opencl_multi ? Qrack::QINTERFACE_QUNIT_MULTI : Qrack::QINTERFACE_QUNIT;
+            qIType2 = use_stabilizer ? Qrack::QINTERFACE_STABILIZER_HYBRID : Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER;
+            qIType3 = use_opencl ? (use_stabilizer ? Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER : Qrack::QINTERFACE_OPTIMAL_SINGLE_PAGE ) : Qrack::QINTERFACE_CPU;
+        } else {
+            qIType1 = use_stabilizer ? Qrack::QINTERFACE_STABILIZER_HYBRID : Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER;
+            qIType2 = use_opencl ? (use_stabilizer ? Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER : Qrack::QINTERFACE_OPTIMAL_SINGLE_PAGE) : Qrack::QINTERFACE_CPU;
+            qIType3 = Qrack::QINTERFACE_OPTIMAL_SINGLE_PAGE;
+        }
 
         m_qReg = MAKE_ENGINE(m_buffer->size(), 0);
     }

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
@@ -29,10 +29,10 @@ namespace quantum {
         Qrack::QInterfaceEngine qIType1, qIType2, qIType3;
         if (use_qunit) {
             qIType1 = use_opencl_multi ? Qrack::QINTERFACE_QUNIT_MULTI : Qrack::QINTERFACE_QUNIT;
-            qIType2 = use_stabilizer ? Qrack::QINTERFACE_STABILIZER_HYBRID : Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER;
+            qIType2 = use_stabilizer ? Qrack::QINTERFACE_STABILIZER_HYBRID : (use_opencl ? Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER : Qrack::QINTERFACE_CPU);
             qIType3 = use_opencl ? (use_stabilizer ? Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER : Qrack::QINTERFACE_OPTIMAL_SINGLE_PAGE ) : Qrack::QINTERFACE_CPU;
         } else {
-            qIType1 = use_stabilizer ? Qrack::QINTERFACE_STABILIZER_HYBRID : Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER;
+            qIType1 = use_stabilizer ? Qrack::QINTERFACE_STABILIZER_HYBRID : (use_opencl ? Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER : Qrack::QINTERFACE_CPU);
             qIType2 = use_opencl ? (use_stabilizer ? Qrack::QINTERFACE_OPTIMAL_SCHROEDINGER : Qrack::QINTERFACE_OPTIMAL_SINGLE_PAGE) : Qrack::QINTERFACE_CPU;
             qIType3 = Qrack::QINTERFACE_OPTIMAL_SINGLE_PAGE;
         }

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
@@ -34,7 +34,7 @@ namespace xacc {
 namespace quantum {
 class QrackVisitor : public AllGateVisitor, public OptionsProvider, public xacc::Cloneable<QrackVisitor> {
 public:
-  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, int device_id, bool doNormalize, double zero_threshold);
+  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, bool use_stabilizer, int device_id, bool doNormalize, double zero_threshold);
   void finalize();
 
   void visit(Hadamard& h) override;


### PR DESCRIPTION
Signed-off-by: WrathfulSpatula <stranoj@gmail.com>

I hope people have found use for the Qrack plugin in XACC! I noticed that recent API changes broke our support. The `min_norm` limit has been replaced by `REAL1_EPSILON`, for this purpose, and new Qrack "layers" are available, which should be possible to switch out in XACC. Also, `doNormalize` is no longer on by default in the Qrack library, and this feature should be off by default.

I haven't benchmarked the new Qrack "layers" operating under the XACC plugin, but I should mention that, with OpenCL enabled, the speed improvement from the new "layers" could be in excess of 30 times. Also, on NVIDIA cards, this will typically allow an additional 2 qubits in maximum width for a coherent width of qubits, because we now segment state vector allocation across all 4 maximum allocation segments typical of NVIDIA cards, letting the maximum state vector be 4 times larger.