### PR TITLE
Update Controlled Gate generator to handle control qubits by (name + index) identifier

### DIFF
--- a/quantum/plugins/algorithms/qpe/ControlledGateApplicator.hpp
+++ b/quantum/plugins/algorithms/qpe/ControlledGateApplicator.hpp
@@ -18,53 +18,58 @@ using namespace xacc::quantum;
 namespace xacc {
 namespace circuits {
 
-class ControlledU: public AllGateVisitor, public quantum::Circuit
-{
+class ControlledU : public AllGateVisitor, public quantum::Circuit {
 public:
-    ControlledU() : Circuit("C-U") {}
-    bool expand(const xacc::HeterogeneousMap& runtimeOptions) override;
-    // Input: The composite "U" and the control Idx.
-    // Control Idx must *not* be one of the qubits that U is acting on.
-    const std::vector<std::string> requiredKeys() override { return { "U", "control-idx" }; }
-    DEFINE_CLONE(ControlledU);
+  ControlledU() : Circuit("C-U") {}
+  bool expand(const xacc::HeterogeneousMap &runtimeOptions) override;
+  // Input: The composite "U" and the control Idx.
+  // Control Idx must *not* be one of the qubits that U is acting on.
+  const std::vector<std::string> requiredKeys() override {
+    return {"U", "control-idx"};
+  }
+  DEFINE_CLONE(ControlledU);
 
-    // AllGateVisitor implementation
-    void visit(Hadamard& h) override;
-    void visit(CNOT& cnot) override;
-    void visit(Rz& rz) override;
-    void visit(Ry& ry) override;
-    void visit(Rx& rx) override;
-    void visit(X& x) override;
-    void visit(Y& y) override;
-    void visit(Z& z) override;
-    void visit(CY& cy) override;
-    void visit(CZ& cz) override;
-    void visit(Swap& s) override;
-    void visit(CRZ& crz) override;
-    void visit(CH& ch) override;
-    void visit(S& s) override;
-    void visit(Sdg& sdg) override;
-    void visit(T& t) override;
-    void visit(Tdg& tdg) override;
-    void visit(CPhase& cphase) override;
-    void visit(U& u) override;
-    void visit(U1& u1) override;
-    // Nothing to do
-    void visit(Identity& i) override {}
-    // These are unsupported.
-    void visit(Measure& measure) override { xacc::error("Unsupported!"); }
-    void visit(IfStmt& ifStmt) override { xacc::error("Unsupported!"); }
-    void visit(fSim& fsim) override { xacc::error("Unsupported!"); }
-    void visit(iSwap& isw) override { xacc::error("Unsupported!"); }
-
-private:
-    // Apply *single* control on the input composite.
-    // Returns the new composite.
-    std::shared_ptr<xacc::CompositeInstruction> applyControl(const std::shared_ptr<xacc::CompositeInstruction>& in_program, int in_ctrlIdx);
+  // AllGateVisitor implementation
+  void visit(Hadamard &h) override;
+  void visit(CNOT &cnot) override;
+  void visit(Rz &rz) override;
+  void visit(Ry &ry) override;
+  void visit(Rx &rx) override;
+  void visit(X &x) override;
+  void visit(Y &y) override;
+  void visit(Z &z) override;
+  void visit(CY &cy) override;
+  void visit(CZ &cz) override;
+  void visit(Swap &s) override;
+  void visit(CRZ &crz) override;
+  void visit(CH &ch) override;
+  void visit(S &s) override;
+  void visit(Sdg &sdg) override;
+  void visit(T &t) override;
+  void visit(Tdg &tdg) override;
+  void visit(CPhase &cphase) override;
+  void visit(U &u) override;
+  void visit(U1 &u1) override;
+  // Nothing to do
+  void visit(Identity &i) override {}
+  // These are unsupported.
+  void visit(Measure &measure) override { xacc::error("Unsupported!"); }
+  void visit(IfStmt &ifStmt) override { xacc::error("Unsupported!"); }
+  void visit(fSim &fsim) override { xacc::error("Unsupported!"); }
+  void visit(iSwap &isw) override { xacc::error("Unsupported!"); }
 
 private:
-    std::shared_ptr<xacc::CompositeInstruction> m_composite;
-    std::shared_ptr<xacc::IRProvider> m_gateProvider;
-    size_t m_ctrlIdx;
+  // Apply *single* control on the input composite.
+  // Returns the new composite.
+  std::shared_ptr<xacc::CompositeInstruction>
+  applyControl(const std::shared_ptr<xacc::CompositeInstruction> &in_program,
+               const std::pair<std::string, size_t> &in_ctrlIdx);
+
+private:
+  std::shared_ptr<xacc::CompositeInstruction> m_composite;
+  std::shared_ptr<xacc::IRProvider> m_gateProvider;
+  // The current control qubit (buffer name & index)
+  std::pair<std::string, size_t> m_ctrlIdx;
 };
-}}
+} // namespace circuits
+} // namespace xacc

--- a/quantum/plugins/algorithms/qpe/tests/ControlledGateTester.cpp
+++ b/quantum/plugins/algorithms/qpe/tests/ControlledGateTester.cpp
@@ -2,6 +2,7 @@
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 #include "CommonGates.hpp"
+#include "qalloc.hpp"
 
 using namespace xacc;
 using namespace xacc::quantum;
@@ -149,6 +150,58 @@ TEST(ControlledGateTester, checkMultipleControl)
     {
         runTestCase(i & 0x001, i & 0x002, i & 0x004);
     }
+}
+
+TEST(ControlledGateTester, checkMultipleControlQregs) 
+{    
+    // Reference circuit (index-based)
+    const std::string ref_circuit_str = []() {
+      auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+      auto x = std::make_shared<X>(0);
+      std::shared_ptr<xacc::CompositeInstruction> comp =
+          gateRegistry->createComposite("__COMPOSITE__X");
+      comp->addInstruction(x);
+      auto ccx = std::dynamic_pointer_cast<CompositeInstruction>(
+          xacc::getService<Instruction>("C-U"));
+      const std::vector<int> ctrl_idxs{1, 2};
+      ccx->expand({{"U", comp}, {"control-idx", ctrl_idxs}});
+      return ccx->toString();
+    }();
+    
+    // Circuit with different buffer names.
+    auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+    auto x = std::make_shared<X>(0);
+    x->setBufferNames({"target"});
+    std::shared_ptr<xacc::CompositeInstruction> comp =
+        gateRegistry->createComposite("__COMPOSITE__X");
+    comp->addInstruction(x);
+    auto ccx = std::dynamic_pointer_cast<CompositeInstruction>(
+        xacc::getService<Instruction>("C-U"));
+
+    auto ctrlReg1 = ::qalloc(1);
+    auto ctrl1 = ctrlReg1[0];
+    ctrl1.first = "control1";
+    auto ctrlReg2 = ::qalloc(1);
+    auto ctrl2 = ctrlReg2[0];
+    ctrl2.first = "control2";
+    const std::vector<xacc::internal_compiler::qubit> ctrl_qubits{ctrl1, ctrl2};
+
+    ccx->expand({{"U", comp}, {"control-idx", ctrl_qubits}});
+    auto new_circ_str = ccx->toString();
+    const auto replaceAll = [](const std::string &t, const std::string &s,
+                               std::string &str) {
+      std::string::size_type n = 0;
+      while ((n = str.find(s, n)) != std::string::npos) {
+        str.replace(n, s.size(), t);
+        n += t.size();
+      }
+    };
+
+    replaceAll("q0", "target0", new_circ_str);
+    replaceAll("q1", "control10", new_circ_str);
+    replaceAll("q2", "control20", new_circ_str);
+    std::cout << "HOWDY:\n" << new_circ_str << "\n";
+    EXPECT_EQ(ref_circuit_str, new_circ_str);
 }
 
 int main(int argc, char **argv) 

--- a/quantum/plugins/algorithms/qpe/tests/ControlledGateTester.cpp
+++ b/quantum/plugins/algorithms/qpe/tests/ControlledGateTester.cpp
@@ -184,7 +184,8 @@ TEST(ControlledGateTester, checkMultipleControlQregs)
     auto ctrlReg2 = ::qalloc(1);
     auto ctrl2 = ctrlReg2[0];
     ctrl2.first = "control2";
-    const std::vector<xacc::internal_compiler::qubit> ctrl_qubits{ctrl1, ctrl2};
+    const std::vector<std::pair<std::string, size_t>> ctrl_qubits{
+        {ctrl1.first, ctrl1.second}, {ctrl2.first, ctrl2.second}};
 
     ccx->expand({{"U", comp}, {"control-idx", ctrl_qubits}});
     auto new_circ_str = ccx->toString();

--- a/xacc/ir/IRProvider.hpp
+++ b/xacc/ir/IRProvider.hpp
@@ -32,6 +32,47 @@ public:
                         std::vector<InstructionParameter>{},
                     const HeterogeneousMap &analog_options = {}) = 0;
 
+  std::shared_ptr<Instruction>
+  createInstruction(const std::string name,
+                    // initializer_list overload to disambiguate
+                    // empty "{}" argument.
+                    std::initializer_list<std::size_t> bits,
+                    std::vector<InstructionParameter> parameters =
+                        std::vector<InstructionParameter>{},
+                    const HeterogeneousMap &analog_options = {}) {
+    return createInstruction(name, std::vector<std::size_t>(bits), parameters,
+                             analog_options);
+  }
+
+  // Overloads for instruction creation with explicit qubit name binding.
+  // i.e. automatically set the buffer names after creation.
+  virtual std::shared_ptr<Instruction>
+  createInstruction(const std::string name,
+                    const std::pair<std::string, std::size_t> &bit) {
+    auto inst = createInstruction(name, bit.second);
+    inst->setBufferNames({bit.first});
+    return inst;
+  }
+
+  virtual std::shared_ptr<Instruction> createInstruction(
+      const std::string name,
+      const std::vector<std::pair<std::string, std::size_t>> &bits,
+      std::vector<InstructionParameter> parameters =
+          std::vector<InstructionParameter>{},
+      const HeterogeneousMap &analog_options = {}) {
+    std::vector<std::string> buffer_names;
+    std::vector<std::size_t> idxs;
+
+    for (const auto &qb : bits) {
+      buffer_names.emplace_back(qb.first);
+      idxs.emplace_back(qb.second);
+    }
+
+    auto inst = createInstruction(name, idxs, parameters, analog_options);
+    inst->setBufferNames(buffer_names);
+    return inst;
+  }
+
   virtual std::shared_ptr<CompositeInstruction>
   createComposite(const std::string name,
                   std::vector<std::string> variables = {},


### PR DESCRIPTION
Resolves https://github.com/eclipse/xacc/issues/433

The C-U generator to track each gate's bits + buffer names explicitly.

For each gate in the original circuit, track and persist its operands (buffer names + bit ids).
For each added control bits, track the (buffer name + id) as well. 
When creating new gates, assign the bit ids and buffer names accordingly.

Added overloads to IRProvider's `createInstruction()` to handle buffer names as well: assign the buffer names on the newly created Instruction. 