### PR TITLE
Add some instructions for common ion trap native gates

### DIFF
--- a/quantum/gate/GateQuantumActivator.cpp
+++ b/quantum/gate/GateQuantumActivator.cpp
@@ -54,6 +54,8 @@ public:
     auto xy = std::make_shared<xacc::quantum::XY>();
     auto u = std::make_shared<xacc::quantum::U>();
     auto u1 = std::make_shared<xacc::quantum::U1>();
+    auto rphi = std::make_shared<xacc::quantum::Rphi>();
+    auto xx = std::make_shared<xacc::quantum::XX>();
 
     auto anneal = std::make_shared<xacc::quantum::AnnealingInstruction>();
 
@@ -92,6 +94,8 @@ public:
     context.RegisterService<xacc::Instruction>(xy);
     context.RegisterService<xacc::Instruction>(u);
     context.RegisterService<xacc::Instruction>(u1);
+    context.RegisterService<xacc::Instruction>(rphi);
+    context.RegisterService<xacc::Instruction>(xx);
 
     context.RegisterService<xacc::Instruction>(ifstmt);
     context.RegisterService<xacc::Instruction>(anneal);

--- a/quantum/gate/ir/CommonGates.hpp
+++ b/quantum/gate/ir/CommonGates.hpp
@@ -301,6 +301,49 @@ public:
   DEFINE_VISITABLE()
 };
 
+// The R_phi(theta) rotation from the Methods section of
+// https://www.nature.com/articles/nature18648
+class Rphi: public Gate {
+public:
+  Rphi()
+      : Gate("Rphi",
+             std::vector<InstructionParameter>{InstructionParameter(0.0),
+                                               InstructionParameter(0.0)}) {}
+  Rphi(std::size_t qbit, std::vector<xacc::InstructionParameter> params)
+      : Gate("Rphi", std::vector<std::size_t>{qbit}, params) {}
+  Rphi(std::size_t qbit, double phi, double theta)
+      : Gate("Rphi", std::vector<std::size_t>{qbit},
+             std::vector<InstructionParameter>{InstructionParameter(phi),
+                                               InstructionParameter(theta)}) {}
+
+  const int nRequiredBits() const override { return 1; }
+
+  DEFINE_CLONE(Rphi)
+  DEFINE_VISITABLE()
+};
+
+// The XX(alpha) entangling gate from the Methods section of
+// https://www.nature.com/articles/nature18648
+// (We call the parameter alpha instead of chi_ij)
+class XX : public Gate {
+public:
+  XX() : Gate("XX", std::vector<InstructionParameter>{0.0}) {}
+  XX(std::size_t leftQubit, std::size_t rightQubit)
+      : Gate("XX", std::vector<std::size_t>{leftQubit, rightQubit},
+             std::vector<InstructionParameter>{0.0, 0.0}) {}
+  XX(std::size_t leftQubit, std::size_t rightQubit, double alpha)
+      : Gate("XX", std::vector<std::size_t>{leftQubit, rightQubit},
+             std::vector<InstructionParameter>{alpha}) {}
+  XX(std::vector<std::size_t> qbits)
+      : Gate("XX", qbits, std::vector<InstructionParameter>{0.0}) {}
+  XX(std::vector<std::size_t> qbits, double alpha)
+      : Gate("XX", qbits, std::vector<InstructionParameter>{alpha}) {}
+  const int nRequiredBits() const override { return 2; }
+
+  DEFINE_CLONE(XX)
+  DEFINE_VISITABLE()
+};
+
 class X : public Gate {
 public:
   X() : Gate("X") {}

--- a/quantum/gate/utils/IRToGraphVisitor.hpp
+++ b/quantum/gate/utils/IRToGraphVisitor.hpp
@@ -70,9 +70,18 @@ public:
   void visit(Sdg &sdg) override {addSingleQubitGate(sdg);}
   void visit(T &t) override {addSingleQubitGate(t);}
   void visit(Tdg &tdg) override {addSingleQubitGate(tdg);}
+  void visit(Rphi &rphi) override { addSingleQubitGate(rphi); }
+  void visit(U1 &u1) override { addSingleQubitGate(u1); }
 
-  void visit(CRZ &crz) override {addTwoQubitGate(crz);}
-  void visit(CH &ch) override {addTwoQubitGate(ch);}
+  void visit(CRZ &crz) override { addTwoQubitGate(crz); }
+  void visit(CH &ch) override { addTwoQubitGate(ch); }
+  void visit(CY &cy) override { addTwoQubitGate(cy); }
+  void visit(fSim &fsim) override { addTwoQubitGate(fsim); }
+  void visit(iSwap &iswap) override { addTwoQubitGate(iswap); }
+  void visit(RZZ &rzz) override { addTwoQubitGate(rzz); }
+  void visit(XX &xx) override { addTwoQubitGate(xx); }
+  void visit(XY &xy) override { addTwoQubitGate(xy); }
+
   // Base gate visitor, i.e. none of the concrete gates can match.
   // We need to assert here because we cannot generate a graph when there are unknown gates.
   // e.g. there is an 1-1 mapping between node Id (in the graph) and instruction counter (in the circuit),


### PR DESCRIPTION
Not sure if users would use these, but they are useful in
IRTransformations in the GTRI testbed backend.

Definitions are from the Methods section of the following paper:
https://www.nature.com/articles/nature18648

## Testing
`ctest`