### PR TITLE
Quil visitor to use theta string rather than trying to cast to double

### DIFF
--- a/quantum/plugins/rigetti/QuilVisitor.hpp
+++ b/quantum/plugins/rigetti/QuilVisitor.hpp
@@ -146,7 +146,7 @@ public:
         quilStr += "RY("+angleStr+") " + qubit + "\n";
     } else {
       Rx rx1(ry.bits()[0], xacc::constants::pi/2.);
-      Rz rz1(ry.bits()[0], ry.getParameter(0).as<double>());
+      Rz rz1(ry.bits()[0], angleStr);
       Rx rx2(ry.bits()[0], -xacc::constants::pi/2.);
       
       visit(rx1);


### PR DESCRIPTION
This is problematic when there is a U3 gate: this visitor will create a Ry with a `string` param, then re-visit.
