### PR TITLE
Fixed https://github.com/eclipse/xacc/issues/466

### DIFF
--- a/tpls/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h
+++ b/tpls/eigen/Eigen/src/Core/arch/AltiVec/PacketMath.h
@@ -452,7 +452,7 @@ template<> EIGEN_STRONG_INLINE Packet4f pandnot<Packet4f>(const Packet4f& a, con
 template<> EIGEN_STRONG_INLINE Packet4i pandnot<Packet4i>(const Packet4i& a, const Packet4i& b) { return vec_and(a, vec_nor(b, b)); }
 
 template<> EIGEN_STRONG_INLINE Packet4f pselect(const Packet4f& mask, const Packet4f& a, const Packet4f& b) {
-  return vec_sel(b, a, mask);
+  return vec_sel(b, a, reinterpret_cast<Packet4ui>(mask));
 }
 
 template<> EIGEN_STRONG_INLINE Packet4f pround<Packet4f>(const Packet4f& a) { return vec_round(a); }


### PR DESCRIPTION
Cherrypicking the Eigen fix to XACC:

https://gitlab.com/libeigen/eigen/-/commit/66d073c38e3cd5dad974deea7b3d1d45247ea55b

Note: updating the whole eigen to the latest version brings other unnecessary compatibility issues.

