### PR TITLE
IBM: Make bidirectional couplings when server sends no coupling_map

### DIFF
--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -812,8 +812,7 @@ std::vector<std::pair<int, int>> IBMAccelerator::getConnectivity() {
     auto nq = backend__["n_qubits"].get<int>();
     for (int i = 0; i < nq; i++) {
       for (int j = 0; j < nq; j++) {
-        if (i < j) {
-          //   graph->addEdge(i, j);
+        if (i != j) {
           graph.push_back({i, j});
         }
       }


### PR DESCRIPTION
In the IBM backend, we require [x, y] to exist in the coupling map to execute CX x,y -- [y, x] in the coupling map is not enough. So when IBM does not include a coupling_map for a given backend, we need to include both [i,j] and [j,i] for all qubits i,j s.t. i != j in the coupling map we create; currently, we only include [i,j] for all qubits i,j with i < j, which will cause errors if a circuit includes CX j,i.

Running this program `cnot_repro.cpp` can reproduce: 
```
__qpu__ void cnot(qreg q) {
    CNOT(q[3],q[0]);
    Measure(q);
}

int main() {
    set_shots(64);
    set_verbose(true);

    auto q = qalloc(5);
    cnot(q);
    q.print();
}
```
With the `ibmq_qasm_simulator` you can hopefully reproduce this:
```
$ qcor -qpu ibm:ibmq_qasm_simulator cnot_repro.cpp -o cnot_repro
$ ./cnot_repro
0x7fc8c943687d: (xacc::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<bool ()>)+0x2b)
0x7fc8b4a1d77c: -- error: unable to obtain symbol name for this frame
0x7fc8b4a1f876: (xacc::quantum::IBMAccelerator::execute(std::shared_ptr<xacc::AcceleratorBuffer>, std::vector<std::shared_ptr<xacc::CompositeInstruction>, std::allocator<std::shared_ptr<xacc::CompositeInstruction> > >)+0x4be)
0x7fc8b4a1cf8e: (xacc::quantum::IBMAccelerator::execute(std::shared_ptr<xacc::AcceleratorBuffer>, std::shared_ptr<xacc::CompositeInstruction>)+0xca)
0x7fc8c98de6d4: (xacc::internal_compiler::execute(xacc::AcceleratorBuffer*, std::shared_ptr<xacc::CompositeInstruction>, double*)+0x16c)
0x7fc8c04d8a2a: (qcor::NISQ::submit(xacc::AcceleratorBuffer*)+0x360)
0x7fc8c990f131: (quantum::submit(xacc::AcceleratorBuffer*)+0x38)
0x40b3d2: (cnot::~cnot()+0x302)
0x40993b: (__internal_call_function_cnot(xacc::internal_compiler::qreg)+0x4b)
0x4098b1: (cnot(xacc::internal_compiler::qreg)+0x21)
0x409a96: (main+0x56)
0x7fc8c84170b3: (__libc_start_main+0xf3)
0x4097be: (_start+0x2e)
terminate called after throwing an instance of 'std::runtime_error'
  what():  Invalid logical program connectivity, no connection between [3,0]
Aborted (core dumped)
```

That error is being thrown here: https://github.com/eclipse/xacc/blob/f83e1825735c937686c4c04ba71ea37fbdd42b51/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp#L418

### Testing
That is fixed above with this patch. I also ran `ctest` this time, although `xacc_QAOATester` was not finishing (even without this patch), so I had to exclude it