### PR TITLE
AcceleratorBuffer: Use exp-val-z extra info for getExpectationValueZ() if present

### DIFF
--- a/xacc/accelerator/AcceleratorBuffer.cpp
+++ b/xacc/accelerator/AcceleratorBuffer.cpp
@@ -424,9 +424,15 @@ const double AcceleratorBuffer::getExpectationValueZ() {
     return 1;
   };
 
-  if (bitStringToCounts.empty() && this->hasExtraInfoKey("exp-val-z")) {
+  if (this->hasExtraInfoKey("exp-val-z")) {
     aver = mpark::get<double>(getInformation("exp-val-z"));
   } else {
+    if (bitStringToCounts.empty()) {
+      xacc::error("called getExpectationValueZ() on an AcceleratorBuffer with "
+                  "no measurements!");
+      return 0;
+    }
+
     for (auto &kv : bitStringToCounts) {
       int i = std::stoi(kv.first, nullptr, 2);
       auto par = has_even_parity(i);

--- a/xacc/accelerator/tests/AcceleratorBufferTester.cpp
+++ b/xacc/accelerator/tests/AcceleratorBufferTester.cpp
@@ -55,6 +55,19 @@ TEST(AcceleratorBufferTester, checkGetExpectationValueZ) {
   EXPECT_TRUE(std::fabs(b.getExpectationValueZ() - 0.178955078125) < 1e-6);
 }
 
+TEST(AcceleratorBufferTester, checkGetExpectationValueZPrioritizesExtraInfo) {
+
+  AcceleratorBuffer buffer("qreg", 5);
+
+  // Add decoy measurements, which have expected value of Z = 1
+  buffer.appendMeasurement("00000", 500);
+  // Add actual expectation we want
+  buffer.addExtraInfo("exp-val-z", -1.0);
+
+  // This should draw from extra info, not calculate from measurements
+  EXPECT_EQ(buffer.getExpectationValueZ(), -1.0);
+}
+
 TEST(AcceleratorBufferTester, checkLoad) {
   const std::string bufferStr = R"bufferStr({
     "AcceleratorBuffer": {


### PR DESCRIPTION
I guess this is a question in the form of a PR. Why does this condition exist (see diff)? I encountered it when working on a VQE benchmark.

For context, I currently don't have a way to pass number of shots to the control software (IGOR) simulator. So it writes a result file with some simulated measurements (for a hardcoded number of "runs") along with the actual state vector. The backend takes the simulated measurement counts and calls `appendMeasurement()` for those, and then calculates the expectation value of Z directly from the state vector and `addExtraInfo("exp-val-z")`s that. But originally, the control software just returned the simulated measurements, and I was seeing that the variational optimizer was having trouble converging when using the expectation value calculated by AcceleratorBuffer from those measurements, so then I added the `addExtraInfo("exp-val-z")` stuff. But I realized that wasn't being used, which I tracked down to this condition.

Is what I'm doing just too weird? I realize the Quantum++ backend decides whether to `appendMeasurement()` or  `addExtraInfo("exp-val-z")` based off the presence of the `shots` param, but the current implementation of the GTRI Accelerator doesn't have a `shots` parameter or any logic like that.

## Testing
Ran `ctest`. Also added a test for this admittedly strange situation