### PR TITLE
Show pulses, parameters in Circuit.toGraph()

### DIFF
--- a/quantum/gate/utils/IRToGraphVisitor.cpp
+++ b/quantum/gate/utils/IRToGraphVisitor.cpp
@@ -18,7 +18,17 @@
 namespace xacc {
 namespace quantum {
 
-void IRToGraphVisitor::addSingleQubitGate(Gate &inst) {
+std::string IRToGraphVisitor::getParamsString(Instruction &inst) {
+  std::string ret = "";
+  std::string sep = "";
+  for (auto &param : inst.getParameters()) {
+    ret += sep + InstructionParameterToString(param);
+    sep = ",";
+  }
+  return ret;
+}
+
+void IRToGraphVisitor::addSingleQubitGate(Instruction &inst) {
   auto bit = inst.bits()[0];
   auto lastNode = qubitToLastNode[bit];
   auto lastBit = lastNode.get<std::vector<std::size_t>>("bits")[0];
@@ -28,6 +38,9 @@ void IRToGraphVisitor::addSingleQubitGate(Gate &inst) {
   CircuitNode newNode{std::make_pair("name", inst.name()),
                       std::make_pair("id", id),
                       std::make_pair("bits", inst.bits())};
+  if (inst.nParameters()) {
+    newNode.insert("params", getParamsString(inst));
+  }
 
   graph->addVertex(newNode);
   graph->addEdge(lastNode.get<std::size_t>("id"), newNode.get<std::size_t>("id"), 1);
@@ -35,7 +48,7 @@ void IRToGraphVisitor::addSingleQubitGate(Gate &inst) {
   qubitToLastNode[bit] = newNode;
 }
 
-void IRToGraphVisitor::addTwoQubitGate(Gate &inst) {
+void IRToGraphVisitor::addTwoQubitGate(Instruction &inst) {
   auto srcbit = inst.bits()[0];
   auto tgtbit = inst.bits()[1];
 
@@ -46,6 +59,9 @@ void IRToGraphVisitor::addTwoQubitGate(Gate &inst) {
   CircuitNode newNode{std::make_pair("name", inst.name()),
                       std::make_pair("id", id),
                       std::make_pair("bits", inst.bits())};
+  if (inst.nParameters()) {
+    newNode.insert("params", getParamsString(inst));
+  }
   graph->addVertex(newNode);
   graph->addEdge(lastsrcnodeid, id, 1);
   graph->addEdge(lasttgtnodeid, id, 1);

--- a/xacc/ir/Instruction.hpp
+++ b/xacc/ir/Instruction.hpp
@@ -60,6 +60,17 @@ InstructionParameterToDouble(const xacc::InstructionParameter &in_parameter) {
   return 0.0;
 }
 
+static std::string InstructionParameterToString(const xacc::InstructionParameter &in_parameter) {
+  switch (in_parameter.which()) {
+    case 0:
+      return std::to_string(in_parameter.as<int>());
+    case 1:
+      return std::to_string(in_parameter.as<double>());
+    default: // 2
+      return in_parameter.as<std::string>();
+  }
+}
+
 class CompositeInstruction;
 
 class CompositeArgument {


### PR DESCRIPTION
The graph produced by `Circuit.toGraph()` (and thus the graphviz output) is currently missing `Instruction` parameters and `Pulse` instructions, so modify it to include both. For context, I'm using the `Pulse` instruction for the native GTRI testbed operations, like (if I recall correctly) you suggested.

Here's an example of rendered graphviz:

![Example image](https://user-images.githubusercontent.com/431756/127233628-2d9bc57b-c703-4871-b4ad-444afba0ebea.png)

If I'm doing anything strange here please let me know