### PR TITLE
Support IfStmt to OpenQASM2 generation

### DIFF
--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -76,6 +76,9 @@ public:
   std::vector<InstructionParameter> getParameters() override {
     return {bufferName};
   }
+
+  std::vector<std::string> getBufferNames() override { return {bufferName}; }
+
   const int nParameters() override { return 1; }
 
   const int nRequiredBits() const override { return 1; }

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -832,6 +832,14 @@ IbmqNoiseModel::averageTwoQubitGateFidelity() const {
 
   return result;
 }
+
+std::string
+AerAccelerator::getNativeCode(std::shared_ptr<CompositeInstruction> program,
+                              const HeterogeneousMap &config) {
+  auto qobj_str = xacc_to_qobj->translate(program);
+  nlohmann::json j = nlohmann::json::parse(qobj_str)["qObject"];
+  return j.dump(2);
+}
 } // namespace quantum
 } // namespace xacc
 

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
@@ -60,7 +60,8 @@ public:
   void apply(std::shared_ptr<AcceleratorBuffer> buffer,
              std::shared_ptr<Instruction> inst) override;
   bool isInitialized() const { return initialized; }
-
+  std::string getNativeCode(std::shared_ptr<CompositeInstruction> program,
+                            const HeterogeneousMap &config = {}) override;
 private:
   static double calcExpectationValueZ(
       const std::vector<std::pair<double, double>> &in_stateVec,

--- a/quantum/plugins/optimizers/simple/CircuitOptimizer.cpp
+++ b/quantum/plugins/optimizers/simple/CircuitOptimizer.cpp
@@ -678,6 +678,21 @@ bool CircuitOptimizer::tryRotationMergingUsingPhasePolynomials(std::shared_ptr<C
             }
           }
           else if (instruction->bits().size() == 2) {
+            // If this gate not involved the qubits that we are checking
+            if (!container::contains(qubits, instruction->bits()[0]) &&
+                !container::contains(qubits, instruction->bits()[1])) {
+              // Skip
+              continue;
+            }
+
+            // This 2-q gate **involves** at least one qubit:
+            if (instruction->name() != "CNOT") {
+              // Not a CNOT: we need to terminate, hence prune the subcircuit.
+              // Move the outer loop index to after this gate.
+              i = idx + 1;
+              break;
+            }
+
             assert(instruction->name() == "CNOT");
             // If the control is *outside* the boundary, we need to terminate, hence prune the subcircuit.
             const auto controlIdx = instruction->bits()[0];

--- a/quantum/plugins/optimizers/simple/CircuitOptimizer.cpp
+++ b/quantum/plugins/optimizers/simple/CircuitOptimizer.cpp
@@ -688,8 +688,6 @@ bool CircuitOptimizer::tryRotationMergingUsingPhasePolynomials(std::shared_ptr<C
             // This 2-q gate **involves** at least one qubit:
             if (instruction->name() != "CNOT") {
               // Not a CNOT: we need to terminate, hence prune the subcircuit.
-              // Move the outer loop index to after this gate.
-              i = idx + 1;
               break;
             }
 
@@ -750,6 +748,8 @@ bool CircuitOptimizer::tryRotationMergingUsingPhasePolynomials(std::shared_ptr<C
           }
         }
       }
+      // Move the instruction index
+      ++i;
     }
     else {
       // Not a CNOT gate, continue

--- a/quantum/plugins/optimizers/simple/tests/CircuitOptimizerTester.cpp
+++ b/quantum/plugins/optimizers/simple/tests/CircuitOptimizerTester.cpp
@@ -818,6 +818,26 @@ measure q[3] -> c[3];
   EXPECT_EQ(truthTableBefore, truthTableAfter);
 }
 
+TEST(CircuitOptimizerTester, checkCZ) {
+  xacc::set_verbose(true);
+  auto compiler = xacc::getService<xacc::Compiler>("xasm");
+  auto program = compiler
+                     ->compile(R"(__qpu__ void testCz(qbit q) {
+        CNOT(q[0], q[1]);
+        CZ(q[0], q[1]);
+        Measure(q[0]);
+        Measure(q[1]);
+    })")
+                     ->getComposites()[0];
+
+  const auto before_xasm_str = program->toString();
+  auto optimizer = xacc::getService<IRTransformation>("circuit-optimizer");
+  optimizer->apply(program, nullptr);
+  std::cout << "FINAL CIRCUIT:\n" << program->toString() << "\n";
+  const auto after_xasm_str = program->toString();
+  EXPECT_EQ(before_xasm_str, after_xasm_str);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);

--- a/quantum/plugins/optimizers/simple/tests/CircuitOptimizerTester.cpp
+++ b/quantum/plugins/optimizers/simple/tests/CircuitOptimizerTester.cpp
@@ -838,6 +838,33 @@ TEST(CircuitOptimizerTester, checkCZ) {
   EXPECT_EQ(before_xasm_str, after_xasm_str);
 }
 
+// Check circuit with random gates
+TEST(CircuitOptimizerTester, checkComplexCircuit) {
+  xacc::set_verbose(true);
+  auto compiler = xacc::getService<xacc::Compiler>("xasm");
+  auto program = compiler
+                     ->compile(R"(__qpu__ void testRandom(qbit q) {
+    X(q[0]);
+    H(q[1]);
+    CZ(q[0], q[1]);
+    H(q[1]);
+    CNOT(q[1], q[2]);
+    T(q[1]);
+    CZ(q[1], q[0]);
+    Measure(q[0]);
+    Measure(q[1]);
+    Measure(q[2]);
+    })")
+                     ->getComposites()[0];
+
+  const auto before_xasm_str = program->toString();
+  auto optimizer = xacc::getService<IRTransformation>("circuit-optimizer");
+  optimizer->apply(program, nullptr);
+  std::cout << "FINAL CIRCUIT:\n" << program->toString() << "\n";
+  const auto after_xasm_str = program->toString();
+  EXPECT_EQ(before_xasm_str, after_xasm_str);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);

--- a/quantum/plugins/staq/compiler/staq_compiler.cpp
+++ b/quantum/plugins/staq/compiler/staq_compiler.cpp
@@ -432,7 +432,7 @@ StaqCompiler::translate(std::shared_ptr<xacc::CompositeInstruction> function) {
   // First search buffer names and see if we have
   while (iter.hasNext()) {
     auto &next = *iter.next();
-    if (next.isEnabled()) {
+    if (!next.isComposite() && next.isEnabled()) {
       for (int i = 0; i < next.nRequiredBits(); i++) {
         auto bufName = next.getBufferName(i);
         int size = next.bits()[i] + 1;

--- a/quantum/plugins/staq/compiler/staq_compiler.cpp
+++ b/quantum/plugins/staq/compiler/staq_compiler.cpp
@@ -428,27 +428,56 @@ std::shared_ptr<IR> StaqCompiler::compile(const std::string &src) {
 const std::string
 StaqCompiler::translate(std::shared_ptr<xacc::CompositeInstruction> function) {
   std::map<std::string, int> bufNamesToSize;
+  std::map<std::string, int> cRegNamesToSize;
   InstructionIterator iter(function);
   // First search buffer names and see if we have
   while (iter.hasNext()) {
     auto &next = *iter.next();
     if (!next.isComposite() && next.isEnabled()) {
-      for (int i = 0; i < next.nRequiredBits(); i++) {
-        auto bufName = next.getBufferName(i);
-        int size = next.bits()[i] + 1;
-        if (bufNamesToSize.count(bufName)) {
-          if (bufNamesToSize[bufName] < size) {
-            bufNamesToSize[bufName] = size;
+      if (next.name() == "Measure") {
+        xacc::quantum::Measure &m = (xacc::quantum::Measure &)next;
+        if (m.hasClassicalRegAssignment()) {
+          auto cregName = next.getBufferName(1);
+          int size = m.getClassicalBitIndex() + 1;
+          if (cRegNamesToSize.count(cregName)) {
+            if (cRegNamesToSize[cregName] < size) {
+              cRegNamesToSize[cregName] = size;
+            }
+          } else {
+            cRegNamesToSize.insert({cregName, size});
           }
         } else {
-          bufNamesToSize.insert({bufName, size});
+          auto bufName = next.getBufferName(0);
+          int size = next.bits()[0] + 1;
+          if (bufNamesToSize.count(bufName)) {
+            if (bufNamesToSize[bufName] < size) {
+              bufNamesToSize[bufName] = size;
+            }
+          } else {
+            bufNamesToSize.insert({bufName, size});
+          }
+        }
+      } else {
+        for (int i = 0; i < next.nRequiredBits(); i++) {
+          auto bufName = next.getBufferName(i);
+          int size = next.bits()[i] + 1;
+          if (bufNamesToSize.count(bufName)) {
+            if (bufNamesToSize[bufName] < size) {
+              bufNamesToSize[bufName] = size;
+            }
+          } else {
+            bufNamesToSize.insert({bufName, size});
+          }
         }
       }
     }
   }
 
   auto translate =
-      std::make_shared<internal_staq::XACCToStaqOpenQasm>(bufNamesToSize);
+      cRegNamesToSize.empty()
+          ? std::make_shared<internal_staq::XACCToStaqOpenQasm>(bufNamesToSize)
+          : std::make_shared<internal_staq::XACCToStaqOpenQasm>(
+                bufNamesToSize, cRegNamesToSize);
   InstructionIterator iter2(function);
   while (iter2.hasNext()) {
     auto &next = *iter2.next();

--- a/quantum/plugins/staq/utils/staq_visitors.hpp
+++ b/quantum/plugins/staq/utils/staq_visitors.hpp
@@ -266,7 +266,8 @@ class XACCToStaqOpenQasm : public AllGateVisitor {
 public:
   std::stringstream ss;
   std::map<std::string, std::string> cregNames;
-
+  // Last known creg that stored the measurement result of a qubit
+  std::map<size_t, std::string> qubitIdxToMeasCregName;
   XACCToStaqOpenQasm(std::map<std::string, int> bufNamesToSize);
   void visit(Hadamard &h) override;
   void visit(CNOT &cnot) override;

--- a/quantum/plugins/staq/utils/staq_visitors.hpp
+++ b/quantum/plugins/staq/utils/staq_visitors.hpp
@@ -266,9 +266,13 @@ class XACCToStaqOpenQasm : public AllGateVisitor {
 public:
   std::stringstream ss;
   std::map<std::string, std::string> cregNames;
-  // Last known creg that stored the measurement result of a qubit
-  std::map<size_t, std::string> qubitIdxToMeasCregName;
+  // Default: assume each qreg is accompanied by a creg of the same size
   XACCToStaqOpenQasm(std::map<std::string, int> bufNamesToSize);
+  // Explicit list of creg:
+  // e.g., IQPE algo: we requires a much larger creg than qreg to store all
+  // measurements.
+  XACCToStaqOpenQasm(std::map<std::string, int> bufNamesToSize,
+                     std::map<std::string, int> cRegNameToSize);
   void visit(Hadamard &h) override;
   void visit(CNOT &cnot) override;
   void visit(Rz &rz) override;


### PR DESCRIPTION
- XACCToStaqOpenQasm to support measure to specific creg bit and if statement to OpenQASM2.

- Fixed a bug in CircuitOptimizer (https://github.com/eclipse/xacc/issues/478)

- Aer to support native code queries as well (Aer can simulate QObj with `bfunc` generated by IfStmt)