### PR TITLE
Consider SWAPs in swap-shortest-path

### DIFF
--- a/quantum/plugins/staq/transformations/staq_swap_short.cpp
+++ b/quantum/plugins/staq/transformations/staq_swap_short.cpp
@@ -78,10 +78,11 @@ void SwapShort::apply(std::shared_ptr<CompositeInstruction> program,
     transformations::desugar(*prog);
     transformations::Inliner::config c;
     // Make sure we treat map all control pauli 
-    // ops as CNOT gates
+    // ops and swaps as CNOT gates
     c.overrides.erase("cx");
     c.overrides.erase("cy");
     c.overrides.erase("cz");
+    c.overrides.erase("swap");
     transformations::inline_ast(*prog, c);
   } catch (std::exception &e) {
     std::stringstream ss;


### PR DESCRIPTION
Remove SWAP gates from the two-qubit gate whitelist for Staq placement also modified in f1eedf0. Otherwise, Swap instructions between non-adjacent qubits can slip through the swap-shortest-path IRTransformation. An example of this would be the QCOR qft() routine, which can generate a Swap between far-away qubits at the end.

Combined with f1eedf0, fixes ORNL-QCI/qcor#199.

## Testing
Ran `ctest -E QAOATester` which also ran a test for this I added (see diff)