### PR TITLE
implementing qaoa simplified and var_assignment modes

### DIFF
--- a/quantum/plugins/algorithms/qaoa/qaoa.cpp
+++ b/quantum/plugins/algorithms/qaoa/qaoa.cpp
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *   Thien Nguyen - initial API and implementation
+ *   Milos Prokop - variable assignment mode
  *******************************************************************************/
 
 #include "qaoa.hpp"
@@ -28,6 +29,7 @@ namespace xacc {
 namespace algorithm {
 
 bool QAOA::initialize(const HeterogeneousMap &parameters) {
+
   bool initializeOk = true;
   // Hyper-parameters for QAOA:
   // (1) Accelerator (QPU)
@@ -59,6 +61,26 @@ bool QAOA::initialize(const HeterogeneousMap &parameters) {
   m_parameterizedMode = "Extended";
   if (parameters.stringExists("parameter-scheme")) {
     m_parameterizedMode = parameters.getString("parameter-scheme");
+  }
+
+  // Determine the optimal variable assignment of the QUBO problem
+  // If false, only optimal value is returned
+  m_varAssignmentMode = false;
+  if (parameters.keyExists<bool>("calc-var-assignment")) {
+	  m_varAssignmentMode = parameters.get<bool>("calc-var-assignment");
+  }
+
+  m_simplifiedSimulationMode = false;
+  if (parameters.keyExists<bool>("simplified-simulation")) {
+	  m_simplifiedSimulationMode = parameters.get<bool>("simplified-simulation");
+    }
+
+  if(m_varAssignmentMode){
+
+	nbSamples = 1024;
+	if(parameters.keyExists<int>("nbSamples"))
+		nbSamples = parameters.get<int>("nbSamples");
+
   }
 
   if (initializeOk) {
@@ -125,6 +147,56 @@ const std::vector<std::string> QAOA::requiredParameters() const {
   return {"accelerator", "optimizer", "observable"};
 }
 
+double QAOA::evaluate_assignment(xacc::Observable* const observable, std::string measurement) const{
+
+	double result =	observable->getIdentitySubTerm()->coefficient().real();
+	for(auto &term: observable->getNonIdentitySubTerms()){
+
+		double coeff = term->coefficient().real(); //get the real part, imag expected to be 0
+
+		//parse to get hamiltonian terms
+		std::string term_str = term->toString();
+		std::vector<int> qubit_indices;
+
+		char z_coeff[6]; // Number of ciphers in qubit index are expected to fit here.
+		int z_index = 0;
+
+		int term_i = 0;
+
+		for(size_t i = term_str.length()-1; i > 0; --i){
+
+			char c = term_str[i];
+			if(isdigit(c))
+				z_coeff[5-z_index++] = c;
+			else if(c == 'Z'){
+				int val = 0;
+				for(; z_index>0; --z_index){
+					val += pow(10, z_index-1) * (z_coeff[5-z_index+1] - '0');
+				}
+
+				qubit_indices.push_back(val);
+				z_index = 0;
+
+			}
+			else if(c == ' '){
+				if(++term_i == 2)
+					break;
+			}
+			else{
+				break;
+			}
+		}
+
+		int multiplier = 1;
+		for(auto &qubit_index: qubit_indices)
+			multiplier *= (measurement[qubit_index] == '0') ? 1 : -1;
+
+		result += multiplier * coeff;
+	}
+
+	return result;
+}
+
 void QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
   const int nbQubits = buffer->size();
   // we need this for ADAPT-QAOA (Daniel)
@@ -146,8 +218,36 @@ void QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       kernel->expand(m);
   } 
 
+  std::vector<std::shared_ptr<CompositeInstruction>> kernels;
+
   // Observe the cost Hamiltonian:
-  auto kernels = m_costHamObs->observe(kernel);
+
+  if(!m_simplifiedSimulationMode){
+	  kernels = m_costHamObs->observe(kernel);
+  }
+  else{
+
+	  auto gateRegistry = xacc::getService<IRProvider>("quantum");
+	  auto gateFunction = gateRegistry->createComposite("blank", kernel->getVariables());
+
+	  gateFunction->setCoefficient(1.);
+
+	  if (kernel->hasChildren()) {
+		gateFunction->addInstruction(kernel->clone());
+	  }
+
+	  for (auto arg : kernel->getArguments()) {
+		gateFunction->addArgument(arg, 0);
+	  }
+
+	  std::vector<size_t> indices;
+	  for(size_t qbit_index=0; qbit_index < nbQubits; ++qbit_index){
+	    indices.push_back(qbit_index);
+	  }
+	  gateFunction->addInstruction(gateRegistry->createInstruction("Measure", indices));
+
+	  kernels.push_back(gateFunction);
+  }
 
   int iterCount = 0;
   // Construct the optimizer/minimizer:
@@ -278,8 +378,78 @@ void QAOA::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
   // Reports the final cost:
   double finalCost = result.first;
   if (m_maximize) finalCost *= -1.0;
-  buffer->addExtraInfo("opt-val", ExtraInfo(finalCost));
-  buffer->addExtraInfo("opt-params", ExtraInfo(result.second));
+
+  if(m_varAssignmentMode){
+
+	  typedef std::pair<int, double> meas_freq_eval;
+	  typedef std::pair<std::string, meas_freq_eval> measurement;
+
+	  auto provider = xacc::getIRProvider("quantum");
+	  auto evaled = kernel->operator()(result.second);
+	  m_qpu->updateShotsNumber(nbSamples);
+
+	  std::vector<size_t> indices;
+	  for(size_t i=0; i < nbQubits; ++i){
+		  indices.push_back(i);
+	  }
+
+	  auto meas = provider->createInstruction("Measure", indices);
+	  evaled->addInstructions({meas});
+
+	  m_qpu->execute(buffer, evaled);
+	  std::vector<measurement> measurements;
+
+	  for(std::pair<std::string, int> meas : buffer->getMeasurementCounts()){
+
+		  bool found = false;
+		  for(auto &instance : measurements)
+			  if(instance.first == meas.first){
+				  found = true;
+				  break;
+			  }
+
+		  if(!found){
+			  measurements.push_back(measurement(meas.first, // bit string
+					  	  	  	  	  meas_freq_eval(meas.second, //frequency
+					  	  	  	  			  evaluate_assignment(m_costHamObs, meas.first))));
+		  }
+	  }
+
+	  if(m_maximize)
+		  std::sort(measurements.begin(), measurements.end(),
+			  [](const std::pair<std::string, std::pair<int, double>>& a, const std::pair<std::string, std::pair<int,int>>& b) {
+				  //sort by global value
+				  return a.second.second > b.second.second;
+	      });
+
+	  else
+		  std::sort(measurements.begin(), measurements.end(),
+			  [](const std::pair<std::string, std::pair<int, double>>& a, const std::pair<std::string, std::pair<int,int>>& b) {
+		          //sort by global value
+		  	  	  return a.second.second < b.second.second;
+	  });
+
+	  double optimal_value = measurements[0].second.second;
+	  std::string opt_config = measurements[0].first;
+
+	  int i = 0;
+	  int hits;
+	  while(i < measurements.size() && abs(measurements[i++].second.second - optimal_value)<10e-1){
+		  hits += measurements[i-1].second.first;
+	  }
+
+	  double hit_rate = hits / double(nbSamples);
+
+	  buffer->addExtraInfo("opt-val", ExtraInfo(optimal_value));
+	  buffer->addExtraInfo("opt-config", opt_config);
+	  buffer->addExtraInfo("hit_rate: ", ExtraInfo(hit_rate));
+	  buffer->addExtraInfo("opt-params", ExtraInfo(result.second));
+
+  }else{
+	  buffer->addExtraInfo("opt-val", ExtraInfo(finalCost));
+	  buffer->addExtraInfo("opt-params", ExtraInfo(result.second));
+  }
+
 }
 
 std::vector<double>

--- a/quantum/plugins/algorithms/qaoa/qaoa.hpp
+++ b/quantum/plugins/algorithms/qaoa/qaoa.hpp
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *   Thien Nguyen - initial API and implementation
+ *   Milos Prokop - variable assignment mode
  *******************************************************************************/
 #pragma once
 
@@ -22,12 +23,13 @@ namespace algorithm {
 class QAOA : public Algorithm 
 {
 public:
-    bool initialize(const HeterogeneousMap& parameters) override;
+    virtual bool initialize(const HeterogeneousMap& parameters) override;
     const std::vector<std::string> requiredParameters() const override;
     void execute(const std::shared_ptr<AcceleratorBuffer> buffer) const override;
     std::vector<double> execute(const std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<double> &parameters) override;
     const std::string name() const override { return "QAOA"; }
     const std::string description() const override { return ""; }
+
     DEFINE_ALGORITHM_CLONE(QAOA)
 private:
     Observable* m_costHamObs;
@@ -37,10 +39,16 @@ private:
     std::shared_ptr<AlgorithmGradientStrategy> gradientStrategy;
     std::shared_ptr<CompositeInstruction> externalAnsatz;
     std::shared_ptr<CompositeInstruction> m_single_exec_kernel;
+
+    double evaluate_assignment(xacc::Observable* const observable, std::string measurement) const;
     int m_nbSteps;
+    int nbSamples = 1024;
     std::string m_parameterizedMode;
     bool m_maximize = false;
+    bool m_varAssignmentMode = false;
+    bool m_simplifiedSimulationMode = false;
     CompositeInstruction* m_initial_state;
+
 };
 } // namespace algorithm
 } // namespace xacc

--- a/quantum/plugins/algorithms/qaoa/tests/QAOATester.cpp
+++ b/quantum/plugins/algorithms/qaoa/tests/QAOATester.cpp
@@ -9,10 +9,12 @@
  *
  * Contributors:
  *   Thien Nguyen - initial API and implementation
+ *   Milos Prokop - test evaluate_assignment
  *******************************************************************************/
 #include <random>
 #include <gtest/gtest.h>
 
+#include "../qaoa.hpp"
 #include "xacc.hpp"
 #include "Algorithm.hpp"
 #include "Observable.hpp"
@@ -70,7 +72,95 @@ TEST(QAOATester, checkStandardParamterizedScheme) {
   EXPECT_LT((*buffer)["opt-val"].as<double>(), -1.58);
 }
 
-// Generate rando
+TEST(QAOATester, check_evaluate_assignment) {
+
+	//
+	// Tests the QAOA::evaluate_assignment function. The parameters of QAOA are deliberately very UNperformant such that the resulting state will not be far from initial state
+	// and hence after many shots we expect to get all possible assignments.
+	//
+
+	const int num_qubits = 3;
+	const int num_terms = 7;
+	std::string hamiltonian[num_terms][3] = {{ "-5",   "",   ""},
+											 {  "2", "Z0",   ""},
+											 {  "3", "Z1",   ""},
+											 { "-1", "Z2",   ""},
+											 { "-4", "Z0", "Z1"},
+											 {  "7", "Z1", "Z2"},
+											 {"0.4", "Z0", "Z2"}
+								   	   	    };
+
+	std::string hamiltonian_str = hamiltonian[0][0] + " ";
+	for(size_t i = 1; i < num_terms; ++i){
+
+		hamiltonian_str += "+ ";
+
+		for(size_t i2 = 0; i2 < 3; i2++)
+			hamiltonian_str += hamiltonian[i][i2] + " ";
+
+	}
+
+	auto acc = xacc::getAccelerator("qpp", {std::make_pair("shots", 50)});
+	auto buffer = xacc::qalloc(num_qubits);
+	auto observable = xacc::quantum::getObservable("pauli", hamiltonian_str);
+
+	const int nbParams = observable -> getNonIdentitySubTerms().size() + observable->nBits();;
+	std::vector<double> initialParams;
+
+	// Init random parameters
+	for (int i = 0; i < nbParams; ++i)
+	{
+	  initialParams.emplace_back(0);
+	}
+
+	auto optimizer = xacc::getOptimizer("nlopt",
+	  xacc::HeterogeneousMap {
+		 std::make_pair("initial-parameters", initialParams),
+		 std::make_pair("nlopt-maxeval", 1) });
+
+		auto qaoa = xacc::getService<xacc::Algorithm>("QAOA");
+		qaoa->initialize({
+		   std::make_pair("accelerator", acc),
+		   std::make_pair("optimizer", optimizer),
+		   std::make_pair("observable", observable),
+		   std::make_pair("steps", 1),
+		   std::make_pair("calc-var-assignment", true),
+		   std::make_pair("nbSamples", 1)
+		});
+		qaoa->execute(buffer);
+
+		std::string meas = (*buffer)["opt-config"].as<std::string>();
+
+		double expected_result = 0.;
+		for(size_t i = 0; i < num_terms; ++i){
+
+			auto term = hamiltonian[i];
+
+			if(term[1] == ""){ //identity term
+
+				expected_result += std::stod(term[0]);
+
+			}else if(term[2] == ""){ //single-Z term
+
+				int qbit = std::stoi(term[1].substr(1));
+				expected_result += (meas[qbit] == '1' ? -1 : 1) * std::stod(term[0]);
+
+			}else{ //double-Z term
+
+				int qbit1 = std::stoi(term[1].substr(1));
+				int qbit2 = std::stoi(term[2].substr(1));
+
+				expected_result += (meas[qbit1] == '1' ? -1 : 1) * (meas[qbit2] == '1' ? -1 : 1) * std::stod(term[0]);
+
+			}
+		}
+
+		EXPECT_NEAR((*buffer)["opt-val"].as<double>(), expected_result, 1e-1);
+
+
+}
+
+// Generate random
 auto random_vector(const double l_range, const double r_range,
                    const std::size_t size) {
   // Generate a random initial parameter set

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -68,6 +68,8 @@ public:
   virtual void updateConfiguration(const HeterogeneousMap &&config) {
     updateConfiguration(config);
   }
+  virtual void updateShotsNumber(int shots) {nbShots = shots;}
+
   virtual const std::vector<std::string> configurationKeys() = 0;
 
   virtual HeterogeneousMap getProperties() { return HeterogeneousMap(); }
@@ -134,6 +136,9 @@ public:
   }
 
   virtual ~Accelerator() {}
+
+protected:
+  int nbShots = -1;
 };
 
 template Accelerator* HeterogeneousMap::getPointerLike<Accelerator>(const std::string key) const;


### PR DESCRIPTION
This PR implements two new QAOA features:

- var_assignment_mode: Which determines the optimal configuration found by the qaoa, not only the optimal value as before. This can be handy for many optimization problems where we do not only seek the optimal value, but we are interested in the solution as well.
- simplified_simulation_mode: We note an odd overhead in sumulating qaoa. For each single/double qubit Pauli string of the problem hamiltonian we start from the zero state and apply cost/mixer hamiltonians to get a state on which we calculate expectation values. Hence the same state is prepared many times, but the expectation value calculation does not collapse it and hence it can be used for subsequent calculations. If the mode is set, the simulation does not truly simulate run of the qaoa on a quantum computer, but provides the same results more efficiently which can be crucial for the simulation abilities.

Signed-off-by: Milos Prokop prokop.milos@gmail.com