### PR TITLE
Initial Thread-Safe Implementation

### DIFF
--- a/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.cpp
@@ -244,6 +244,9 @@ namespace quantum {
 
     void QppAccelerator::execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::shared_ptr<CompositeInstruction> compositeInstruction)
     {
+#ifdef _XACC_MUTEX
+        std::lock_guard<std::recursive_mutex> lock(getMutex());
+#endif
         const auto runCircuit = [&](bool shotsMode){
             m_visitor->initialize(buffer, shotsMode);
 
@@ -325,6 +328,10 @@ namespace quantum {
     
     void QppAccelerator::execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<std::shared_ptr<CompositeInstruction>> compositeInstructions)
     {
+#ifdef _XACC_MUTEX
+        std::lock_guard<std::recursive_mutex> lock(getMutex());
+#endif
+
         if (!m_vqeMode || compositeInstructions.size() <= 1) 
         {
             for (auto& f : compositeInstructions)
@@ -370,6 +377,10 @@ namespace quantum {
 
     void QppAccelerator::apply(std::shared_ptr<AcceleratorBuffer> buffer, std::shared_ptr<Instruction> inst) 
     {
+#ifdef _XACC_MUTEX
+        std::lock_guard<std::recursive_mutex> lock(getMutex());
+#endif
+
         if (!m_visitor->isInitialized()) {
             m_visitor->initialize(buffer);
             m_currentBuffer = std::make_pair(buffer.get(), buffer->size());

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -14,7 +14,9 @@
 #include "xacc.hpp"
 #include "QppVisitor.hpp"
 #include "NoiseModel.hpp"
-
+#ifdef _XACC_MUTEX
+#include <mutex>
+#endif
 namespace xacc {
 namespace quantum {
 
@@ -49,6 +51,12 @@ public:
     std::vector<std::pair<int,int>> m_connectivity;
     xacc::HeterogeneousMap m_executionInfo;
     std::pair<AcceleratorBuffer*, size_t> m_currentBuffer;
+#ifdef _XACC_MUTEX
+    static std::recursive_mutex& getMutex() {
+        static std::recursive_mutex m;;
+        return m;
+    }
+#endif
 };
 
 class DefaultNoiseModelUtils : public NoiseModelUtils 

--- a/xacc/optimizer/nlopt-optimizers/nlopt_optimizer.cpp
+++ b/xacc/optimizer/nlopt-optimizers/nlopt_optimizer.cpp
@@ -56,6 +56,9 @@ const bool NLOptimizer::isGradientBased() const {
 }
 
 OptResult NLOptimizer::optimize(OptFunction &function) {
+#ifdef _XACC_MUTEX
+  std::lock_guard<std::mutex> lock(getMutex());
+#endif
 
   auto dim = function.dimensions();
   nlopt::algorithm algo = nlopt::algorithm::LN_COBYLA;

--- a/xacc/optimizer/nlopt-optimizers/nlopt_optimizer.hpp
+++ b/xacc/optimizer/nlopt-optimizers/nlopt_optimizer.hpp
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "Optimizer.hpp"
+#include "xacc.hpp"
 
 namespace xacc {
 
@@ -24,7 +25,13 @@ struct ExtraNLOptData {
     std::function<double(const std::vector<double>&, std::vector<double>&)> f;
 };
 
-class NLOptimizer : public Optimizer {
+class NLOptimizer : public Optimizer, public xacc::Cloneable<Optimizer> {
+#ifdef _XACC_MUTEX
+  static std::mutex& getMutex() {
+    static std::mutex lock;
+    return lock;
+  }
+#endif
 public:
   OptResult optimize(OptFunction &function) override;
   const bool isGradientBased() const override;
@@ -32,6 +39,10 @@ public:
 
   const std::string name() const override { return "nlopt"; }
   const std::string description() const override { return ""; }
+
+  std::shared_ptr<Optimizer> clone() override {
+    return std::make_shared<NLOptimizer>();
+  }
 };
 } // namespace xacc
 #endif

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -155,7 +155,14 @@ void error(const std::string &msg, MessagePredicate predicate) {
   }
 }
 
+#ifdef _XACC_MUTEX
+std::mutex qalloc_lock;
+#endif
+
 qbit qalloc(const int n) {
+#ifdef _XACC_MUTEX
+  std::lock_guard<std::mutex> lock(qalloc_lock);
+#endif
   qbit q(n);
   std::stringstream ss;
   ss << "qreg_" << q;
@@ -164,6 +171,9 @@ qbit qalloc(const int n) {
   return q;
 }
 qbit qalloc() {
+#ifdef _XACC_MUTEX
+  std::lock_guard<std::mutex> lock(qalloc_lock);
+#endif
   qbit q;
   std::stringstream ss;
   ss << "qreg_" << q;

--- a/xacc/xacc.hpp
+++ b/xacc/xacc.hpp
@@ -28,6 +28,11 @@
 #include <sys/stat.h>
 #include <fstream>
 
+#undef _XACC_MUTEX
+#ifdef _XACC_MUTEX
+#include <mutex>
+#endif
+
 namespace xacc {
 
 namespace constants {


### PR DESCRIPTION
Add thread-safety to XACC/QCOR (Experimental). We introduce `_XACC_MUTEX` macro in `xacc.hpp` to turn on/off the feature (default is OFF). When the macro is ON, only a single thread can execute the following routines by using either `std::mutex` or `std::recursive_mutex`:

- User-facing API routines
   - `xacc::qalloc()`

- Backend modules
   - `QppAccelerator`
       - `execute()` (the existing shot-level parallel execution still works)
       - `apply()`
   - `NLOptimizer`
      -  `optimize()`

Also, regardless of the macro, the `NLOptimizer` class is now `xacc::Cloneable`.

Signed-off-by: Akihiro Hayashi <ahayashi@gatech.edu>