### PR TITLE
Set initial_state CompositeInstruction ptr to null by default in QAOA

### DIFF
--- a/quantum/plugins/algorithms/qaoa/qaoa.hpp
+++ b/quantum/plugins/algorithms/qaoa/qaoa.hpp
@@ -40,7 +40,7 @@ private:
     int m_nbSteps;
     std::string m_parameterizedMode;
     bool m_maximize = false;
-    CompositeInstruction* m_initial_state;
+    CompositeInstruction* m_initial_state = nullptr;
 };
 } // namespace algorithm
 } // namespace xacc

--- a/quantum/plugins/algorithms/qaoa/qaoa_circuit.hpp
+++ b/quantum/plugins/algorithms/qaoa/qaoa_circuit.hpp
@@ -40,7 +40,7 @@ private:
     size_t m_nbSteps;
     std::vector<std::string> m_refHam;
     std::vector<std::string> m_costHam;
-    CompositeInstruction* m_initial_state;
+    CompositeInstruction* m_initial_state = nullptr;
 };
 } // namespace circuits
 } // namespace xacc

--- a/quantum/plugins/algorithms/qaoa/qaoa_maxcut.hpp
+++ b/quantum/plugins/algorithms/qaoa/qaoa_maxcut.hpp
@@ -45,7 +45,7 @@ private:
     std::string m_initializationMode = "default";
     xacc::Graph* m_graph;
     bool m_maximize = false;
-    CompositeInstruction* m_initial_state;
+    CompositeInstruction* m_initial_state = nullptr;
 };
 } // namespace algorithm
 } // namespace xacc


### PR DESCRIPTION
This bug was hidden until it gets on Summit :)
Looks like the compiler there set uninitialized pointers to bogus.

