### PR TITLE
IBM Backend: Default to multi_meas_enabled=false if missing

### DIFF
--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -258,7 +258,7 @@ void IBMAccelerator::initialize(const HeterogeneousMap &params) {
 
     chosenBackend = availableBackends[backend];
     xacc::info("Backend config:\n" + chosenBackend.dump());
-    multi_meas_enabled = chosenBackend["multi_meas_enabled"].get<bool>();
+    multi_meas_enabled = chosenBackend.value("multi_meas_enabled", false);
     defaults_response =
         get(IBM_API_URL,
             IBM_CREDENTIALS_PATH + "/devices/" + backend + "/defaults", {},


### PR DESCRIPTION
Currently the JSON configuration IBM sends for some backends does not include `multi_meas_enabled` at all, causing a crash when the IBM backend tries to find it in the response. [Here is the raw response JSON](https://github.com/eclipse/xacc/files/6540569/backends-formatted.json.txt) I get from the `/api/Backends` endpoint. (I am using the public IBM-Q configuration)

I tried to handle this in this PR, but to be conservative, I assumed no `multi_meas_enabled` means `multi_meas_enabled=false`. I'm not sure if this is actually the correct thing to assume. I will note that if you look at that response JSON I linked above, the only time `multi_meas_enabled` appears is when it's true, so I'm wondering if IBM is excluding it when it's false. However, I don't know much about this — let me know what y'all think

My testing for this is the same as #284