### PR TITLE
RZZ gate for XASM and XACC IR

### DIFF
--- a/quantum/gate/GateQuantumActivator.cpp
+++ b/quantum/gate/GateQuantumActivator.cpp
@@ -69,7 +69,10 @@ public:
     auto ifstmt = std::make_shared<xacc::quantum::IfStmt>();
     auto reset = std::make_shared<xacc::quantum::Reset>();
     auto scheduler = std::make_shared<xacc::quantum::PulseScheduler>();
+    auto rzz= std::make_shared<xacc::quantum::RZZ>();
+
     context.RegisterService<xacc::Scheduler>(scheduler);
+    context.RegisterService<xacc::Instruction>(rzz);
 
     context.RegisterService<xacc::Instruction>(h);
     context.RegisterService<xacc::Instruction>(cn);

--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -536,6 +536,24 @@ public:
   DEFINE_VISITABLE()
 };
 
+class RZZ : public Gate {
+public:
+  RZZ() : Gate("RZZ",std::vector<InstructionParameter>{0.0}) {}
+  RZZ(std::size_t controlQubit, std::size_t targetQubit)
+      : Gate("RZZ", std::vector<std::size_t>{controlQubit, targetQubit},
+             std::vector<InstructionParameter>{0.0}) {} 
+  RZZ(std::vector<std::size_t> qbits)
+      : Gate("RZZ", qbits, std::vector<InstructionParameter>{0.0}) {}
+  RZZ(std::size_t controlQubit, std::size_t targetQubit, double theta)
+      : Gate("RZZ", std::vector<std::size_t>{controlQubit, targetQubit},
+             std::vector<InstructionParameter>{theta}) {}
+ 
+  const int nRequiredBits() const override { return 2; }
+
+  DEFINE_CLONE(RZZ)
+  DEFINE_VISITABLE()
+};
+
 } // namespace quantum
 } // namespace xacc
 #endif

--- a/quantum/gate/utils/AllGateVisitor.hpp
+++ b/quantum/gate/utils/AllGateVisitor.hpp
@@ -48,8 +48,10 @@ class AllGateVisitor : public BaseInstructionVisitor,
                        public InstructionVisitor<U1>,
                        public InstructionVisitor<IfStmt>,
                        public InstructionVisitor<XY>,
-                       public InstructionVisitor<Reset> {
+                       public InstructionVisitor<Reset>,
+                       public InstructionVisitor<RZZ> {
 public:
+  void visit(RZZ &rzz) override {}
   void visit(Hadamard &h) override {}
   void visit(CNOT &h) override {}
   void visit(Rz &h) override {}

--- a/quantum/plugins/xasm/tests/XASMCompilerTester.cpp
+++ b/quantum/plugins/xasm/tests/XASMCompilerTester.cpp
@@ -22,6 +22,23 @@
 
 #include "Circuit.hpp"
 
+TEST(XASMCompilerTester, checkRZZ) {
+
+  auto compiler = xacc::getCompiler("xasm");
+  auto IR =
+      compiler->compile(R"(
+__qpu__ void rzz_test(qbit q, double theta) {
+  H(q[0]);
+  RZZ(q[0], q[1], theta);
+  CX(q[0], q[1]);
+}
+)");
+
+  auto kernel = IR->getComposites()[0];
+  std::cout << "HELLO: " << kernel->toString() << "\n";
+  std::cout << kernel->operator()({2.4})->toString() << "\n";
+}
+
 TEST (XASMCompilerTester, checkQcorIssue23) {
 auto compiler = xacc::getCompiler("xasm");
   auto IR = compiler->compile(R"(__qpu__ void rotate(qbit q, double x) {


### PR DESCRIPTION
Signed-off-by: Quantum Brilliance [Simon Yin, Senior Software Engineer] <simon.y@quantum-brilliance.com>

## 1.1 Current status of XACC support for RZZ

Here is a Gtest unit test using the proposed XASM format RZZ gate:

```bash
TEST(XASMCompilerTester, checkRZZ) {

  auto compiler = xacc::getCompiler("xasm");
  auto IR =
      compiler->compile(R"(
__qpu__ void rzz_test(qbit q, double theta) {
  H(q[0]);
  RZZ(q[0], q[1], theta);
  CX(q[0], q[1]);
}
)");

  auto kernel = IR->getComposites()[0];
  std::cout << "HELLO: " << kernel->toString() << "\n";
  std::cout << kernel->operator()({2.4})->toString() << "\n";
}
```

**Result**

XACC returns an error saying it does not recognise RZZ :

```bash
quantum/plugins/xasm/tests/XASMCompilerTester      
[==========] Running 20 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 20 tests from XASMCompilerTester
[ RUN      ] XASMCompilerTester.checkRZZ
0x7f44aeaaeec5: (xacc::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<bool ()>)+0x25)
0x7f448b6e28e0: (xacc::quantum::QuantumIRProvider::createInstruction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<unsigned long, std::allocator<unsigned long> >, std::vector<xacc::Variant<int, double, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<xacc::Variant<int, double, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, xacc::HeterogeneousMap const&)+0xcb0)
0x7f448a502e2a: (xacc::XASMListener::exitInstruction(xasm::xasmParser::InstructionContext*)+0x19a)
0x7f44aca5e18c: (antlr4::tree::ParseTreeWalker::exitRule(antlr4::tree::ParseTreeListener*, antlr4::tree::ParseTree*) const+0x3c)
0x7f44aca5ddbc: (antlr4::tree::IterativeParseTreeWalker::walk(antlr4::tree::ParseTreeListener*, antlr4::tree::ParseTree*) const+0x21c)
0x7f448a4f0f7e: (xacc::XASMCompiler::compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<xacc::Accelerator>)+0x18e)
0x7f448a4f0322: (xacc::XASMCompiler::compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0x32)
0x55bbe69e8167: (XASMCompilerTester_checkRZZ_Test::TestBody()+0x77)
0x7f44af05804a: (void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x4a)
0x7f44af04e21a: (testing::Test::Run()+0xba)
0x7f44af04e368: (testing::TestInfo::Run()+0x118)
0x7f44af04e475: (testing::TestCase::Run()+0xe5)
0x7f44af04e98c: (testing::internal::UnitTestImpl::RunAllTests()+0x46c)
0x7f44af04ea99: (testing::UnitTest::Run()+0x69)
0x55bbe69e6bf5: (main+0x35)
0x7f44ae0e1b97: (__libc_start_main+0xe7)
0x55bbe69e734a: (_start+0x2a)
[2021-06-03 05:26:17.317] [xacc-logger] [error] [XACC Error] Invalid instruction name - RZZ
[2021-06-03 05:26:17.317] [xacc-logger] [error] [XACC Error] Framework Exiting
```

## 1.2 Results from unit test of this implementation

```bash
[==========] Running 20 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 20 tests from XASMCompilerTester
[ RUN      ] XASMCompilerTester.checkRZZ
HELLO: 
H q0
RZZ(theta) q0,q1
CNOT q0,q1

H q0
RZZ(2.4) q0,q1
CNOT q0,q1

[       OK ] XASMCompilerTester.checkRZZ (3 ms)

```

