### PR TITLE
Adding layer metadata to gate node in the DAG representation

### DIFF
--- a/quantum/gate/ir/Circuit.cpp
+++ b/quantum/gate/ir/Circuit.cpp
@@ -199,7 +199,7 @@ void Circuit::load(std::istream &inStream) {
   }
 }
 
-const int Circuit::depth() { return toGraph()->depth() - 2; }
+const int Circuit::depth() { return toGraph()->depth(); }
 
 const std::string Circuit::persistGraph() {
   std::stringstream s;

--- a/quantum/gate/ir/tests/GateTester.cpp
+++ b/quantum/gate/ir/tests/GateTester.cpp
@@ -279,11 +279,11 @@ TEST(GateTester, checkGenerateGraph) {
   std::string expected = R"expected(digraph G {
 node [shape=box style=filled]
 0 [label="bits=[0,1,2];id=0;name=InitialState"];
-1 [label="bits=[1];id=1;name=H"];
-2 [label="bits=[1,2];id=2;name=CNOT"];
-3 [label="bits=[0,1];id=3;name=CNOT"];
-4 [label="bits=[0];id=4;name=H"];
-5 [label="bits=[2];id=5;name=Rz"];
+1 [label="bits=[1];id=1;layer=0;name=H"];
+2 [label="bits=[1,2];id=2;layer=1;name=CNOT"];
+3 [label="bits=[0,1];id=3;layer=2;name=CNOT"];
+4 [label="bits=[0];id=4;layer=3;name=H"];
+5 [label="bits=[2];id=5;layer=3;name=Rz"];
 6 [label="bits=[0,1,2];id=6;name=FinalState"];
 0->1 ;
 0->2 ;

--- a/quantum/gate/utils/IRToGraphVisitor.cpp
+++ b/quantum/gate/utils/IRToGraphVisitor.cpp
@@ -30,7 +30,10 @@ void IRToGraphVisitor::addSingleQubitGate(Gate &inst) {
                       std::make_pair("bits", inst.bits())};
 
   graph->addVertex(newNode);
-  graph->addEdge(lastNode.get<std::size_t>("id"), newNode.get<std::size_t>("id"), 1);
+  graph->addEdge(lastNode.get<std::size_t>("id"),
+                 newNode.get<std::size_t>("id"), 1);
+  const int layerId = graph->depth();
+  graph->getVertexProperties(id).insert("layer", layerId);
 
   qubitToLastNode[bit] = newNode;
 }
@@ -49,7 +52,8 @@ void IRToGraphVisitor::addTwoQubitGate(Gate &inst) {
   graph->addVertex(newNode);
   graph->addEdge(lastsrcnodeid, id, 1);
   graph->addEdge(lasttgtnodeid, id, 1);
-
+  const auto layerId = graph->depth();
+  graph->getVertexProperties(id).insert("layer", layerId);
   qubitToLastNode[srcbit] = newNode;
   qubitToLastNode[tgtbit] = newNode;
 }

--- a/quantum/gate/utils/tests/IRToGraphVisitorTester.cpp
+++ b/quantum/gate/utils/tests/IRToGraphVisitorTester.cpp
@@ -44,6 +44,23 @@ TEST(IRToGraphTester, checkSimple) {
   auto graph = vis->getGraph();
 
   graph->write(std::cout);
+  EXPECT_EQ(graph->order(), f->nInstructions() + 2);
+  // X and H are on the first layer
+  EXPECT_EQ(graph->getVertexProperties(1).getString("name"), x->name());
+  EXPECT_EQ(graph->getVertexProperties(1).get<int>("layer"), 0);
+  EXPECT_EQ(graph->getVertexProperties(2).getString("name"), h->name());
+  EXPECT_EQ(graph->getVertexProperties(2).get<int>("layer"), 0);
+
+  // CNOT on the second layer
+  EXPECT_EQ(graph->getVertexProperties(3).getString("name"), "CNOT");
+  EXPECT_EQ(graph->getVertexProperties(3).get<int>("layer"), 1);
+
+  // Rz and Z on the third layer
+  EXPECT_EQ(graph->getVertexProperties(4).getString("name"), rz->name());
+  EXPECT_EQ(graph->getVertexProperties(4).get<int>("layer"), 2);
+
+  EXPECT_EQ(graph->getVertexProperties(5).getString("name"), z->name());
+  EXPECT_EQ(graph->getVertexProperties(5).get<int>("layer"), 2);
 }
 
 TEST(IRToGraphTester, checkCNOTLadder) {
@@ -69,6 +86,12 @@ TEST(IRToGraphTester, checkCNOTLadder) {
   auto graph = vis->getGraph();
 
   graph->write(std::cout);
+  // These CNOT gates cannot be on the same layer.
+  for (int i = 1; i < graph->order() - 2; i++) {
+    auto node = graph->getVertexProperties(i);
+    EXPECT_EQ(node.getString("name"), "CNOT");
+    EXPECT_EQ(node.get<int>("layer"), i - 1);
+  }
 }
 
 int main(int argc, char **argv) {

--- a/quantum/gate/utils/tests/IRToGraphVisitorTester.cpp
+++ b/quantum/gate/utils/tests/IRToGraphVisitorTester.cpp
@@ -61,6 +61,7 @@ TEST(IRToGraphTester, checkSimple) {
 
   EXPECT_EQ(graph->getVertexProperties(5).getString("name"), z->name());
   EXPECT_EQ(graph->getVertexProperties(5).get<int>("layer"), 2);
+  EXPECT_EQ(f->depth(), 3);
 }
 
 TEST(IRToGraphTester, checkCNOTLadder) {
@@ -92,6 +93,15 @@ TEST(IRToGraphTester, checkCNOTLadder) {
     EXPECT_EQ(node.getString("name"), "CNOT");
     EXPECT_EQ(node.get<int>("layer"), i - 1);
   }
+  EXPECT_EQ(f->depth(), 4);
+}
+
+TEST(IRToGraphTester, checkSingleGate) {
+  auto f = std::make_shared<Circuit>("foo");
+  auto x = std::make_shared<X>(0);
+  f->addInstruction(x);
+  f->toGraph()->write(std::cout);
+  EXPECT_EQ(f->depth(), 1);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Also, fixed the circuit depth method (the graph depth has accounted for the initial and end nodes)