### PR TITLE
Added a more robust way to add compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 include(format)
+include(cxxFlags)
 include(ExternalProject)
 
 if(NOT WIN32)

--- a/cmake/Modules/cxxFlags.cmake
+++ b/cmake/Modules/cxxFlags.cmake
@@ -1,0 +1,8 @@
+include(CheckCXXCompilerFlag)
+# Add a compile flag if the compiler supports
+function(add_compile_flags_if_supported flag)
+    check_cxx_compiler_flag("${flag}" "XACC_COMPILER_SUPPORTS_${flag}_FLAG")
+    if (XACC_COMPILER_SUPPORTS_${flag}_FLAG)
+        add_compile_options(${flag})    
+    endif()
+endfunction()

--- a/tpls/CMakeLists.txt
+++ b/tpls/CMakeLists.txt
@@ -22,6 +22,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-copy")
   endif()
 endif()
+
+# Disable 'deprecated-copy' warnings if the compiler recognizes the flag.
+# especially for different versions of Clang/AppleClang, 
+# we don't want to set the flag on compilers that don't support it yet (errors)
+add_compile_flags_if_supported(-Wno-deprecated-copy)
 add_subdirectory(cppmicroservices)
 
 # Fix for bug #161


### PR DESCRIPTION
e.g. disable certain warnings.

Use CMake's check_cxx_compiler_flag to check the flag before adding to prevent unknown flags errors.

Fixed https://github.com/eclipse/xacc/issues/440
