### PR TITLE
Qpp to handle FTQC buffer size change

### DIFF
--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -372,8 +372,22 @@ namespace quantum {
     {
         if (!m_visitor->isInitialized()) {
             m_visitor->initialize(buffer);
+            m_currentBuffer = std::make_pair(buffer.get(), buffer->size());
         }
-        
+
+        if (buffer.get() == m_currentBuffer.first &&
+            buffer->size() != m_currentBuffer.second) {
+            if (buffer->size() > m_currentBuffer.second) {
+                const auto nbQubitsToAlloc = buffer->size() - m_currentBuffer.second;
+                // std::cout << "Allocate " << nbQubitsToAlloc << " qubits.\n";
+                m_visitor->allocateQubits(nbQubitsToAlloc);
+                m_currentBuffer.second = buffer->size();
+            }
+            else {
+                xacc::error("Qubits deallocation is not supported.");
+            }
+        }
+
         if (inst->isComposite() || inst->isAnalog())
         {
             xacc::error("Only gates are allowed.");

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -48,6 +48,7 @@ public:
     bool m_vqeMode;
     std::vector<std::pair<int,int>> m_connectivity;
     xacc::HeterogeneousMap m_executionInfo;
+    std::pair<AcceleratorBuffer*, size_t> m_currentBuffer;
 };
 
 class DefaultNoiseModelUtils : public NoiseModelUtils 

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -424,7 +424,7 @@ namespace quantum {
         }
         const std::vector<qpp::idx> initialState(in_nbQubits, 0);
         auto new_stateVec = qpp::mket(initialState);
-        m_stateVec = qpp::kron(m_stateVec, new_stateVec);
+        m_stateVec = qpp::kron(new_stateVec, m_stateVec);
         const std::vector<qpp::idx> new_dims(in_nbQubits, 2);
         m_dims.insert(m_dims.end(), new_dims.begin(), new_dims.end());
         if (xacc::verbose)

--- a/quantum/plugins/qpp/accelerator/QppVisitor.cpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.cpp
@@ -413,4 +413,23 @@ namespace quantum {
         m_stateVec = cachedStateVec;
         return result;
     }
+
+    void QppVisitor::allocateQubits(size_t in_nbQubits) 
+    {
+        assert(in_nbQubits > 0);
+        if (xacc::verbose)
+        {
+            std::cout << ">> Allocate : " << in_nbQubits << " qubits.\n";
+            std::cout << ">> State before allocate: " << qpp::disp(m_stateVec, ", ") << "\n";
+        }
+        const std::vector<qpp::idx> initialState(in_nbQubits, 0);
+        auto new_stateVec = qpp::mket(initialState);
+        m_stateVec = qpp::kron(m_stateVec, new_stateVec);
+        const std::vector<qpp::idx> new_dims(in_nbQubits, 2);
+        m_dims.insert(m_dims.end(), new_dims.begin(), new_dims.end());
+        if (xacc::verbose)
+        {
+            std::cout << ">> State after allocate: " << qpp::disp(m_stateVec, ", ") << "\n";
+        }
+    }
 }}

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -53,15 +53,17 @@ public:
   void visit(iSwap& in_iSwapGate) override;
   void visit(fSim& in_fsimGate) override;
   void visit(Reset& in_resetGate) override;
-  virtual std::shared_ptr<QppVisitor> clone() { return std::make_shared<QppVisitor>(); }
+  virtual std::shared_ptr<QppVisitor> clone() override { return std::make_shared<QppVisitor>(); }
   const KetVectorType& getStateVec() const { return m_stateVec; }
   static double calcExpectationValueZ(const KetVectorType& in_stateVec, const std::vector<qpp::idx>& in_bits);
   double getExpectationValueZ(std::shared_ptr<CompositeInstruction> in_composite);
 
-  // Gate-by-gate API
+  // Gate-by-gate API (FTQC)
   void applyGate(Gate& in_gate);
   bool measure(size_t in_bit);
   bool isInitialized() const { return m_initialized; }
+  // Allocate more qubits (zero state)
+  void allocateQubits(size_t in_nbQubits);
 private:
   qpp::idx xaccIdxToQppIdx(size_t in_idx) const;
 private:


### PR DESCRIPTION
In FTQC's `apply()` method, check for buffer size change and allocate new qubits accordingly.
 