### PR TITLE
Fix a potential race condition during Python shutdown

### DIFF
--- a/python/xacc.py
+++ b/python/xacc.py
@@ -279,9 +279,7 @@ class qpu(object):
 
 class PyServiceRegistry(object):
     def __init__(self):
-        self.framework = pelix.framework.create_framework((
-            "pelix.ipopo.core",
-            "pelix.shell.console"))
+        self.framework = pelix.framework.create_framework(["pelix.ipopo.core"])
         self.framework.start()
         self.context = self.framework.get_bundle_context()
         self.registry = {}
@@ -500,6 +498,11 @@ loaded_from_cpp_dont_finalize = False
 
 def _finalize():
     if not loaded_from_cpp_dont_finalize:
+        # Stop the Pelix framework:
+        # cleaning up all Python threads that it has started.
+        serviceRegistry.framework.stop()  
+        # Wait for the framework to stop
+        serviceRegistry.framework.wait_for_stop()
         Finalize()
 
 atexit.register(_finalize)

--- a/quantum/plugins/algorithms/ml/ddcl/python/wrappedDDCL.py
+++ b/quantum/plugins/algorithms/ml/ddcl/python/wrappedDDCL.py
@@ -25,7 +25,7 @@ class WrappedDDCLF(xacc.DecoratorFunction):
     def unbind_optimizers(self, field, service, svc_ref):
         if svc_ref.get_property('vqe_optimizer'):
             optimizer = svc_ref.get_property('vqe_optimizer')
-            del vqe_optimizers[optimizer]
+            del self.vqe_optimizers[optimizer]
 
     def __call__(self, *args, **kwargs):
         super().__call__(*args, **kwargs)


### PR DESCRIPTION
The pelix library uses Python threading and can cause random segfault during main interpreter thread shutdown.

The behavior is that it finishes the script, e.g. a Python test, then crashes with a SEGFAULT.
This can be reproduced by running the tests many times. Typically, the Pelix shell console thread is involved, e.g.
```
Current thread 0x00007f592b497700 (most recent call first):
  File "/usr/lib/python3.8/threading.py", line 306 in wait
  File "/usr/lib/python3.8/threading.py", line 558 in wait
  File "/usr/local/lib/python3.8/dist-packages/pelix/shell/console.py", line 209 in _run_loop
  File "/usr/local/lib/python3.8/dist-packages/pelix/shell/console.py", line 165 in loop_input
 ``` 

Fixes are:

- Don't use `pelix.shell.console` bundle since we don't need it.
Looks like it creates a long-running thread which may cause race condition (with the main Python thread) during shut-down.

- Explicitly stop the pelix framework during finalize before the interpreter thread terminates.

- Fixed a bug in WrappedDDCLF plugin, missing `self.`, causing a Python error on clean shut-down.

Tested by: running QCOR Python tests in a loop.