### PR TITLE
Ibmq accelerator select lowest queue backend: resolve #441

### DIFF
--- a/python/examples/ibmq_select_least_busy.py
+++ b/python/examples/ibmq_select_least_busy.py
@@ -1,0 +1,21 @@
+import xacc
+
+qpu = xacc.getAccelerator(
+    'ibm', {'shots': 256, 'backend': 'lowest-queue-count', 'n-qubits': 5, 'check-jobs-limit': True})
+
+print(qpu.getProperties()["total-json"])
+
+xacc.qasm('''.compiler xasm
+.circuit bell
+.qbit q
+H(q[0]);
+CX(q[0],q[1]);
+Measure(q[0]);
+Measure(q[1]);
+''')
+bell = xacc.getCompiled('bell')
+
+q = xacc.qalloc(2)
+qpu.execute(q, bell)
+
+print(q)

--- a/quantum/examples/base_api/CMakeLists.txt
+++ b/quantum/examples/base_api/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(bell_quil_ibm_local PRIVATE xacc)
 add_executable(bell_xasm_ibm_local bell_xasm_ibm_local.cpp)
 target_link_libraries(bell_xasm_ibm_local PRIVATE xacc)
 
+add_executable(bell_xasm_ibm_select_backend bell_xasm_ibm_select_backend.cpp)
+target_link_libraries(bell_xasm_ibm_select_backend PRIVATE xacc)
+
 add_executable(deuteron_2qbit_xasm_X0X1 deuteron_2qbit_xasm_X0X1.cpp)
 target_link_libraries(deuteron_2qbit_xasm_X0X1 PRIVATE xacc)
 

--- a/quantum/examples/base_api/CMakeLists.txt
+++ b/quantum/examples/base_api/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(bell_quil_ibm_local PRIVATE xacc)
 add_executable(bell_xasm_ibm_local bell_xasm_ibm_local.cpp)
 target_link_libraries(bell_xasm_ibm_local PRIVATE xacc)
 
+
 add_executable(bell_xasm_ibm_select_backend bell_xasm_ibm_select_backend.cpp)
 target_link_libraries(bell_xasm_ibm_select_backend PRIVATE xacc)
 

--- a/quantum/examples/base_api/CMakeLists.txt
+++ b/quantum/examples/base_api/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(bell_quil_ibm_local PRIVATE xacc)
 add_executable(bell_xasm_ibm_local bell_xasm_ibm_local.cpp)
 target_link_libraries(bell_xasm_ibm_local PRIVATE xacc)
 
-
 add_executable(bell_xasm_ibm_select_backend bell_xasm_ibm_select_backend.cpp)
 target_link_libraries(bell_xasm_ibm_select_backend PRIVATE xacc)
 

--- a/quantum/examples/base_api/bell_xasm_ibm_select_backend.cpp
+++ b/quantum/examples/base_api/bell_xasm_ibm_select_backend.cpp
@@ -1,0 +1,36 @@
+#include "xacc.hpp"
+
+int main(int argc, char **argv) {
+
+    xacc::Initialize(argc, argv);
+    xacc::external::load_external_language_plugins();
+    xacc::set_verbose(true);
+
+    auto accelerator = xacc::getAccelerator(
+        "ibm", {std::make_pair("backend", "lowest-queue-count"),
+                std::make_pair("n-qubits", 5),
+                std::make_pair("check-jobs-limit", true)}
+                );
+
+    xacc::qasm(R"(
+  .compiler xasm
+  .circuit bell
+  .qbit q
+  H(q[0]);
+  CX(q[0],q[1]);
+  Measure(q[0]);
+  Measure(q[1]);
+  )");
+    auto bell = xacc::getCompiled("bell");
+
+    // Allocate some qubits and execute
+    auto buffer = xacc::qalloc(2);
+    accelerator->execute(buffer, bell);
+
+    buffer->print();
+
+    xacc::external::unload_external_language_plugins();
+    xacc::Finalize();
+
+    return 0;
+}

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -212,16 +212,16 @@ void IBMAccelerator::processBackendCandidate(nlohmann::json& backend_json) {
 // Get current backend status
   auto status_response = get(IBM_API_URL, getStatusPath, {},
         {std::make_pair("version", "1"),
-          std::make_pair("access_token", currentApiToken)});
+         std::make_pair("access_token", currentApiToken)});
   auto status_response_json = json::parse(status_response);
   auto queue_lenght = status_response_json["lengthQueue"].get<int>();
   auto state = status_response_json["state"].get<bool>();
 
-  if( state && (backend_queue_lenght < 0 || backend_queue_lenght > queue_lenght)) {
+  if (state && (selected_backend_queue_lenght < 0 || selected_backend_queue_lenght > queue_lenght)) {
     if (filterByJobsLimit && !verifyJobsLimit(curr_backend)) {
       return;
     }
-    backend_queue_lenght = queue_lenght;
+    selected_backend_queue_lenght = queue_lenght;
     auto old_backend = backend;
     backend = curr_backend;
     availableBackends.clear();
@@ -231,7 +231,7 @@ void IBMAccelerator::processBackendCandidate(nlohmann::json& backend_json) {
 
 void IBMAccelerator::selectBackend(std::vector<std::string>& all_available_backends) {
   bool lowest_queue_backend = false;
-  if( backend == "lowest-queue-count" ) {
+  if (backend == "lowest-queue-count") {
     lowest_queue_backend = true;
   }
 
@@ -246,8 +246,8 @@ void IBMAccelerator::selectBackend(std::vector<std::string>& all_available_backe
       }
     }
     // Simple case: select by backend_name
-    if( !lowest_queue_backend ) {
-      if(b["backend_name"].get<std::string>() == backend) {
+    if (!lowest_queue_backend) {
+      if (b["backend_name"].get<std::string>() == backend) {
         availableBackends.insert(std::make_pair(backend, b));
       }
     } else {
@@ -311,7 +311,7 @@ void IBMAccelerator::initialize(const HeterogeneousMap &params) {
         get(IBM_API_URL, getBackendPropertiesPath, {},
             {std::make_pair("version", "1"),
              std::make_pair("access_token", currentApiToken)});
-    //xacc::info("Backend property:\n" + backend_props_response);
+    xacc::info("Backend property:\n" + backend_props_response);
     auto props = json::parse(backend_props_response);
     backendProperties.insert({backend, props});
 

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -214,14 +214,14 @@ void IBMAccelerator::processBackendCandidate(nlohmann::json& backend_json) {
         {std::make_pair("version", "1"),
          std::make_pair("access_token", currentApiToken)});
   auto status_response_json = json::parse(status_response);
-  auto queue_lenght = status_response_json["lengthQueue"].get<int>();
+  auto queue_length = status_response_json["lengthQueue"].get<int>();
   auto state = status_response_json["state"].get<bool>();
 
-  if (state && (backendQueueLenght < 0 || backendQueueLenght > queue_lenght)) {
+  if (state && (backendQueueLength < 0 || backendQueueLength > queue_length)) {
     if (filterByJobsLimit && !verifyJobsLimit(curr_backend)) {
       return;
     }
-    backendQueueLenght = queue_lenght;
+    backendQueueLength = queue_length;
     auto old_backend = backend;
     backend = curr_backend;
     availableBackends.clear();

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -104,6 +104,9 @@ public:
     if (config.keyExists<int>("n-qubits")) {
       requested_n_qubits = config.get<int>("n-qubits");
     }
+    if (config.keyExists<bool>("check-jobs-limit")) {
+      filterByJobsLimit = config.get<bool>("check-jobs-limit");
+    }
     if (config.keyExists<bool>("http-verbose")) {
       restClient->setVerbose(config.get<bool>("http-verbose"));
     }
@@ -114,7 +117,7 @@ public:
   }
 
   const std::vector<std::string> configurationKeys() override {
-    return {"shots", "backend"};
+    return {"shots", "backend", "n-qubits", "check-jobs-limit", "http-verbose", "mode"};
   }
 
   HeterogeneousMap getProperties() override;
@@ -161,6 +164,7 @@ private:
                         std::string &project, const std::string &p);
   void selectBackend(std::vector<std::string>& all_available_backends);
   void processBackendCandidate(nlohmann::json& b);
+  bool verifyJobsLimit(std::string& curr_backend);
 
   std::shared_ptr<RestClient> restClient;
 
@@ -193,6 +197,7 @@ private:
   std::string defaults_response = "{}";
   std::string mode = "qasm";
   int requested_n_qubits = 0;
+  bool filterByJobsLimit = false;
   std::string post(const std::string &_url, const std::string &path,
                    const std::string &postStr,
                    std::map<std::string, std::string> headers = {});

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -182,7 +182,7 @@ private:
 
   int shots = 1024;
   std::string backend = DEFAULT_IBM_BACKEND;
-  int backendQueueLenght = -1; 
+  int backendQueueLength = -1; 
 
   bool jobIsRunning = false;
   std::string currentJobId = "";

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -182,7 +182,7 @@ private:
 
   int shots = 1024;
   std::string backend = DEFAULT_IBM_BACKEND;
-  int selected_backend_queue_lenght = -1; 
+  int backendQueueLenght = -1; 
 
   bool jobIsRunning = false;
   std::string currentJobId = "";

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -182,7 +182,7 @@ private:
 
   int shots = 1024;
   std::string backend = DEFAULT_IBM_BACKEND;
-  int backend_queue_lenght = -1; 
+  int selected_backend_queue_lenght = -1; 
 
   bool jobIsRunning = false;
   std::string currentJobId = "";

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -101,6 +101,9 @@ public:
     if (config.stringExists("backend")) {
       backend = config.getString("backend");
     }
+    if (config.keyExists<int>("n-qubits")) {
+      requested_n_qubits = config.get<int>("n-qubits");
+    }
     if (config.keyExists<bool>("http-verbose")) {
       restClient->setVerbose(config.get<bool>("http-verbose"));
     }
@@ -156,6 +159,9 @@ private:
                     std::string &project);
   void findApiKeyInFile(std::string &key, std::string &hub, std::string &group,
                         std::string &project, const std::string &p);
+  void selectBackend(std::vector<std::string>& all_available_backends);
+  void processBackendCandidate(nlohmann::json& b);
+
   std::shared_ptr<RestClient> restClient;
 
   static const std::string IBM_AUTH_URL;
@@ -172,6 +178,7 @@ private:
 
   int shots = 1024;
   std::string backend = DEFAULT_IBM_BACKEND;
+  int backend_queue_lenght = -1; 
 
   bool jobIsRunning = false;
   std::string currentJobId = "";
@@ -185,6 +192,7 @@ private:
   std::string getBackendPropsResponse = "{}";
   std::string defaults_response = "{}";
   std::string mode = "qasm";
+  int requested_n_qubits = 0;
   std::string post(const std::string &_url, const std::string &path,
                    const std::string &postStr,
                    std::map<std::string, std::string> headers = {});


### PR DESCRIPTION
Implemented backend selection functionality with a minimum number of tasks in the queue. At the same time, backends are filtered according to the following conditions:
1. simulators backends
2. backedns in state - false.
3 if the "n-qubits" option is specified, then backends with the number of qbuits is less than the specified. 
4. if the "check-jobs-limit" option is specified, then the backends for which the number of allowed tasks is less than the number of running tasks.