### PR TITLE
Added some missing headers for GCC 11 compatibility

### DIFF
--- a/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/QuantumNaturalGradient.cpp
@@ -15,7 +15,7 @@
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 #include <cassert>
-
+#include <optional>
 using namespace xacc;
 
 namespace {

--- a/quantum/plugins/ibm/accelerator/json/PulseQObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/PulseQObject.hpp
@@ -16,6 +16,7 @@
 
 #include <stdexcept>
 #include <regex>
+#include <optional>
 
 namespace xacc {
 namespace ibm_pulse {

--- a/quantum/plugins/ibm/accelerator/json/QObject.hpp
+++ b/quantum/plugins/ibm/accelerator/json/QObject.hpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include <regex>
 #include <unordered_map>
+#include <optional>
 #ifndef NLOHMANN_OPT_HELPER
 #define NLOHMANN_OPT_HELPER
 namespace nlohmann {

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -29,6 +29,7 @@
 #include "xacc_service.hpp"
 
 #include <bitset>
+#include <optional>
 #include "QObjGenerator.hpp"
 #include "py-aer/aer_python_adapter.hpp"
 

--- a/quantum/plugins/optimizers/gate_merge/GateMergeOptimizer.cpp
+++ b/quantum/plugins/optimizers/gate_merge/GateMergeOptimizer.cpp
@@ -2,7 +2,7 @@
 #include "GateMergeOptimizer.hpp"
 #include "GateFusion.hpp"
 #include "xacc_service.hpp"
-
+#include <optional>
 namespace {
 bool compareMatIgnoreGlobalPhase(const Eigen::Matrix4cd& in_a, const Eigen::Matrix4cd& in_b)
 {

--- a/quantum/plugins/qsim/accelerator/QsimAccelerator.cpp
+++ b/quantum/plugins/qsim/accelerator/QsimAccelerator.cpp
@@ -14,7 +14,7 @@
 #include "xacc_plugin.hpp"
 #include "IRUtils.hpp"
 #include <cassert>
-
+#include <optional>
 namespace {
 inline bool isMeasureGate(const xacc::InstPtr &in_instr) {
   return (in_instr->name() == "Measure");

--- a/xacc/ir/Instruction.hpp
+++ b/xacc/ir/Instruction.hpp
@@ -17,6 +17,7 @@
 #include "Cloneable.hpp"
 #include "InstructionVisitor.hpp"
 #include "heterogeneous.hpp"
+#include <limits>
 
 namespace xacc {
 using InstructionParameter = Variant<int, double, std::string>;


### PR DESCRIPTION
Ref: https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes

```
The following headers are used less widely in libstdc++ and may need to be included explicitly when compiled with GCC 11:
<limits> (for std::numeric_limits)
<memory> (for std::unique_ptr, std::shared_ptr etc.)
<utility> (for std::pair, std::tuple_size, std::index_sequence etc.)
<thread> (for members of namespace std::this_thread.)
```

Also, our cppmicroservices fork has been updated to include a missing header file.