### PR TITLE
Fixed https://github.com/eclipse/xacc/issues/399

### DIFF
--- a/quantum/observable/pauli/PauliOperator.cpp
+++ b/quantum/observable/pauli/PauliOperator.cpp
@@ -1005,7 +1005,7 @@ double PauliOperator::calcExpValFromGroupedExecution(
       temp_buffer->setMeasurements(resultBuffer->getMarginalCounts(meas_bits, bit_order));
       const auto coeff = spinInst.coeff();
       const double term_exp_val = temp_buffer->getExpectationValueZ();
-      temp_buffer->print();
+      // temp_buffer->print();
       // std::cout << "Exp = " << term_exp_val << "\n";
       // std::cout << "Coeff = " << coeff << "\n";
       energy += (term_exp_val * coeff);
@@ -1021,7 +1021,7 @@ double PauliOperator::postProcess(std::shared_ptr<AcceleratorBuffer> buffer,
       buffer->getChildren()[0]->name().find("GroupObserve") !=
           std::string::npos &&
       !buffer->getChildren()[0]->getMeasurementCounts().empty()) {
-    std::cout << "Grouping post processing!\n";
+    // std::cout << "Grouping post processing!\n";
     return calcExpValFromGroupedExecution(buffer);
   }
 

--- a/quantum/observable/pauli/PauliOperator.cpp
+++ b/quantum/observable/pauli/PauliOperator.cpp
@@ -297,9 +297,8 @@ PauliOperator::observe(std::shared_ptr<CompositeInstruction> function, const Het
 
   if (!shots_enabled) {
     // Log that we cannot do grouping (since shots is not set)
-    std::cout << qpu->name()
-              << " accelerator is not running 'shots' execution. Observable "
-                 "grouping will be ignored.\n";
+    xacc::info(qpu->name() + " accelerator is not running 'shots' execution. "
+                             "Observable grouping will be ignored.");
     return observe(function);
   }
   // For this grouping, we only support *single* grouping,
@@ -431,7 +430,7 @@ PauliOperator::observe(std::shared_ptr<CompositeInstruction> function, const Het
     meas->setParameter(0, classicalIdx);
     gateFunction->addInstruction(meas);
   }
-  std::cout << "Group observed circuit:\n" << gateFunction->toString() << "\n";
+  // std::cout << "Group observed circuit:\n" << gateFunction->toString() << "\n";
   return {gateFunction};
 }
 

--- a/quantum/observable/pauli/PauliOperator.cpp
+++ b/quantum/observable/pauli/PauliOperator.cpp
@@ -277,7 +277,7 @@ PauliOperator::observe(std::shared_ptr<CompositeInstruction> function, const Het
   }
 
   // For this, we require the Accelerator info:
-  if (grouping_options.pointerLikeExists<Accelerator>("accelerator")) {
+  if (!grouping_options.pointerLikeExists<Accelerator>("accelerator")) {
     xacc::error("'accelerator' is required for Observable grouping");
   }
   auto qpu = grouping_options.getPointerLike<Accelerator>("accelerator");

--- a/quantum/observable/pauli/PauliOperator.hpp
+++ b/quantum/observable/pauli/PauliOperator.hpp
@@ -247,6 +247,9 @@ public:
 
   std::vector<std::shared_ptr<CompositeInstruction>>
   observe(std::shared_ptr<CompositeInstruction> function) override;
+  std::vector<std::shared_ptr<CompositeInstruction>>
+  observe(std::shared_ptr<CompositeInstruction> function,
+          const HeterogeneousMap &grouping_options) override;
 
   std::vector<std::shared_ptr<Observable>> getSubTerms() override {
     std::vector<std::shared_ptr<Observable>> ret;

--- a/quantum/observable/pauli/PauliOperator.hpp
+++ b/quantum/observable/pauli/PauliOperator.hpp
@@ -352,6 +352,9 @@ public:
   virtual double postProcess(std::shared_ptr<AcceleratorBuffer> buffer,
                              const std::string &postProcessTask,
                              const HeterogeneousMap &extra_data) override;
+private:
+  double
+  calcExpValFromGroupedExecution(std::shared_ptr<AcceleratorBuffer> buffer);
 };
 } // namespace quantum
 

--- a/quantum/observable/pauli/tests/PauliOperatorTester.cpp
+++ b/quantum/observable/pauli/tests/PauliOperatorTester.cpp
@@ -490,6 +490,29 @@ TEST(PauliOperatorTester, checkNormalize) {
 
 }
 
+TEST(PauliOperatorTester, checkGroupingQaoa) {
+  PauliOperator op;
+  op.fromString("(0, -1) Z0 Z1 + (0, -1) Z1 Z2 + (0, -1) Z2 Z0");
+  std::cout << op.toString() << "\n";
+  auto qpu = xacc::getAccelerator("qpp", {{"shots", 1024}});
+  auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+  auto f = gateRegistry->createComposite("f");
+  auto h0 = gateRegistry->createInstruction("H", 0);
+  auto h1 = gateRegistry->createInstruction("H", 1);
+  auto h2 = gateRegistry->createInstruction("H", 2);
+  f->addInstructions({h0, h1, h2});
+  auto observed = op.observe(f, {{"accelerator", qpu}});
+  EXPECT_EQ(observed.size(), 1);
+
+  // Check non-commute as well:
+  PauliOperator op_non_commute;
+  op_non_commute.fromString("(0, -1) Z0 Z1 + (0, -1) Z1 Z2 + (0, -1) Z2 X0");
+  std::cout << op_non_commute.toString() << "\n";
+  auto observed_non_commute = op_non_commute.observe(f, {{"accelerator", qpu}});
+  // Three terms:
+  EXPECT_EQ(observed_non_commute.size(), 3);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
@@ -77,6 +77,9 @@ public:
   virtual std::vector<std::pair<int, int>> getConnectivity() override;
 
   virtual BitOrder getBitOrder() override { return BitOrder::MSB; }
+  virtual HeterogeneousMap getProperties() override {
+    return {{"shots", m_shots}};
+  }
   virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer,
                        const std::shared_ptr<CompositeInstruction>
                            compositeInstruction) override;

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -50,7 +50,9 @@ std::string hex_string_to_binary_string(std::string hex) {
 HeterogeneousMap AerAccelerator::getProperties() {
   auto props = physical_backend_properties;
   // Insert 'shots' data
-  props.insert("shots", m_shots);
+  if (m_simtype == "qasm") {
+    props.insert("shots", m_shots);
+  }
   return props;
 }
 

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -48,7 +48,10 @@ std::string hex_string_to_binary_string(std::string hex) {
 }
 
 HeterogeneousMap AerAccelerator::getProperties() {
-  return physical_backend_properties;
+  auto props = physical_backend_properties;
+  // Insert 'shots' data
+  props.insert("shots", m_shots);
+  return props;
 }
 
 void AerAccelerator::initialize(const HeterogeneousMap &params) {

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -28,6 +28,7 @@ public:
     virtual void initialize(const HeterogeneousMap& params = {}) override;
     virtual void updateConfiguration(const HeterogeneousMap& config) override {initialize(config);};
     virtual const std::vector<std::string> configurationKeys() override { return {}; }
+    virtual HeterogeneousMap getProperties() override { return {{"shots", m_shots}}; }
     virtual BitOrder getBitOrder() override {return BitOrder::LSB;}
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::shared_ptr<CompositeInstruction> compositeInstruction) override;
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<std::shared_ptr<CompositeInstruction>> compositeInstructions) override;

--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
@@ -29,6 +29,9 @@ public:
     virtual void updateConfiguration(const HeterogeneousMap& config) override {initialize(config);};
     virtual const std::vector<std::string> configurationKeys() override { return {}; }
     virtual BitOrder getBitOrder() override {return BitOrder::LSB;}
+    virtual HeterogeneousMap getProperties() override {
+      return {{"shots", m_shots}};
+    }
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::shared_ptr<CompositeInstruction> compositeInstruction) override;
     virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer, const std::vector<std::shared_ptr<CompositeInstruction>> compositeInstructions) override;
 private:

--- a/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
+++ b/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
@@ -226,6 +226,9 @@ public:
     return {};
   }
   virtual BitOrder getBitOrder() override { return BitOrder::MSB; }
+  virtual HeterogeneousMap getProperties() override {
+    return {{"shots", m_shots}};
+  }
   virtual void execute(std::shared_ptr<AcceleratorBuffer> buffer,
                        const std::shared_ptr<CompositeInstruction>
                            compositeInstruction) override;

--- a/xacc/ir/Observable.hpp
+++ b/xacc/ir/Observable.hpp
@@ -35,6 +35,20 @@ public:
   virtual std::vector<std::shared_ptr<CompositeInstruction>>
   observe(std::shared_ptr<CompositeInstruction> CompositeInstruction) = 0;
 
+  // Overload for observe with grouping enabled.
+  virtual std::vector<std::shared_ptr<CompositeInstruction>>
+  observe(std::shared_ptr<CompositeInstruction> function,
+          const HeterogeneousMap &grouping_options) {
+    if (grouping_options.size() != 0) {
+      XACCLogger::instance()->error("Observable '" + name() +
+                                    "' doesn't support Observable grouping.");
+      return {};
+    } else {
+      // Gracefully use non-grouping method.
+      return observe(function);
+    }
+  }
+
   virtual const std::string toString() = 0;
   virtual void fromString(const std::string str) = 0;
   virtual const int nBits() = 0;


### PR DESCRIPTION
While waiting for an uber solution (for observable grouping), this impl. specifically targets the QAOA Maxcut use case (all Z operators).

Simply check that all the terms generate a unique basis-change circuit (in combination), i.e. all terms commute, then only submit that single circuit.

This only works (and matters) when the Accelerator is running in the 'shots' mode.