### PR TITLE
Pauli constructor that allows you to construct arbitrary Pauli strings with 2-qubit terms

### DIFF
--- a/quantum/observable/pauli/PauliOperator.cpp
+++ b/quantum/observable/pauli/PauliOperator.cpp
@@ -161,6 +161,21 @@ PauliOperator::PauliOperator(std::map<int, std::string> operators,
                 std::forward_as_tuple(coeff, operators));
 }
 
+PauliOperator::PauliOperator(std::map<int, std::pair<std::string, std::complex<double>>> operators){
+
+	std::map<int, std::string> buffer;
+
+	for(auto &op : operators){
+
+		buffer.clear();
+		buffer.emplace(op.first, op.second.first);
+
+		terms.emplace(std::piecewise_construct,
+				std::forward_as_tuple(Term::id(buffer)),
+				std::forward_as_tuple(op.second.second, buffer));
+	}
+}
+
 PauliOperator::PauliOperator(std::map<int, std::string> operators, double coeff)
     : PauliOperator(operators, std::complex<double>(coeff, 0)) {}
 

--- a/quantum/observable/pauli/PauliOperator.hpp
+++ b/quantum/observable/pauli/PauliOperator.hpp
@@ -241,6 +241,7 @@ public:
   PauliOperator(std::map<int, std::string> operators, std::string var);
   PauliOperator(std::map<int, std::string> operators,
                 std::complex<double> coeff);
+  PauliOperator(std::map<int, std::pair<std::string, std::complex<double>>>);
   PauliOperator(std::map<int, std::string> operators, double coeff);
   PauliOperator(std::map<int, std::string> operators,
                 std::complex<double> coeff, std::string var);


### PR DESCRIPTION
So far, the only way to construct Pauli observables is from the string.
```c++
xacc::quantum::getObservable("pauli", hamiltonian_string);
```
This allows you to create arbitrary Pauli 2-qubit strings in a more elegant way. This is useful when e.g. constructing problem hamiltonian for QAOA.