### PR TITLE
Remote IBM Accelerator is using an invalid defaultPlacementTransformation

### DIFF
--- a/quantum/gate/ir/Gate.cpp
+++ b/quantum/gate/ir/Gate.cpp
@@ -52,6 +52,11 @@ const std::vector<std::size_t> Gate::bits() { return qbits; }
 
 void Gate::mapBits(std::vector<std::size_t> bitMap) {
   for (int i = 0; i < qbits.size(); i++) {
+    if (qbits[i] >= bitMap.size()) {
+      xacc::error("Invalid bit mapping for instruction: " + name() +
+                  ", bit operand = " + std::to_string(qbits[i]) +
+                  ", bit map size = " + std::to_string(bitMap.size()));
+    }
     qbits[i] = bitMap[qbits[i]];
   }
 }

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -128,7 +128,7 @@ public:
   // Return the name of an IRTransformation of type Placement that is
   // preferred for this Accelerator
   const std::string defaultPlacementTransformation() override {
-    return "default-placement";
+    return "swap-shortest-path";
   }
 
   const std::string name() const override { return "ibm"; }


### PR DESCRIPTION
QCOR relies on `defaultPlacementTransformation` to select placement plugin, but IBM is using an invalid one.
(`default-placement` needs an explicit map)

Also, add an error message to Gate::mapBits to catch these mapping errors, rather than SEGFAULT on out-of-range indexing.

