### PR TITLE
First pass of implementing Accelerator::getNativeCode

### DIFF
--- a/python/examples/ibm_get_native_code.py
+++ b/python/examples/ibm_get_native_code.py
@@ -60,4 +60,4 @@ Measure(q[0], c[3]);
 f = xacc.getCompiled('iterative_qpe')
 
 qpu = xacc.getAccelerator('ibm:ibmq_manhattan')
-print('HOWDY:\n', qpu.getNativeCode(f))
+print('HOWDY:\n', qpu.getNativeCode(f, {'format': 'qasm'}))

--- a/python/examples/ibm_get_native_code.py
+++ b/python/examples/ibm_get_native_code.py
@@ -60,4 +60,17 @@ Measure(q[0], c[3]);
 f = xacc.getCompiled('iterative_qpe')
 
 qpu = xacc.getAccelerator('ibm:ibmq_manhattan')
-print('HOWDY:\n', qpu.getNativeCode(f, {'format': 'qasm'}))
+# Note: this QASM represents the circuit in the *native* gateset of the backend:
+# e.g. {sx, rz, cx}
+print('HOWDY QASM:\n', qpu.getNativeCode(f, {'format': 'qasm'}))
+# we can also see the native circuit as a QObj json
+print('HOWDY QObj:\n', qpu.getNativeCode(f, {'format': 'QObj'}))
+
+
+# Make sure the native QASM is valid by recompiling with Qiskit.
+from qiskit import QuantumCircuit
+qiskit_qc = QuantumCircuit.from_qasm_str(qpu.getNativeCode(f, {'format': 'qasm'}))
+qiskit_qc.draw()
+
+
+

--- a/python/examples/ibm_get_native_code.py
+++ b/python/examples/ibm_get_native_code.py
@@ -1,0 +1,63 @@
+import xacc
+xacc.qasm('''
+.compiler xasm
+.circuit iterative_qpe
+.qbit q
+H(q[0]);
+X(q[1]);
+// Prepare the state:
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+H(q[0]);
+// Measure and reset
+Measure(q[0], c[0]);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+// Conditional rotation
+if(c[0]) {
+    Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], c[1]);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+CPhase(q[0], q[1], -5*pi/8);
+if(c[0]) {
+    Rz(q[0], -pi/4);
+}
+if(c[1]) {
+    Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], c[2]);
+Reset(q[0]);
+H(q[0]);
+CPhase(q[0], q[1], -5*pi/8);
+if(c[0]) {
+    Rz(q[0], -pi/8);
+}
+if(c[1]) {
+    Rz(q[0], -pi/4);
+}
+if(c[2]) {
+    Rz(q[0], -pi/2);
+}
+H(q[0]);
+Measure(q[0], c[3]);
+''')
+
+f = xacc.getCompiled('iterative_qpe')
+
+qpu = xacc.getAccelerator('ibm:ibmq_manhattan')
+print('HOWDY:\n', qpu.getNativeCode(f))

--- a/python/py_accelerator.cpp
+++ b/python/py_accelerator.cpp
@@ -112,6 +112,12 @@ void bind_accelerator(py::module &m) {
                xacc::Accelerator::updateConfiguration,
            "")
       .def("getConnectivity", &xacc::Accelerator::getConnectivity, "")
+      .def(
+          "getNativeCode",
+          [](xacc::Accelerator &qpu, std::shared_ptr<CompositeInstruction> f) {
+            return qpu.getNativeCode(f);
+          },
+          "")
       .def("configurationKeys", &xacc::Accelerator::configurationKeys, "")
       .def("contributeInstructions", &xacc::Accelerator::contributeInstructions,
            "");

--- a/python/py_accelerator.cpp
+++ b/python/py_accelerator.cpp
@@ -118,6 +118,18 @@ void bind_accelerator(py::module &m) {
             return qpu.getNativeCode(f);
           },
           "")
+      .def(
+          "getNativeCode",
+          [](xacc::Accelerator &qpu, std::shared_ptr<CompositeInstruction> f,
+             PyHeterogeneousMap &options) {
+            HeterogeneousMap m;
+            for (auto &item : options) {
+              PyHeterogeneousMap2HeterogeneousMap vis(m, item.first);
+              mpark::visit(vis, item.second);
+            }
+            return qpu.getNativeCode(f, m);
+          },
+          "")
       .def("configurationKeys", &xacc::Accelerator::configurationKeys, "")
       .def("contributeInstructions", &xacc::Accelerator::contributeInstructions,
            "");

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -1275,7 +1275,11 @@ IBMAccelerator::getNativeCode(std::shared_ptr<CompositeInstruction> program,
       if (nextInst->isEnabled() && !nextInst->isComposite()) {
         auto visitor = std::make_shared<QObjectExperimentVisitor>(
             program->name(), program->nLogicalBits(), gateSet);
+        visitor->maxMemorySlots = memSlots;
         nextInst->accept(visitor);
+        if (nextInst->name() == "Measure") {
+          ++memSlots;
+        }
         auto experiment = visitor->getExperiment();
         for (auto &inst : experiment.get_instructions()) {
           // std::cout << "HOWDY: " << inst.toString() << "\n";

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -1238,6 +1238,35 @@ void IBMAccelerator::put(const std::string &_url, const std::string &postStr,
 }
 
 std::string
+IBMAccelerator::getNativeCode(std::shared_ptr<CompositeInstruction> program,
+                              const HeterogeneousMap &config) {
+  std::string format = "QObj"; // QObj/QASM
+  if (config.stringExists("format")) {
+    format = config.getString("format");
+  }
+
+  // Handle different ways to specify the format:
+  if (format == "QObj" || format == "QOBJ" || format == "JSON") {
+    chosenBackend = availableBackends[backend];
+    auto connectivity = getConnectivity();
+    // Get the correct QObject Generator
+    auto qobjGen = xacc::getService<QObjGenerator>(mode);
+
+    // Generate the QObject JSON
+    auto jsonStr = qobjGen->getQObjJsonStr(
+        {program}, shots, chosenBackend, getBackendPropsResponse, connectivity,
+        json::parse(defaults_response));
+
+    return jsonStr;
+  } else if (format == "qasm" || format == "Qasm" || format == "QASM" ||
+             format == "OpenQASM" || format == "OPENQASM") {
+    return "";
+  }
+  xacc::error("Unknown native code format '" + format + "'");
+  return "";
+}
+
+std::string
 IBMAccelerator::get(const std::string &_url, const std::string &path,
                     std::map<std::string, std::string> headers,
                     std::map<std::string, std::string> extraParams) {

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.cpp
@@ -1315,12 +1315,12 @@ IBMAccelerator::getNativeCode(std::shared_ptr<CompositeInstruction> program,
                   "c[" + std::to_string(nextInst->bits()[0]) + "]";
               if (cbit_reg_map.find(orig_reg_name) != cbit_reg_map.end()) {
                 const std::string single_reg_name = cbit_reg_map[orig_reg_name];
-                ss << "if (c[" << nextInst->bits()[0] << "] == 1) ";
+                ss << "if (" + single_reg_name + " == 1) ";
               } else {
                 const std::string single_reg_name =
                     "cReg" + std::to_string(cbit_reg_map.size());
                 cbit_reg_map[orig_reg_name] = single_reg_name;
-                ss << "if (c[" << nextInst->bits()[0] << "] == 1) ";
+                ss << "if (" + single_reg_name + " == 1) ";
               }
               ss << inst.toString() << "\n";
             }

--- a/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
+++ b/quantum/plugins/ibm/accelerator/IBMAccelerator.hpp
@@ -131,6 +131,8 @@ public:
 
   std::vector<std::pair<int, int>> getConnectivity() override;
 
+  std::string getNativeCode(std::shared_ptr<CompositeInstruction> program,
+                            const HeterogeneousMap &config) override;
   // Return the name of an IRTransformation of type Placement that is
   // preferred for this Accelerator
   const std::string defaultPlacementTransformation() override {

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -399,6 +399,26 @@ public:
 
   std::optional<int64_t> get_condition_reg_id() const { return conditional; }
   void set_condition_reg_id(int64_t value) { this->conditional = value; }
+
+  std::string toString() const {
+    std::stringstream ss;
+    ss << name;
+    if (!params.empty()) {
+      ss << "(";
+      for (int i = 0; i < params.size(); ++i) {
+        ss << params[i];
+        if (i != params.size() - 1) {
+          ss << ", ";
+        }
+      }
+      ss << ")";
+    }
+    for (const auto &qb : qubits) {
+      ss << " q[" << qb << "]";
+    }
+    ss << ";";
+    return ss.str();
+  }
 };
 
 class Experiment {

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -413,8 +413,15 @@ public:
       }
       ss << ")";
     }
-    for (const auto &qb : qubits) {
-      ss << " q[" << qb << "]";
+    for (int i = 0; i < qubits.size(); ++i) {
+      ss << " q[" << qubits[i] << "]";
+      if (i != qubits.size() - 1) {
+        ss << ", ";
+      }
+    }
+
+    if (!get_memory().empty()) {
+      ss << " -> c[" << get_memory()[0] << "]";
     }
     ss << ";";
     return ss.str();

--- a/xacc/accelerator/Accelerator.hpp
+++ b/xacc/accelerator/Accelerator.hpp
@@ -106,6 +106,14 @@ public:
     return std::vector<std::pair<int, int>>{};
   }
 
+  // Get circuit representation that the backend would be submitting to the
+  // physical QPU
+  virtual std::string
+  getNativeCode(std::shared_ptr<CompositeInstruction> program,
+                const HeterogeneousMap &config = {}) {
+    return program->toString();
+  }
+
   virtual const std::vector<std::complex<double>>
   getAcceleratorState(std::shared_ptr<CompositeInstruction> program) {
     return std::vector<std::complex<double>>{};


### PR DESCRIPTION
- Returns a string representation of the native code. Default to just return the XASM printout as is.

- IBM backend: support both the QObj and OpenQasm formats. Leveraging the `QObjectExperimentVisitor` utility to generate native code (as `xacc::ibm::Instruction`). Add a `toString` method returning an OpenQASM equivalent.

- Add Python binding.
