### PR TITLE
Add one-qubit IRTransformation for ion trap backend

### DIFF
--- a/quantum/plugins/iontrap/CMakeLists.txt
+++ b/quantum/plugins/iontrap/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_NAME xacc-iontrap)
 
 file(GLOB SRC
           *.cpp
+          decomp/*.cpp
           transformations/*.cpp)
 
 usfunctiongetresourcesource(TARGET ${LIBRARY_NAME} OUT SRC)
@@ -24,6 +25,7 @@ add_library(${LIBRARY_NAME} SHARED ${SRC})
 
 target_include_directories(${LIBRARY_NAME}
                              PUBLIC .
+                                    ./decomp
                                     ./transformations
                                     ${CMAKE_SOURCE_DIR}/tpls/ensmallen
                                     ${CMAKE_SOURCE_DIR}/tpls/armadillo)

--- a/quantum/plugins/iontrap/IonTrapActivator.cpp
+++ b/quantum/plugins/iontrap/IonTrapActivator.cpp
@@ -15,6 +15,7 @@
 #include "cppmicroservices/BundleActivator.h"
 #include "cppmicroservices/BundleContext.h"
 #include "cppmicroservices/ServiceProperties.h"
+#include "IonTrapOneQubitPass.hpp"
 #include "IonTrapTwoQubitPass.hpp"
 
 using namespace cppmicroservices;
@@ -26,6 +27,9 @@ public:
   void Start(BundleContext context) {
     auto twoQubitPass = std::make_shared<xacc::quantum::IonTrapTwoQubitPass>();
     context.RegisterService<xacc::IRTransformation>(twoQubitPass);
+
+    auto oneQubitPass = std::make_shared<xacc::quantum::IonTrapOneQubitPass>();
+    context.RegisterService<xacc::IRTransformation>(oneQubitPass);
   }
 
   void Stop(BundleContext context) {}

--- a/quantum/plugins/iontrap/decomp/IonTrapDecomp.cpp
+++ b/quantum/plugins/iontrap/decomp/IonTrapDecomp.cpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ * License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Austin Adams - initial implementation
+ *******************************************************************************/
+#include <cassert>
+#include "IonTrapDecomp.hpp"
+
+namespace xacc {
+namespace quantum {
+
+std::string decompName(const Decomp decomp) {
+    switch (decomp) {
+        case Decomp::Exact:
+            return "exact";
+        case Decomp::RX:
+            return "Rx";
+        case Decomp::RZ:
+            return "Rz";
+        case Decomp::RZExact:
+            return "RzExact";
+        case Decomp::RZRX:
+            return "RzRx";
+        case Decomp::RZRZ:
+            return "RzRz";
+        default:
+            assert(0);
+            return "";
+    }
+}
+
+Decomp decompNextToTry(const Decomp decomp) {
+    switch (decomp) {
+        case Decomp::RX:
+        case Decomp::RZ:
+        case Decomp::RZExact:
+            return Decomp::Exact;
+        case Decomp::RZRX:
+            return Decomp::RX;
+        case Decomp::RZRZ:
+            return Decomp::RZ;
+        default:
+            // Exact should never call this function. If exact fails, we are
+            // in bad shape and should handle it differently
+            assert(0);
+            return Decomp::Exact;
+    }
+}
+
+bool decompShouldSkip(const Decomp decomp, const int rotations) {
+    // Rx(phi2).Rz(phi1) needs two angles. One can be 0, that's fine.
+    // Also, Rz(phi2).Rz(phi1) = Rz(phi2 + phi1) is really just 1 angle.
+    return (decomp == Decomp::RZRX && rotations == 1)
+           || (decomp == Decomp::RZRZ && rotations == 2);
+}
+
+std::size_t decompFromRotationCount(const Decomp decomp) {
+    // The first 1 entry of the array of rotations is an Rz for
+    // Decomp::RZ{Exact,RX,RZ}, but in the case of plain
+    // old Decomp::{Exact,RX,RZ}, there are 0 such entries
+    return decomp != Decomp::Exact && decomp != Decomp::RX && decomp != Decomp::RZ;
+}
+
+std::size_t decompCount(const Decomp decomp) {
+    // The last 1 entry of the array of rotations is an Rx/Rz for
+    // Decomp::RX/RZ, but in the case of Decomp::Exact,
+    // there are 0 such entries
+    return decomp != Decomp::Exact && decomp != Decomp::RZExact;
+}
+
+bool decompShouldTrack(const Decomp decomp) {
+    // We only care about tracking Rx rotations (across XX gates)
+    return decomp == Decomp::RX || decomp == Decomp::RZRX;
+}
+
+arma::cx_mat decompFromMat(const Decomp decomp, const double phi) {
+    const auto i = std::complex<double>(0, 1);
+
+    if (decomp == Decomp::Exact || decomp == Decomp::RX || decomp == Decomp::RZ) {
+        return arma::eye<arma::cx_mat>(2,2);
+    } else if (decomp == Decomp::RZExact || decomp == Decomp::RZRX || decomp == Decomp::RZRZ) {
+        // Reuse RZ rotation code from decompMat()
+        return decompMat(Decomp::RZ, phi);
+    } else {
+        assert(0);
+        return {};
+    }
+}
+
+arma::cx_mat decompMat(const Decomp decomp, const double phi) {
+    const auto i = std::complex<double>(0, 1);
+
+    if (decomp == Decomp::Exact || decomp == Decomp::RZExact) {
+        return arma::eye<arma::cx_mat>(2,2);
+    } else if (decomp == Decomp::RX || decomp == Decomp::RZRX) {
+        arma::cx_mat rx({std::cos(phi/2.0), -i*std::sin(phi/2.0),
+                         -i*std::sin(phi/2.0), std::cos(phi/2.0)});
+        rx.reshape(2, 2);
+        return rx;
+    } else if (decomp == Decomp::RZ || decomp == Decomp::RZRZ) {
+        arma::cx_mat rz({std::exp(-i*phi/2.0), 0,
+                         0, std::exp(i*phi/2.0)});
+        rz.reshape(2, 2);
+        return rz;
+    } else {
+        assert(0);
+        return {};
+    }
+}
+
+} // namespace quantum
+} // namespace xacc

--- a/quantum/plugins/iontrap/decomp/IonTrapDecomp.hpp
+++ b/quantum/plugins/iontrap/decomp/IonTrapDecomp.hpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ * License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Alexander J. McCaskey - initial API and implementation
+ *   Austin Adams - adapted for GTRI testbed
+ *******************************************************************************/
+#ifndef QUANTUM_ACCELERATORS_IONTRAPDECOMP_HPP_
+#define QUANTUM_ACCELERATORS_IONTRAPDECOMP_HPP_
+
+#include <armadillo>
+
+namespace xacc {
+namespace quantum {
+
+enum class Decomp : int { Exact, RX, RZ, RZExact, RZRX, RZRZ };
+
+std::size_t decompFromRotationCount(const Decomp);
+arma::cx_mat decompFromMat(const Decomp, const double);
+arma::cx_mat decompMat(const Decomp, const double);
+std::size_t decompCount(const Decomp);
+Decomp decompNextToTry(const Decomp);
+bool decompShouldSkip(const Decomp, const int);
+std::string decompName(const Decomp);
+bool decompShouldTrack(const Decomp);
+
+} // namespace quantum
+} // namespace xacc
+
+#endif

--- a/quantum/plugins/iontrap/decomp/IonTrapOptFunction.cpp
+++ b/quantum/plugins/iontrap/decomp/IonTrapOptFunction.cpp
@@ -1,0 +1,317 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ * License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Alexander J. McCaskey - initial API and implementation
+ *   Austin Adams - initial implementation
+ *******************************************************************************/
+#include <cassert>
+#include "IonTrapOptFunction.hpp"
+
+namespace xacc {
+namespace quantum {
+
+//
+// Gradients up to global phase (exact)
+//
+
+void IonTrapOptFunction::nablaHExact_1(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = (std::exp(-i*phi(0,0))*(-std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))))/std::sqrt(2.0);
+}
+
+void IonTrapOptFunction::nablaHExact_2(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*std::exp(-i*(phi(0,0)+phi(1,0)))*(-i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+std::exp(i*phi(1,0))*(-std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))+i*std::exp(i*phi(1,0))*std::conj(goal(1,1))));
+
+    gh(1,0) = 1.0/2.0*std::exp(-i*(phi(0,0)+phi(1,0)))*(i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*(std::exp(i*phi(0,0))*std::conj(goal(1,0))-i*std::conj(goal(1,1))));
+}
+
+void IonTrapOptFunction::nablaHExact_3(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-i*phi(0,0))*((-1.0+std::exp(i*(phi(1,0)-phi(2,0))))*std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*(1.0-std::exp(-i*(phi(1,0)-phi(2,0))))*std::conj(goal(1,0))-i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))*(std::cos(phi(1,0))+std::cos(phi(2,0))-i*(std::sin(phi(1,0))+std::sin(phi(2,0))))+i*std::conj(goal(1,1))*(std::cos(phi(1,0))+std::cos(phi(2,0))+i*(std::sin(phi(1,0))+std::sin(phi(2,0)))));
+
+    gh(1,0) = 1.0/std::sqrt(2.0)*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(2,0)))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))*(-std::conj(goal(0,1))+std::conj(goal(1,0))*(std::cos(phi(0,0)+phi(2,0))+i*std::sin(phi(0,0)+phi(2,0))))-(std::exp(i*phi(0,0))*std::conj(goal(0,0))+std::exp(i*phi(2,0))*std::conj(goal(1,1)))*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0))));
+
+    gh(2,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-i*(phi(0,0)+phi(1,0)+phi(2,0)))*(i*std::exp(i*(phi(0,0)+phi(1,0)))*(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::conj(goal(0,0))+(std::exp(2.0*i*phi(1,0))-std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(0,1))-std::exp(2.0*i*phi(2,0))*((std::exp(2.0*i*phi(0,0))-std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(1,0))+i*(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::conj(goal(1,1))));
+}
+
+void IonTrapOptFunction::nablaHExact_4(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/4.0*std::exp(-i*(phi(0,0)+phi(1,0)+phi(2,0)+phi(3,0)))*(i*std::exp(2.0*i*phi(0,0))*(std::exp(2.0*i*phi(2,0))-std::exp(i*(phi(1,0)+phi(2,0)))-std::exp(i*(phi(1,0)+phi(3,0)))-std::exp(i*(phi(2,0)+phi(3,0))))*std::conj(goal(0,0))+std::exp(i*phi(1,0))*(std::exp(2.0*i*phi(2,0))+std::exp(i*(phi(1,0)+phi(2,0)))+std::exp(i*(phi(1,0)+phi(3,0)))-std::exp(i*(phi(2,0)+phi(3,0))))*std::conj(goal(0,1))+std::exp(i*phi(3,0))*(-std::exp(2.0*i*phi(0,0))*(std::exp(2.0*i*phi(2,0))-std::exp(i*(phi(1,0)+phi(2,0)))+std::exp(i*(phi(1,0)+phi(3,0)))+std::exp(i*(phi(2,0)+phi(3,0))))*std::conj(goal(1,0))+i*std::exp(i*phi(1,0))*(std::exp(2.0*i*phi(2,0))+std::exp(i*(phi(1,0)+phi(2,0)))-std::exp(i*(phi(1,0)+phi(3,0)))+std::exp(i*(phi(2,0)+phi(3,0))))*std::conj(goal(1,1))));
+
+    gh(1,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(3,0)))*(-std::conj(goal(0,1))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(3,0)))-i*std::sin(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0))+std::exp(i*(phi(0,0)+phi(3,0)))*std::conj(goal(1,0))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(3,0)))+i*std::sin(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0))+i*std::exp(i*phi(3,0))*std::conj(goal(1,1))*(std::cos(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0)+i*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(3,0))))-std::exp(i*phi(0,0))*std::conj(goal(0,0))*(i*std::cos(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0)+std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(3,0)))));
+
+    gh(2,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(3,0)))*(std::exp(i*(phi(0,0)+phi(3,0)))*std::conj(goal(1,0))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(2,0)+phi(3,0)))-i*std::sin(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0))-std::conj(goal(0,1))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(2,0)+phi(3,0)))+i*std::sin(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0))+std::conj(goal(1,1))*(-i*std::cos(phi(3,0))+std::sin(phi(3,0)))*(std::cos(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0)-i*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(2,0)+phi(3,0))))+i*std::exp(i*phi(0,0))*std::conj(goal(0,0))*(std::cos(phi(0,0)/2.0-phi(1,0)+phi(2,0)-phi(3,0)/2.0)+i*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(2,0)+phi(3,0)))));
+
+    gh(3,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(2,0)+2.0*phi(3,0)))*(std::exp(2.0*i*phi(3,0))*(-std::exp(i*phi(0,0))*std::conj(goal(1,0))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))+i*std::sin((phi(0,0)-phi(2,0))/2.0))+std::conj(goal(1,1))*(-i*std::cos((phi(0,0)-phi(2,0))/2.0)+std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))))+std::exp(i*phi(2,0))*(std::conj(goal(0,1))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))-i*std::sin((phi(0,0)-phi(2,0))/2.0))+std::exp(i*phi(0,0))*std::conj(goal(0,0))*(i*std::cos((phi(0,0)-phi(2,0))/2.0)+std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0))))));
+}
+
+//
+// Gradients up to Rx
+//
+
+void IonTrapOptFunction::nablaHRx_1(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = -(1.0/2.0)*i*(std::conj(goal(0,1))+std::conj(goal(1,0)))*std::cos(phi(0,0)/2.0)-1.0/2.0*(std::conj(goal(0,0))+std::conj(goal(1,1)))*std::sin(phi(0,0)/2.0);
+}
+
+void IonTrapOptFunction::nablaHRx_2(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/std::sqrt(2.0)*std::exp(-i*phi(0,0))*(-((std::conj(goal(0,1))-std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0)))*std::cos(phi(1,0)/2.0))+i*(-std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+std::conj(goal(1,1)))*std::sin(phi(1,0)/2.0));
+
+    gh(1,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-i*phi(0,0))*(-((std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+i*std::exp(i*phi(0,0))*(std::conj(goal(0,1))+std::conj(goal(1,0)))+std::conj(goal(1,1)))*std::cos(phi(1,0)/2.0))+i*(std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))+i*std::exp(i*phi(0,0))*(std::conj(goal(0,0))+std::conj(goal(1,1))))*std::sin(phi(1,0)/2.0));
+}
+
+void IonTrapOptFunction::nablaHRx_3(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*std::exp(-i*(phi(0,0)+phi(1,0)))*((-i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+std::exp(i*phi(1,0))*(-std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))+i*std::exp(i*phi(1,0))*std::conj(goal(1,1))))*std::cos(phi(2,0)/2.0)+(std::exp(2.0*i*phi(1,0))*std::conj(goal(0,1))-std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))-i*std::exp(i*phi(1,0))*(std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))-std::conj(goal(1,1))))*std::sin(phi(2,0)/2.0));
+
+    gh(1,0) = 1.0/2.0*std::exp(-i*(phi(0,0)+phi(1,0)))*((i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*(std::exp(i*phi(0,0))*std::conj(goal(1,0))-i*std::conj(goal(1,1))))*std::cos(phi(2,0)/2.0)+(-i*std::exp(i*(phi(0,0)+2.0*phi(1,0)))*std::conj(goal(0,0))-std::exp(2.0*i*phi(1,0))*std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))+i*std::exp(i*phi(0,0))*std::conj(goal(1,1)))*std::sin(phi(2,0)/2.0));
+
+    gh(2,0) = 1.0/4.0*std::exp(-i*(phi(0,0)+phi(1,0)))*(-std::cos(phi(2,0)/2.0)*(std::exp(2.0*i*phi(1,0))*(std::exp(i*phi(0,0))*std::conj(goal(0,0))-i*std::conj(goal(0,1)))+std::exp(i*phi(1,0))*(std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+i*std::exp(i*phi(0,0))*(std::conj(goal(0,1))+std::conj(goal(1,0)))+std::conj(goal(1,1)))+std::exp(i*phi(0,0))*(std::conj(goal(1,1))+std::conj(goal(1,0))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0)))))+(std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+i*std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*(i*std::exp(i*phi(0,0))*std::conj(goal(1,0))+std::conj(goal(1,1)))+i*std::exp(i*phi(1,0))*(std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))+i*std::exp(i*phi(0,0))*(std::conj(goal(0,0))+std::conj(goal(1,1)))))*std::sin(phi(2,0)/2.0));
+}
+
+void IonTrapOptFunction::nablaHRx_4(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-i*(phi(0,0)+phi(1,0)+phi(2,0)))*(i*std::exp(i*(2.0*phi(0,0)+phi(2,0)))*(-std::cos(phi(3,0)/2.0)*(std::conj(goal(0,0))+std::conj(goal(1,0))*(-i*std::cos(phi(2,0))+std::sin(phi(2,0))))+(std::exp(i*phi(2,0))*std::conj(goal(0,0))+i*std::conj(goal(1,0)))*std::sin(phi(3,0)/2.0))+std::exp(i*phi(1,0))*((-i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+std::exp(i*phi(2,0))*(-std::conj(goal(0,1))+std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))+i*std::exp(i*phi(2,0))*std::conj(goal(1,1))))*std::cos(phi(3,0)/2.0)+(std::exp(2.0*i*phi(2,0))*std::conj(goal(0,1))-std::exp(2.0*i*phi(0,0))*std::conj(goal(1,0))-i*std::exp(i*phi(2,0))*(std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))-std::conj(goal(1,1))))*std::sin(phi(3,0)/2.0))+std::exp(2.0*i*phi(1,0))*((std::conj(goal(0,1))+i*std::exp(i*phi(2,0))*std::conj(goal(1,1)))*std::cos(phi(3,0)/2.0)+(std::exp(i*phi(2,0))*std::conj(goal(0,1))-i*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0)));
+
+    gh(1,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-i*(phi(0,0)+phi(1,0)+phi(2,0)))*(-((std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(2,0))))*std::conj(goal(0,1))*std::cos(phi(3,0)/2.0))+std::exp(2.0*i*phi(1,0))*(std::exp(i*phi(0,0))*std::conj(goal(1,0))-i*std::conj(goal(1,1)))*(std::exp(i*phi(2,0))*std::cos(phi(3,0)/2.0)-std::sin(phi(3,0)/2.0))+std::exp(i*phi(2,0))*(-std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(2,0))))*std::conj(goal(0,1))*std::sin(phi(3,0)/2.0)+std::exp(i*(phi(0,0)+phi(2,0)))*(std::exp(i*phi(0,0))*std::conj(goal(1,0))+i*std::conj(goal(1,1)))*(std::exp(i*phi(2,0))*std::cos(phi(3,0)/2.0)+std::sin(phi(3,0)/2.0))-i*std::exp(i*phi(0,0))*std::conj(goal(0,0))*((std::exp(2.0*i*phi(1,0))-std::exp(i*(phi(0,0)+phi(2,0))))*std::cos(phi(3,0)/2.0)+std::exp(i*phi(2,0))*(std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(2,0))))*std::sin(phi(3,0)/2.0)));
+
+    gh(2,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-i*(phi(0,0)+phi(1,0)+phi(2,0)))*(-std::exp(2.0*i*phi(2,0))*((std::exp(2.0*i*phi(0,0))-std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(1,0))+i*(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::conj(goal(1,1)))*std::cos(phi(3,0)/2.0)+std::exp(i*phi(1,0))*((std::exp(2.0*i*phi(0,0))+std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(1,0))+i*(std::exp(i*phi(0,0))-std::exp(i*phi(1,0)))*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0)+i*std::exp(i*phi(0,0))*std::conj(goal(0,0))*((std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(1,0))))*std::cos(phi(3,0)/2.0)+std::exp(2.0*i*phi(2,0))*(std::exp(i*phi(0,0))-std::exp(i*phi(1,0)))*std::sin(phi(3,0)/2.0))+std::conj(goal(0,1))*((std::exp(2.0*i*phi(1,0))-std::exp(i*(phi(0,0)+phi(1,0))))*std::cos(phi(3,0)/2.0)-std::exp(2.0*i*phi(2,0))*(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::sin(phi(3,0)/2.0)));
+
+    gh(3,0) = -(1.0/8.0)*i*(-std::sqrt(2.0)*std::cos(phi(3,0)/2.0)*((-1.0+std::exp(-i*(phi(0,0)+phi(1,0)))*(std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(2,0)))+std::exp(i*(phi(1,0)+phi(2,0)))))*std::conj(goal(0,1))+(-1.0+std::exp(i*(phi(0,0)-phi(1,0)))+std::exp(i*(phi(0,0)-phi(2,0)))+std::exp(i*(phi(1,0)-phi(2,0))))*std::conj(goal(1,0))+std::conj(goal(1,1))*(i*std::cos(phi(0,0))+i*std::cos(phi(1,0))+i*std::cos(phi(2,0))-i*std::cos(phi(0,0)-phi(1,0)+phi(2,0))+std::sin(phi(0,0))+std::sin(phi(1,0))+std::sin(phi(2,0))-std::sin(phi(0,0)-phi(1,0)+phi(2,0))))-std::sqrt(2.0)*((std::exp(-i*phi(0,0))+std::exp(-i*phi(1,0))+std::exp(-i*phi(2,0))-std::exp(-i*(phi(0,0)-phi(1,0)+phi(2,0))))*std::conj(goal(0,1))+(std::exp(i*phi(0,0))+std::exp(i*phi(1,0))+std::exp(i*phi(2,0))-std::exp(i*(phi(0,0)-phi(1,0)+phi(2,0))))*std::conj(goal(1,0))-i*(-1.0+std::exp(-i*(phi(0,0)+phi(1,0)))*(std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(2,0)))+std::exp(i*(phi(1,0)+phi(2,0)))))*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0)-i*std::sqrt(2.0)*std::exp(-i*(phi(1,0)+phi(2,0)))*std::conj(goal(0,0))*(std::exp(i*phi(2,0))*(std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(1,0)))-std::exp(i*(phi(0,0)+phi(2,0)))+std::exp(i*(phi(1,0)+phi(2,0))))*std::cos(phi(3,0)/2.0)-(std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(0,0)+phi(1,0)))+std::exp(i*(phi(0,0)+phi(2,0)))-std::exp(i*(phi(1,0)+phi(2,0))))*std::sin(phi(3,0)/2.0)));
+}
+
+//
+// Gradients up to Rz
+//
+
+void IonTrapOptFunction::nablaHRz_1(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*i*std::exp(-((i*phi(0,0))/2.0))*(-std::conj(goal(0,0))+std::exp(i*phi(0,0))*std::conj(goal(1,1)));
+}
+
+void IonTrapOptFunction::nablaHRz_2(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = (std::exp(-(1.0/2.0)*i*(2.0*phi(0,0)+phi(1,0)))*(-std::conj(goal(0,1))+std::exp(i*(2.0*phi(0,0)+phi(1,0)))*std::conj(goal(1,0))))/std::sqrt(2.0);
+
+    gh(1,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-(1.0/2.0)*i*(2.0*phi(0,0)+phi(1,0)))*(-std::conj(goal(0,1))+std::exp(i*(phi(0,0)+phi(1,0)))*(std::exp(i*phi(0,0))*std::conj(goal(1,0))+i*std::conj(goal(1,1)))+std::conj(goal(0,0))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0))));
+}
+
+void IonTrapOptFunction::nablaHRz_3(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(2.0*(phi(0,0)+phi(1,0))+phi(2,0)))*(-i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))+std::exp(i*phi(1,0))*(-std::conj(goal(0,1))+std::exp(i*(2.0*phi(0,0)+phi(2,0)))*std::conj(goal(1,0))+i*std::exp(i*(phi(1,0)+phi(2,0)))*std::conj(goal(1,1))));
+
+    gh(1,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(2.0*(phi(0,0)+phi(1,0))+phi(2,0)))*(i*std::exp(2.0*i*phi(0,0))*std::conj(goal(0,0))-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(i*(2.0*phi(1,0)+phi(2,0)))*(std::exp(i*phi(0,0))*std::conj(goal(1,0))-i*std::conj(goal(1,1))));
+
+    gh(2,0) = 1.0/4.0*std::exp(-(1.0/2.0)*i*(2.0*(phi(0,0)+phi(1,0))+phi(2,0)))*(i*std::exp(i*phi(0,0))*(std::exp(i*phi(0,0))-std::exp(i*phi(1,0)))*std::conj(goal(0,0))-(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::conj(goal(0,1))+std::exp(i*(phi(1,0)+phi(2,0)))*((std::exp(2.0*i*phi(0,0))+std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(1,0))+i*(std::exp(i*phi(0,0))-std::exp(i*phi(1,0)))*std::conj(goal(1,1))));
+}
+
+void IonTrapOptFunction::nablaHRz_4(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-(1.0/2.0)*i*(2.0*(phi(0,0)+phi(1,0)+phi(2,0))+phi(3,0)))*(-i*std::exp(2.0*i*phi(0,0))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::conj(goal(0,0))+(std::exp(2.0*i*phi(1,0))-std::exp(i*(phi(1,0)+phi(2,0))))*std::conj(goal(0,1))+std::exp(i*(phi(2,0)+phi(3,0)))*(std::exp(2.0*i*phi(0,0))*(std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::conj(goal(1,0))+i*std::exp(i*phi(1,0))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::conj(goal(1,1))));
+
+    gh(1,0) = 1.0/std::sqrt(2.0)*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(2,0)+phi(3,0)))*(-std::conj(goal(0,1))*std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))+std::exp(i*(phi(0,0)+phi(2,0)+phi(3,0)))*std::conj(goal(1,0))*std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))-(std::exp(i*phi(0,0))*std::conj(goal(0,0))+std::exp(i*(phi(2,0)+phi(3,0)))*std::conj(goal(1,1)))*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0))));
+
+    gh(2,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-(1.0/2.0)*i*(2.0*(phi(0,0)+phi(1,0)+phi(2,0))+phi(3,0)))*(i*std::exp(i*(phi(0,0)+phi(1,0)))*(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::conj(goal(0,0))+(std::exp(2.0*i*phi(1,0))-std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(0,1))-std::exp(i*(2.0*phi(2,0)+phi(3,0)))*((std::exp(2.0*i*phi(0,0))-std::exp(i*(phi(0,0)+phi(1,0))))*std::conj(goal(1,0))+i*(std::exp(i*phi(0,0))+std::exp(i*phi(1,0)))*std::conj(goal(1,1))));
+
+    gh(3,0) = 1.0/(2.0*std::sqrt(2.0))*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(2,0)+phi(3,0)))*(-i*std::exp(i*(phi(2,0)+phi(3,0)))*std::conj(goal(1,1))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))-i*std::sin((phi(0,0)-phi(2,0))/2.0))+i*std::exp(i*phi(0,0))*std::conj(goal(0,0))*(std::cos(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))+i*std::sin((phi(0,0)-phi(2,0))/2.0))+std::exp(i*(phi(0,0)+phi(2,0)+phi(3,0)))*std::conj(goal(1,0))*(std::cos((phi(0,0)-phi(2,0))/2.0)-i*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0))))-std::conj(goal(0,1))*(std::cos((phi(0,0)-phi(2,0))/2.0)+i*std::sin(1.0/2.0*(phi(0,0)-2.0*phi(1,0)+phi(2,0)))));
+}
+
+//
+// Gradients from Rz up to exact
+//
+
+void IonTrapOptFunction::nablaHRzExact_1(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*i*std::exp(-((i*phi(0,0))/2.0))*(-std::conj(goal(0,0))+std::exp(i*phi(0,0))*std::conj(goal(1,1)));
+}
+
+void IonTrapOptFunction::nablaHRzExact_2(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = (std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)))*(std::exp(i*phi(0,0))*std::conj(goal(0,1))-std::exp(2.0*i*phi(1,0))*std::conj(goal(1,0))-i*std::exp(i*phi(1,0))*(std::conj(goal(0,0))-std::exp(i*phi(0,0))*std::conj(goal(1,1)))))/(2.0*std::sqrt(2.0));
+
+    gh(1,0) = (std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)))*(-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*std::conj(goal(1,0))))/std::sqrt(2.0);
+}
+
+void IonTrapOptFunction::nablaHRzExact_3(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/4.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(i*std::exp(i*phi(1,0))*(std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::conj(goal(0,0))+std::exp(i*phi(0,0))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::conj(goal(0,1))+std::exp(i*phi(2,0))*(-((std::exp(2.0*i*phi(1,0))+std::exp(i*(phi(1,0)+phi(2,0))))*std::conj(goal(1,0)))+i*std::exp(i*phi(0,0))*(std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::conj(goal(1,1))));
+
+    gh(1,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(-i*std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))-std::exp(i*(phi(0,0)+phi(2,0)))*std::conj(goal(0,1))+std::exp(i*(2.0*phi(1,0)+phi(2,0)))*std::conj(goal(1,0))+i*std::exp(i*(phi(0,0)+2.0*phi(2,0)))*std::conj(goal(1,1)));
+
+    gh(2,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(i*std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))-std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(0,1))+std::exp(2.0*i*phi(2,0))*(std::exp(i*phi(1,0))*std::conj(goal(1,0))+std::conj(goal(1,1))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0)))));
+}
+
+void IonTrapOptFunction::nablaHRzExact_4(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = (1.0/(2.0*std::sqrt(2.0)))*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(1,0)+phi(3,0)))*(i*std::exp(i*phi(1,0))*std::conj(goal(0,0))*(std::cos(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0)))+i*std::sin((phi(1,0)-phi(3,0))/2.0))+std::conj(goal(1,1))*(std::cos(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0)))-i*std::sin((phi(1,0)-phi(3,0))/2.0))*(-i*std::cos(phi(0,0)+phi(3,0))+std::sin(phi(0,0)+phi(3,0)))-std::conj(goal(1,0))*(std::cos(phi(1,0)+phi(3,0))+i*std::sin(phi(1,0)+phi(3,0)))*(std::cos((phi(1,0)-phi(3,0))/2.0)-i*std::sin(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0))))+std::exp(i*phi(0,0))*std::conj(goal(0,1))*(std::cos((phi(1,0)-phi(3,0))/2.0)+i*std::sin(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0)))));
+
+    gh(1,0) = (1.0/(2.0*std::sqrt(2.0)))*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0)+phi(3,0))))*(std::exp(i*(phi(0,0)+phi(2,0)))*(std::exp(i*phi(2,0))-std::exp(i*phi(3,0)))*std::conj(goal(0,1))-std::exp(i*(2.0*phi(1,0)+phi(3,0)))*(-std::exp(i*phi(2,0))+std::exp(i*phi(3,0)))*std::conj(goal(1,0))+i*(std::exp(i*phi(2,0))+std::exp(i*phi(3,0)))*(-std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))+std::exp(i*(phi(0,0)+phi(2,0)+phi(3,0)))*std::conj(goal(1,1))));
+
+    gh(2,0) = (1.0/std::sqrt(2.0))*std::exp(-(1.0/2.0)*i*(phi(0,0)+phi(1,0)+phi(3,0)))*(-std::exp(i*phi(0,0))*std::conj(goal(0,1))*std::cos(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0)))+std::conj(goal(1,0))*std::cos(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0)))*(std::cos(phi(1,0)+phi(3,0))+i*std::sin(phi(1,0)+phi(3,0)))-(std::exp(i*phi(1,0))*std::conj(goal(0,0))+std::conj(goal(1,1))*(std::cos(phi(0,0)+phi(3,0))+i*std::sin(phi(0,0)+phi(3,0))))*std::sin(1.0/2.0*(phi(1,0)-2.0*phi(2,0)+phi(3,0))));
+
+    gh(3,0) = (1.0/(2.0*std::sqrt(2.0)))*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0)+phi(3,0))))*(i*std::exp(i*(phi(1,0)+phi(2,0)))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::conj(goal(0,0))+std::exp(i*(phi(0,0)+phi(2,0)))*(-std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::conj(goal(0,1))-std::exp(2.0*i*phi(3,0))*((std::exp(2.0*i*phi(1,0))-std::exp(i*(phi(1,0)+phi(2,0))))*std::conj(goal(1,0))+i*std::exp(i*phi(0,0))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::conj(goal(1,1))));
+}
+
+//
+// Gradients from Rz up to Rz
+//
+
+void IonTrapOptFunction::nablaHRzRz_1(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*i*std::exp(-((i*phi(0,0))/2.0))*(-std::conj(goal(0,0))+std::exp(i*phi(0,0))*std::conj(goal(1,1)));
+}
+
+void IonTrapOptFunction::nablaHRzRz_3(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = (std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)+phi(2,0)))*(std::exp(i*phi(0,0))*std::conj(goal(0,1))-std::exp(i*phi(1,0))*(i*std::conj(goal(0,0))+std::exp(i*(phi(1,0)+phi(2,0)))*std::conj(goal(1,0))-i*std::exp(i*(phi(0,0)+phi(2,0)))*std::conj(goal(1,1)))))/(2.0*std::sqrt(2.0));
+
+    gh(1,0) = (std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)+phi(2,0)))*(-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(i*(2.0*phi(1,0)+phi(2,0)))*std::conj(goal(1,0))))/std::sqrt(2.0);
+
+    gh(2,0) = (std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)+phi(2,0)))*(-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(i*phi(1,0))*(-i*std::conj(goal(0,0))+std::exp(i*(phi(1,0)+phi(2,0)))*std::conj(goal(1,0))+i*std::exp(i*(phi(0,0)+phi(2,0)))*std::conj(goal(1,1)))))/(2.0*std::sqrt(2.0));
+}
+
+void IonTrapOptFunction::nablaHRzRz_4(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/4.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(-std::exp(i*phi(1,0))*std::conj(goal(1,0))*((std::exp(2.0*i*phi(2,0))+std::exp(i*(phi(1,0)+phi(2,0))))*std::cos(phi(3,0)/2.0)-(std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0))+std::exp(i*phi(0,0))*std::conj(goal(0,1))*((std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::cos(phi(3,0)/2.0)-std::exp(i*phi(2,0))*(-std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0))-i*std::exp(i*phi(0,0))*std::conj(goal(1,1))*((std::exp(2.0*i*phi(2,0))-std::exp(i*(phi(1,0)+phi(2,0))))*std::cos(phi(3,0)/2.0)+(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0))+i*std::exp(i*phi(1,0))*std::conj(goal(0,0))*((std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::cos(phi(3,0)/2.0)+std::exp(i*phi(2,0))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0)));
+
+    gh(1,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(std::exp(2.0*i*phi(1,0))*((-i*std::conj(goal(0,0))+std::exp(i*phi(2,0))*std::conj(goal(1,0)))*std::cos(phi(3,0)/2.0)-(i*std::exp(i*phi(2,0))*std::conj(goal(0,0))+std::conj(goal(1,0)))*std::sin(phi(3,0)/2.0))+std::exp(i*(phi(0,0)+phi(2,0)))*(-std::cos(phi(3,0)/2.0)*(std::conj(goal(0,1))+std::conj(goal(1,1))*(-i*std::cos(phi(2,0))+std::sin(phi(2,0))))+(std::exp(i*phi(2,0))*std::conj(goal(0,1))+i*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0)));
+
+    gh(2,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(std::cos(phi(3,0)/2.0)*(i*std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))-std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(0,1))+std::exp(2.0*i*phi(2,0))*(std::exp(i*phi(1,0))*std::conj(goal(1,0))+std::conj(goal(1,1))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0)))))+(-i*std::exp(i*(phi(1,0)+2.0*phi(2,0)))*std::conj(goal(0,0))-std::exp(i*(phi(0,0)+2.0*phi(2,0)))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*std::conj(goal(1,0))+i*std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0));
+
+    gh(3,0) = 1.0/2.0*std::exp(-((i*phi(0,0))/2.0))*(-std::exp(i*phi(0,0))*std::conj(goal(1,1))*(1.0/2.0*(std::exp(-i*phi(1,0))+std::exp(-i*phi(2,0)))*std::cos(phi(3,0)/2.0)-1.0/2.0*(-1.0+std::exp(-i*(phi(1,0)-phi(2,0))))*std::sin(phi(3,0)/2.0))+std::conj(goal(0,0))*(-(1.0/2.0)*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::cos(phi(3,0)/2.0)+1.0/2.0*(-1.0+std::exp(i*(phi(1,0)-phi(2,0))))*std::sin(phi(3,0)/2.0))-std::exp(i*phi(0,0))*std::conj(goal(0,1))*(1.0/2.0*i*(1.0-std::exp(-i*(phi(1,0)-phi(2,0))))*std::cos(phi(3,0)/2.0)-1.0/2.0*(i*std::cos(phi(1,0))+i*std::cos(phi(2,0))+std::sin(phi(1,0))+std::sin(phi(2,0)))*std::sin(phi(3,0)/2.0))+1.0/2.0*i*std::conj(goal(1,0))*((-1.0+std::exp(i*(phi(1,0)-phi(2,0))))*std::cos(phi(3,0)/2.0)+(std::cos(phi(1,0))+std::cos(phi(2,0))+i*(std::sin(phi(1,0))+std::sin(phi(2,0))))*std::sin(phi(3,0)/2.0)));
+}
+
+//
+// Gradients from Rz up to Rx
+//
+
+void IonTrapOptFunction::nablaHRzRx_2(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/2.0*std::exp(-((i*phi(0,0))/2.0))*(-i*(std::conj(goal(0,0))-std::exp(i*phi(0,0))*std::conj(goal(1,1)))*std::cos(phi(1,0)/2.0)+(std::exp(i*phi(0,0))*std::conj(goal(0,1))-std::conj(goal(1,0)))*std::sin(phi(1,0)/2.0));
+
+    gh(1,0) = 1.0/2.0*std::exp(-((i*phi(0,0))/2.0))*(-i*(std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::conj(goal(1,0)))*std::cos(phi(1,0)/2.0)-(std::conj(goal(0,0))+std::exp(i*phi(0,0))*std::conj(goal(1,1)))*std::sin(phi(1,0)/2.0));
+}
+
+void IonTrapOptFunction::nablaHRzRx_3(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = (1.0/(2.0*std::sqrt(2.0)))*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)))*(-((i*std::exp(i*phi(1,0))*std::conj(goal(0,0))-std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*std::conj(goal(1,0))-i*std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(1,1)))*std::cos(phi(2,0)/2.0))+(i*std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))+std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(0,1))-std::exp(i*phi(1,0))*std::conj(goal(1,0))+std::conj(goal(1,1))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0))))*std::sin(phi(2,0)/2.0));
+
+    gh(1,0) = (std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)))*(std::exp(2.0*i*phi(1,0))*(std::conj(goal(1,0))*std::cos(phi(2,0)/2.0)-i*std::conj(goal(0,0))*std::sin(phi(2,0)/2.0))+std::exp(i*phi(0,0))*(-std::conj(goal(0,1))*std::cos(phi(2,0)/2.0)+i*std::conj(goal(1,1))*std::sin(phi(2,0)/2.0))))/std::sqrt(2.0);
+
+    gh(2,0) = (1.0/std::sqrt(2.0))*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*phi(1,0)))*(-(1.0/2.0)*(std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))+i*std::exp(i*phi(1,0))*(std::exp(i*phi(0,0))*std::conj(goal(0,1))+std::conj(goal(1,0)))+std::exp(i*phi(0,0))*std::conj(goal(1,1)))*std::cos(phi(2,0)/2.0)-1.0/2.0*(std::conj(goal(0,1))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0)))+std::exp(i*phi(1,0))*(std::conj(goal(0,0))+std::exp(i*phi(0,0))*std::conj(goal(1,1))+std::conj(goal(1,0))*(-i*std::cos(phi(1,0))+std::sin(phi(1,0)))))*std::sin(phi(2,0)/2.0));
+}
+
+void IonTrapOptFunction::nablaHRzRx_4(const arma::mat &phi, arma::cx_mat &gh) {
+    const auto i = std::complex<double>(0, 1);
+
+    gh(0,0) = 1.0/4.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(-std::exp(i*phi(1,0))*std::conj(goal(1,0))*((std::exp(2.0*i*phi(2,0))+std::exp(i*(phi(1,0)+phi(2,0))))*std::cos(phi(3,0)/2.0)-(std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0))+std::exp(i*phi(0,0))*std::conj(goal(0,1))*((std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::cos(phi(3,0)/2.0)-std::exp(i*phi(2,0))*(-std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0))-i*std::exp(i*phi(0,0))*std::conj(goal(1,1))*((std::exp(2.0*i*phi(2,0))-std::exp(i*(phi(1,0)+phi(2,0))))*std::cos(phi(3,0)/2.0)+(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0))+i*std::exp(i*phi(1,0))*std::conj(goal(0,0))*((std::exp(i*phi(1,0))-std::exp(i*phi(2,0)))*std::cos(phi(3,0)/2.0)+std::exp(i*phi(2,0))*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::sin(phi(3,0)/2.0)));
+
+    gh(1,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(std::exp(2.0*i*phi(1,0))*((-i*std::conj(goal(0,0))+std::exp(i*phi(2,0))*std::conj(goal(1,0)))*std::cos(phi(3,0)/2.0)-(i*std::exp(i*phi(2,0))*std::conj(goal(0,0))+std::conj(goal(1,0)))*std::sin(phi(3,0)/2.0))+std::exp(i*(phi(0,0)+phi(2,0)))*(-std::cos(phi(3,0)/2.0)*(std::conj(goal(0,1))+std::conj(goal(1,1))*(-i*std::cos(phi(2,0))+std::sin(phi(2,0))))+(std::exp(i*phi(2,0))*std::conj(goal(0,1))+i*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0)));
+
+    gh(2,0) = 1.0/2.0*std::exp(-(1.0/2.0)*i*(phi(0,0)+2.0*(phi(1,0)+phi(2,0))))*(std::cos(phi(3,0)/2.0)*(i*std::exp(2.0*i*phi(1,0))*std::conj(goal(0,0))-std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(0,1))+std::exp(2.0*i*phi(2,0))*(std::exp(i*phi(1,0))*std::conj(goal(1,0))+std::conj(goal(1,1))*(-i*std::cos(phi(0,0))+std::sin(phi(0,0)))))+(-i*std::exp(i*(phi(1,0)+2.0*phi(2,0)))*std::conj(goal(0,0))-std::exp(i*(phi(0,0)+2.0*phi(2,0)))*std::conj(goal(0,1))+std::exp(2.0*i*phi(1,0))*std::conj(goal(1,0))+i*std::exp(i*(phi(0,0)+phi(1,0)))*std::conj(goal(1,1)))*std::sin(phi(3,0)/2.0));
+
+    gh(3,0) = 1.0/2.0*std::exp(-((i*phi(0,0))/2.0))*(-std::exp(i*phi(0,0))*std::conj(goal(1,1))*(1.0/2.0*(std::exp(-i*phi(1,0))+std::exp(-i*phi(2,0)))*std::cos(phi(3,0)/2.0)-1.0/2.0*(-1.0+std::exp(-i*(phi(1,0)-phi(2,0))))*std::sin(phi(3,0)/2.0))+std::conj(goal(0,0))*(-(1.0/2.0)*(std::exp(i*phi(1,0))+std::exp(i*phi(2,0)))*std::cos(phi(3,0)/2.0)+1.0/2.0*(-1.0+std::exp(i*(phi(1,0)-phi(2,0))))*std::sin(phi(3,0)/2.0))-std::exp(i*phi(0,0))*std::conj(goal(0,1))*(1.0/2.0*i*(1.0-std::exp(-i*(phi(1,0)-phi(2,0))))*std::cos(phi(3,0)/2.0)-1.0/2.0*(i*std::cos(phi(1,0))+i*std::cos(phi(2,0))+std::sin(phi(1,0))+std::sin(phi(2,0)))*std::sin(phi(3,0)/2.0))+1.0/2.0*i*std::conj(goal(1,0))*((-1.0+std::exp(i*(phi(1,0)-phi(2,0))))*std::cos(phi(3,0)/2.0)+(std::cos(phi(1,0))+std::cos(phi(2,0))+i*(std::sin(phi(1,0))+std::sin(phi(2,0))))*std::sin(phi(3,0)/2.0)));
+}
+
+std::complex<double> IonTrapOptFunction::H(const arma::mat &phi) {
+    arma::cx_mat actual = arma::eye<arma::cx_mat>(2,2);
+
+    for (std::size_t i = 0; i < phi.n_rows; i++) {
+        double phi_ = phi(i, 0);
+        arma::cx_mat rot;
+
+        if (i < decompFromRotationCount(decomp)) {
+            rot = decompFromMat(decomp, phi_);
+        } else if (i + decompCount(decomp) < phi.n_rows) {
+            rot = {{1, std::complex<double>(-std::sin(phi_), -std::cos(phi_))},
+                   {std::complex<double>(std::sin(phi_), -std::cos(phi_)), 1}};
+            rot /= sqrt(2);
+        } else {
+            rot = decompMat(decomp, phi_);
+        }
+
+        actual = rot * actual;
+    }
+
+    return arma::trace(goal.t() * actual);
+}
+
+double IonTrapOptFunction::EvaluateWithGradient(const arma::mat &phi, arma::mat &g) {
+    static const NablaMethod nablaHExact[] = {&xacc::quantum::IonTrapOptFunction::nablaHExact_1,
+                                              &xacc::quantum::IonTrapOptFunction::nablaHExact_2,
+                                              &xacc::quantum::IonTrapOptFunction::nablaHExact_3,
+                                              &xacc::quantum::IonTrapOptFunction::nablaHExact_4};
+    static const NablaMethod nablaHRx[] = {&xacc::quantum::IonTrapOptFunction::nablaHRx_1,
+                                           &xacc::quantum::IonTrapOptFunction::nablaHRx_2,
+                                           &xacc::quantum::IonTrapOptFunction::nablaHRx_3,
+                                           &xacc::quantum::IonTrapOptFunction::nablaHRx_4};
+    static const NablaMethod nablaHRz[] = {&xacc::quantum::IonTrapOptFunction::nablaHRz_1,
+                                           &xacc::quantum::IonTrapOptFunction::nablaHRz_2,
+                                           &xacc::quantum::IonTrapOptFunction::nablaHRz_3,
+                                           &xacc::quantum::IonTrapOptFunction::nablaHRz_4};
+    static const NablaMethod nablaHRzExact[] = {&xacc::quantum::IonTrapOptFunction::nablaHRzExact_1,
+                                                &xacc::quantum::IonTrapOptFunction::nablaHRzExact_2,
+                                                &xacc::quantum::IonTrapOptFunction::nablaHRzExact_3,
+                                                &xacc::quantum::IonTrapOptFunction::nablaHRzExact_4};
+    static const NablaMethod nablaHRzRx[] = {nullptr, // Rx(phi2).Rz(phi1) needs two angles. One can be 0, that's fine
+                                             &xacc::quantum::IonTrapOptFunction::nablaHRzRx_2,
+                                             &xacc::quantum::IonTrapOptFunction::nablaHRzRx_3,
+                                             &xacc::quantum::IonTrapOptFunction::nablaHRzRx_4};
+    static const NablaMethod nablaHRzRz[] = {&xacc::quantum::IonTrapOptFunction::nablaHRzRz_1,
+                                             nullptr, // Rz(phi2).Rz(phi1) = Rz(phi2 + phi1) is really just 1 angle
+                                             &xacc::quantum::IonTrapOptFunction::nablaHRzRz_3,
+                                             &xacc::quantum::IonTrapOptFunction::nablaHRzRz_4};
+    static const NablaMethod *nablaArr[] = {nablaHExact, nablaHRx, nablaHRz, nablaHRzExact, nablaHRzRx, nablaHRzRz};
+
+    assert(phi.n_rows-1 < sizeof nablaHExact / sizeof *nablaHExact);
+    assert(phi.n_rows-1 < sizeof nablaHRx / sizeof *nablaHRx);
+    assert(phi.n_rows-1 < sizeof nablaHRz / sizeof *nablaHRz);
+    assert(phi.n_rows-1 < sizeof nablaHRzExact / sizeof *nablaHExact);
+    assert(phi.n_rows-1 < sizeof nablaHRzRx / sizeof *nablaHRzRx);
+    assert(phi.n_rows-1 < sizeof nablaHRzRz / sizeof *nablaHRzRz);
+    assert((int)decomp < sizeof nablaArr / sizeof *nablaArr);
+
+    auto nablaMethod = nablaArr[(int)decomp][phi.n_rows-1];
+    assert(nablaMethod != nullptr);
+
+    arma::cx_mat gh(phi.n_rows, 1);
+    (this->*nablaMethod)(phi, gh);
+
+    std::complex<double> h = H(phi);
+    g = arma::real(-(std::conj(h)*gh + h*arma::conj(gh)));
+
+    return 4 - std::norm(h);
+}
+
+} // namespace quantum
+} // namespace xacc

--- a/quantum/plugins/iontrap/decomp/IonTrapOptFunction.hpp
+++ b/quantum/plugins/iontrap/decomp/IonTrapOptFunction.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ * License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Alexander J. McCaskey - initial API and implementation
+ *   Austin Adams - adapted for GTRI testbed
+ *******************************************************************************/
+#ifndef QUANTUM_ACCELERATORS_IONTRAPOPTFUNCTION_HPP_
+#define QUANTUM_ACCELERATORS_IONTRAPOPTFUNCTION_HPP_
+
+#include <armadillo>
+#include "IonTrapDecomp.hpp"
+
+namespace xacc {
+namespace quantum {
+
+class IonTrapOptFunction {
+public:
+    IonTrapOptFunction(Decomp decomp, const arma::cx_mat &goalUnitary)
+        : decomp(decomp), goal(goalUnitary) {}
+
+    double Evaluate(const arma::mat &phi);
+    double EvaluateWithGradient(const arma::mat &phi, arma::mat &g);
+
+private:
+    typedef void (IonTrapOptFunction::*NablaMethod)(const arma::mat &, arma::cx_mat &);
+
+    const Decomp decomp;
+    const arma::cx_mat &goal;
+
+    std::complex<double> H(const arma::mat &phi);
+    void nablaHExact_1(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRx_1(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRz_1(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzExact_1(const arma::mat &phi, arma::cx_mat &gh);
+    // No nablaHRzRx_1() because Rx(phi2).Rz(phi1) needs two angles. One can be 0, that's fine
+    void nablaHRzRz_1(const arma::mat &phi, arma::cx_mat &gh);
+
+    void nablaHExact_2(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRx_2(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRz_2(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzExact_2(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzRx_2(const arma::mat &phi, arma::cx_mat &gh);
+    // No nablaHRzRz_2() because Rz(phi2).Rz(phi1) = Rz(phi2 + phi1) is really just 1 angle
+
+    void nablaHExact_3(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRx_3(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRz_3(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzExact_3(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzRx_3(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzRz_3(const arma::mat &phi, arma::cx_mat &gh);
+
+    void nablaHExact_4(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRx_4(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRz_4(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzExact_4(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzRx_4(const arma::mat &phi, arma::cx_mat &gh);
+    void nablaHRzRz_4(const arma::mat &phi, arma::cx_mat &gh);
+};
+
+} // namespace quantum
+} // namespace xacc
+
+#endif

--- a/quantum/plugins/iontrap/tests/CMakeLists.txt
+++ b/quantum/plugins/iontrap/tests/CMakeLists.txt
@@ -13,5 +13,8 @@
 #   Austin Adams - adaption for GTRI testbed
 # *******************************************************************************/
 
+add_xacc_test(IonTrapOneQubitPass)
+target_link_libraries(IonTrapOneQubitPassTester xacc-iontrap)
+
 add_xacc_test(IonTrapTwoQubitPass)
 target_link_libraries(IonTrapTwoQubitPassTester xacc-iontrap)

--- a/quantum/plugins/iontrap/tests/IonTrapOneQubitPassTester.cpp
+++ b/quantum/plugins/iontrap/tests/IonTrapOneQubitPassTester.cpp
@@ -1,0 +1,286 @@
+/*******************************************************************************
+ * Copyright (c) 2019-2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ * License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Thien Nguyen - initial API and implementation
+ *   Daniel Strano - adaption from Quantum++ to Qrack
+ *   Austin Adams - adaption for GTRI testbed
+ *******************************************************************************/
+#include <gtest/gtest.h>
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "IonTrapOneQubitPass.hpp"
+#include "IonTrapTwoQubitPass.hpp"
+
+namespace {
+// Give us some nice breathing room
+const double ERR = 1e-4;
+const double THRESHOLD = 1e-3;
+}
+
+//
+// Single-qubit pass tests
+//
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassExactX)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void my_x(qbit q) {
+        X(q[0]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", true},
+                                      {"keep-rx-before-xx", true},
+                                      {"keep-leading-rz", true}});
+
+    std::vector<std::size_t> bits0({0});
+
+    EXPECT_EQ(2, ir->nInstructions());
+
+    EXPECT_EQ("Rphi", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(0.0,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Rphi", ir->getInstruction(1)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(1)->bits());
+    EXPECT_NEAR(0.0,
+                xacc::InstructionParameterToDouble(ir->getInstruction(1)->getParameter(0)),
+                ERR);
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassCommuteXAroundXX)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void xx_x_test(qbit q) {
+        X(q[0]);
+        X(q[1]);
+        XX(q[0], q[1], pi/4);
+        X(q[0]);
+        X(q[1]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", true},
+                                      {"keep-rx-before-xx", false},
+                                      {"keep-leading-rz", true}});
+
+    std::vector<std::size_t> bits01({0, 1});
+
+    EXPECT_EQ(1, ir->nInstructions());
+
+    EXPECT_EQ("XX", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits01, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(M_PI/4,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassUpToZ)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void upToZ(qbit q) {
+        H(q[0]);
+        Measure(q[0]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", false},
+                                      {"keep-rx-before-xx", true},
+                                      {"keep-leading-rz", true}});
+
+    std::vector<std::size_t> bits0({0});
+
+    EXPECT_EQ(2, ir->nInstructions());
+
+    EXPECT_EQ("Rphi", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(-M_PI/2,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Measure", ir->getInstruction(1)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(1)->bits());
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassFromZ)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void fromZ(qbit q) {
+        H(q[0]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", true},
+                                      {"keep-rx-before-xx", true},
+                                      {"keep-leading-rz", false}});
+
+    std::vector<std::size_t> bits0({0});
+
+    EXPECT_EQ(1, ir->nInstructions());
+
+    EXPECT_EQ("Rphi", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(M_PI/2,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassFromZtoX)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void fromZtoX(qbit q) {
+        Y(q[0]);
+        XX(q[0], q[1], pi/4);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", true},
+                                      {"keep-rx-before-xx", false},
+                                      {"keep-leading-rz", false}});
+
+    std::vector<std::size_t> bits0({0});
+    std::vector<std::size_t> bits01({0,1});
+
+    EXPECT_EQ(3, ir->nInstructions());
+
+    EXPECT_EQ("XX", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits01, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(M_PI/4,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Rphi", ir->getInstruction(1)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(1)->bits());
+    EXPECT_NEAR(0,
+                xacc::InstructionParameterToDouble(ir->getInstruction(1)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Rphi", ir->getInstruction(2)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(2)->bits());
+    EXPECT_NEAR(0,
+                xacc::InstructionParameterToDouble(ir->getInstruction(2)->getParameter(0)),
+                ERR);
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassFromZtoZ)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void fromZtoZ(qbit q) {
+        Z(q[0]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", false},
+                                      {"keep-rx-before-xx", true},
+                                      {"keep-leading-rz", false}});
+
+    std::vector<std::size_t> bits0({0});
+
+    EXPECT_EQ(0, ir->nInstructions());
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassTrailingGates)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void fromZtoZ(qbit q) {
+        XX(q[0], q[1], pi/4);
+        X(q[1]);
+        Y(q[0]);
+        Measure(q[0]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", false},
+                                      {"keep-rz-before-meas", true},
+                                      {"keep-rx-before-xx", true},
+                                      {"keep-leading-rz", true}});
+
+    std::vector<std::size_t> bits0({0});
+    std::vector<std::size_t> bits01({0,1});
+
+    EXPECT_EQ(4, ir->nInstructions());
+
+    EXPECT_EQ("XX", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits01, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(M_PI/4,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Rphi", ir->getInstruction(1)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(1)->bits());
+    EXPECT_NEAR(M_PI/2,
+                xacc::InstructionParameterToDouble(ir->getInstruction(1)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Rphi", ir->getInstruction(2)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(2)->bits());
+    EXPECT_NEAR(M_PI/2,
+                xacc::InstructionParameterToDouble(ir->getInstruction(2)->getParameter(0)),
+                ERR);
+
+    EXPECT_EQ("Measure", ir->getInstruction(3)->name());
+    EXPECT_EQ(bits0, ir->getInstruction(3)->bits());
+}
+
+TEST(IonTrapOneQubitPassTester, oneQubitPassIdentity)
+{
+    auto c = xacc::getService<xacc::Compiler>("xasm");
+    auto ir = c->compile(R"(__qpu__ void identityTest(qbit q) {
+        X(q[0]);
+        XX(q[0], q[1], pi/4);
+        X(q[0]);
+        H(q[1]);
+        H(q[1]);
+    })")->getComposites()[0];
+    auto oneQubitPass = xacc::getService<xacc::IRTransformation>("iontrap-1q-pass");
+
+    oneQubitPass->apply(ir, nullptr, {{"threshold", THRESHOLD},
+                                      {"keep-trailing-gates", true},
+                                      {"keep-rz-before-meas", true},
+                                      {"keep-rx-before-xx", false},
+                                      {"keep-leading-rz", true}});
+
+    std::vector<std::size_t> bits01({0,1});
+
+    EXPECT_EQ(1, ir->nInstructions());
+
+    EXPECT_EQ("XX", ir->getInstruction(0)->name());
+    EXPECT_EQ(bits01, ir->getInstruction(0)->bits());
+    EXPECT_NEAR(M_PI/4,
+                xacc::InstructionParameterToDouble(ir->getInstruction(0)->getParameter(0)),
+                ERR);
+}
+
+
+int main(int argc, char **argv) {
+  xacc::Initialize();
+
+  ::testing::InitGoogleTest(&argc, argv);
+  const auto result = RUN_ALL_TESTS();
+
+  xacc::Finalize();
+
+  return result;
+}

--- a/quantum/plugins/iontrap/transformations/IonTrapOneQubitPass.cpp
+++ b/quantum/plugins/iontrap/transformations/IonTrapOneQubitPass.cpp
@@ -1,0 +1,464 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ *License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Alexander J. McCaskey - initial API and implementation
+ *   Austin Adams - adapted for GTRI testbed
+ *******************************************************************************/
+#include <limits>
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include <ensmallen.hpp>
+#include "IonTrapOneQubitPass.hpp"
+#include "IonTrapOptFunction.hpp"
+#include "Accelerator.hpp"
+#include "CommonGates.hpp"
+#include "GateFusion.hpp"
+
+namespace xacc {
+namespace quantum {
+
+//
+// Single-qubit decomposition
+//
+
+void IonTrapOneQubitPass::matrixMod(arma::mat &mat, double mod) {
+    for (double &elem : mat) {
+        elem = std::fmod(elem, mod);
+    }
+}
+
+arma::mat IonTrapOneQubitPass::runOptimizer(Decomp decomp, arma::cx_mat goal, int rotations, double &obj_final) {
+    if (rotations) {
+        arma::mat angles(rotations, 1, arma::fill::randu);
+        IonTrapOptFunction func(decomp, goal);
+        ens::L_BFGS opt;
+        opt.NumBasis() = 15;
+        ens::StoreBestCoordinates<arma::mat> cb;
+
+        opt.Optimize(func, angles, cb);
+        obj_final = cb.BestObjective();
+        matrixMod(angles, 2*M_PI);
+        return angles;
+    } else {
+        // Special case: for no rotations, don't bother running the optimizer
+        obj_final = distanceFromIdentity(goal);
+        return {};
+    }
+}
+
+
+std::vector<InstPtr> IonTrapOneQubitPass::decompose(Decomp decomp,
+                                                 const arma::cx_mat goal,
+                                                 double threshold,
+                                                 std::size_t bitIdx,
+                                                 std::string &bufferName,
+                                                 arma::cx_mat &tracking_out) {
+    static const int max_rotations = 4;
+    int rotations = 0;
+    auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+
+    xacc::debug("Running " + decompName(decomp) + " optimizer...");
+
+    // Save results in case we get poor results and need to backtrack
+    std::vector<double> saved_obj;
+    // Column X stores the angles found for using X rotations
+    arma::mat saved_angles(max_rotations, max_rotations + 1, arma::fill::zeros);
+
+    while (1) {
+        if (decompShouldSkip(decomp, rotations)) {
+            // Make sure we never use this number of rotations
+            saved_obj.push_back(std::numeric_limits<double>::infinity());
+            xacc::debug("Skipping " + decompName(decomp) + " optimizer with "
+                        + std::to_string(rotations) + " rotations because there is "
+                        "no optimizer for it. Adding a rotation and retrying...");
+            rotations++;
+            continue;
+        }
+
+        double obj_final;
+        arma::mat angles = runOptimizer(decomp, goal, rotations, obj_final);
+
+        if (rotations) {
+            saved_angles.col(rotations).head(rotations) = angles.col(0);
+        }
+        saved_obj.push_back(obj_final);
+
+        xacc::debug("Final obj function value with " + std::to_string(rotations)
+                    + " rotations: " + std::to_string(obj_final));
+
+        if (obj_final <= threshold) {
+            break;
+        } else if (rotations == max_rotations) {
+            if (decomp == Decomp::Exact) {
+                int min_idx = 0;
+                for (int i = 1; i <= max_rotations; i++) {
+                    if (saved_obj[i] < saved_obj[min_idx]) {
+                        min_idx = i;
+                    }
+                }
+
+                xacc::warning("Should never require more than 4 rotations to "
+                              "find a unitary. Is the " + decompName(decomp) +
+                              " optimizer broken? Falling back to " +
+                              std::to_string(min_idx) + " rotations with "
+                              "objective function value " +
+                              std::to_string(saved_obj[min_idx]) + "...");
+                if (xacc::verbose) {
+                    std::stringstream ss;
+                    ss << "Goal\n" << goal;
+                    xacc::warning(ss.str());
+                }
+                rotations = min_idx;
+                break;
+            } else {
+                Decomp nextToTry = decompNextToTry(decomp);
+                xacc::warning("Should never require more than 4 rotations to "
+                              "find a unitary. Is the " + decompName(decomp) +
+                              " optimizer broken? Falling back to generating an " +
+                              decompName(nextToTry) + " decomposition...");
+                return decompose(nextToTry, goal, threshold,
+                                 bitIdx, bufferName, tracking_out);
+            }
+        } else {
+            rotations++;
+        }
+    }
+
+    for (int i = 0; i < rotations; i++) {
+        xacc::debug("rotation " + std::to_string(i) + ": " + std::to_string(saved_angles(i, rotations)));
+    }
+
+    std::size_t nonPirotAngles = decompFromRotationCount(decomp) + decompCount(decomp);
+    std::vector<InstPtr> ops(std::max<int>(rotations - (int)nonPirotAngles, 0));
+    for (int i = 0; i < ops.size(); i++) {
+        double phi = saved_angles(i + (int)decompFromRotationCount(decomp), rotations);
+        // On the IonTrap system, theta is always pi/2.
+        // See: https://doi.org/10.1088/1367-2630/18/2/023048
+        double theta = M_PI/2.0;
+        InstPtr rot = gateRegistry->createInstruction("Rphi", {bitIdx}, {phi, theta});
+        rot->setBufferNames({bufferName});
+        ops[i] = rot;
+    }
+
+    if (rotations && decompCount(decomp) && decompShouldTrack(decomp)) {
+        if (decomp == Decomp::RZ) {
+            xacc::debug("discarding Rz(" + std::to_string(saved_angles(rotations-1, rotations))
+                        + ") on qubit " + std::to_string(bitIdx));
+        }
+        // TODO: if decompCount(decomp) > 1, this will break
+        tracking_out = decompMat(decomp, saved_angles(rotations-1, rotations));
+    } else {
+        tracking_out = arma::eye<arma::cx_mat>(2,2);
+    }
+
+    return ops;
+}
+
+double IonTrapOneQubitPass::distanceFromIdentity(arma::cx_mat mat) {
+    double abs = std::abs(arma::trace(mat));
+    return 4 - abs*abs;
+}
+
+void IonTrapOneQubitPass::nukeGates(std::shared_ptr<CompositeInstruction> program,
+                                   const std::vector<std::size_t> &sequence) {
+    for (const auto instIdx : sequence) {
+        auto instrPtr = program->getInstruction(instIdx);
+        instrPtr->disable();
+    }
+    program->removeDisabled();
+}
+
+std::size_t IonTrapOneQubitPass::decomposeTracking(Decomp decomp,
+                                                std::shared_ptr<CompositeInstruction> program,
+                                                std::size_t instIdx,
+                                                std::map<std::size_t, arma::cx_mat> &tracking,
+                                                double threshold,
+                                                std::string &bufferName,
+                                                IonTrapLogTransformCallback logTransCallback) {
+    std::size_t totalDecomp = 0;
+    std::vector<std::size_t> bits;
+    if (instIdx >= program->nInstructions()) {
+        // end of circuit
+        for (auto const &kv : tracking) {
+            bits.push_back(kv.first);
+        }
+    } else {
+        // measure instruction etc
+        InstPtr inst = program->getInstruction(instIdx);
+        bits = inst->bits();
+    }
+
+    for (const auto bit : bits) {
+        if (tracking.count(bit) && distanceFromIdentity(tracking[bit]) >= threshold) {
+            std::vector<InstPtr> decomposed = decompose(decomp, tracking[bit],
+                                                        threshold, bit, bufferName,
+                                                        tracking[bit]);
+
+            for (std::size_t i = 0; i < decomposed.size(); i++) {
+                if (instIdx + i < program->nInstructions()) {
+                    program->insertInstruction(instIdx + i, decomposed[i]);
+                } else {
+                    program->addInstruction(decomposed[i]);
+                }
+            }
+
+            totalDecomp += decomposed.size();
+        }
+    }
+
+    if (logTransCallback) {
+        std::vector<InstPtr> newInsts(totalDecomp);
+        for (std::size_t i = 0; i < totalDecomp; i++) {
+            newInsts[i] = program->getInstruction(instIdx + i);
+        }
+        logTransCallback({}, newInsts);
+    }
+
+    return totalDecomp;
+}
+
+std::size_t IonTrapOneQubitPass::decomposeInPlace(Decomp decomp,
+                                               std::shared_ptr<CompositeInstruction> program,
+                                               const std::vector<std::size_t> &sequence,
+                                               std::map<std::size_t, arma::cx_mat> &tracking,
+                                               double threshold,
+                                               std::string &bufferName,
+                                               IonTrapLogTransformCallback logTransCallback) {
+    auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+    auto tmpKernel = gateRegistry->createComposite("__TMP__");
+    for (const auto instIdx: sequence) {
+        auto instrPtr = program->getInstruction(instIdx)->clone();
+        assert(instrPtr->bits().size() == 1);
+        // Remap to bit 0 for fusing
+        instrPtr->setBits({ 0 });
+        tmpKernel->addInstruction(instrPtr);
+    }
+
+    auto fuser = xacc::getService<xacc::quantum::GateFuser>("default");
+    fuser->initialize(tmpKernel);
+    Eigen::Matrix2cd uMat = fuser->calcFusedGate(1);
+    const arma::cx_mat unitary = arma::cx_mat(uMat.data(), uMat.rows(), uMat.cols());
+    const std::size_t bitIdx = program->getInstruction(sequence[0])->bits()[0];
+
+    // Disable existing instructions (so we can remove them at the end
+    // of this method)
+    for (const auto instIdx : sequence) {
+        auto instrPtr = program->getInstruction(instIdx);
+        instrPtr->disable();
+    }
+
+    if (!tracking.count(bitIdx)) {
+        tracking[bitIdx] = arma::eye<arma::cx_mat>(2,2);
+    }
+
+    std::vector<InstPtr> decomposed = decompose(decomp, unitary * tracking[bitIdx],
+                                                threshold, bitIdx, bufferName,
+                                                tracking[bitIdx]);
+    auto locationToInsert = sequence[0];
+    for (auto& newInst : decomposed) {
+        program->insertInstruction(locationToInsert, newInst);
+        locationToInsert++;
+    }
+
+    if (logTransCallback) {
+        std::vector<InstPtr> oldInsts(sequence.size());
+        for (std::size_t i = 0; i < sequence.size(); i++) {
+            oldInsts[i] = program->getInstruction(sequence[i] + decomposed.size());
+        }
+        std::vector<InstPtr> newInsts(decomposed.size());
+        for (std::size_t i = 0; i < decomposed.size(); i++) {
+            newInsts[i] = program->getInstruction(sequence[0] + i);
+        }
+
+        logTransCallback(oldInsts, newInsts);
+    }
+
+    program->removeDisabled();
+
+    return decomposed.size();
+}
+
+// Yoinked from MergeSingleQubitGatesOptimizer
+// Check if the composite uses a single qubit register,
+// the qubit line is determined by the qubit idx,
+// hence we don't want to accidentally merge wrong gates.
+std::size_t IonTrapOneQubitPass::numDistinctBuffers(const std::shared_ptr<CompositeInstruction> program, std::string &bufferNameOut) {
+    std::set<std::string> allBuffers;
+    InstructionIterator it(program);
+    while (it.hasNext()) {
+        auto nextInst = it.next();
+        for (const auto &bufferName : nextInst->getBufferNames()) {
+            allBuffers.emplace(bufferName);
+        }
+    }
+
+    if (!allBuffers.empty()) {
+        bufferNameOut = *allBuffers.begin();
+    }
+
+    return allBuffers.size();
+}
+
+std::vector<std::size_t> IonTrapOneQubitPass::findSingleQubitGateSequence(const std::shared_ptr<CompositeInstruction> program, size_t startIdx, std::set<std::size_t> &qubitsSeen, GateSeqStart &start, GateSeqTerm &term) {
+    const auto nInstructions = program->nInstructions();
+
+    if (startIdx >= nInstructions) {
+        // TODO: set start to some sentinel value instead? this is a little misleading
+        //       since we don't have enough information to actually say
+        start = GateSeqStart::TWO_QUBIT_GATE;
+        term = GateSeqTerm::CIRCUIT_END;
+        return {};
+    }
+
+    auto firstInst = program->getInstruction(startIdx);
+
+    auto bits = firstInst->bits();
+    start = std::any_of(bits.begin(), bits.end(), [&](std::size_t idx) {
+                return qubitsSeen.count(idx);
+            }) ? GateSeqStart::TWO_QUBIT_GATE : GateSeqStart::CIRCUIT_START;
+    //qubitsSeen.insert(firstInst->bits().begin(), firstInst->bits().end());
+    qubitsSeen.insert(bits.begin(), bits.end());
+
+    // Not a single-qubit gate.
+    if (bits.size() > 1) {
+        term = GateSeqTerm::TWO_QUBIT_GATE;
+        return {};
+    } else if (firstInst->name() == "Measure") {
+        term = GateSeqTerm::MEASUREMENT;
+        return {};
+    }
+
+    const std::size_t bitIdx = firstInst->bits()[0];
+    std::vector<std::size_t> gateSequence;
+    gateSequence.emplace_back(startIdx);
+
+    for (size_t instIdx = startIdx + 1; instIdx < nInstructions; instIdx++) {
+        auto instPtr = program->getInstruction(instIdx);
+
+        if (instPtr->bits().size() == 1 && instPtr->bits()[0] == bitIdx) {
+            if (instPtr->name() != "Measure") {
+                gateSequence.emplace_back(instIdx);
+            } else {
+                term = GateSeqTerm::MEASUREMENT;
+                return gateSequence;
+            }
+        // If this is a two-qubit gate that involves this qubit wire,
+        // terminate the scan and return.
+        } else if (instPtr->bits().size() == 2 && xacc::container::contains(instPtr->bits(), bitIdx)) {
+            term = GateSeqTerm::TWO_QUBIT_GATE;
+            return gateSequence;
+        }
+    }
+
+    // Reach the end of the circuit:
+    term = GateSeqTerm::CIRCUIT_END;
+    return gateSequence;
+}
+
+void IonTrapOneQubitPass::apply(std::shared_ptr<CompositeInstruction> program, const std::shared_ptr<Accelerator> accelerator, const HeterogeneousMap &options) {
+    IonTrapLogTransformCallback logTransCallback = nullptr;
+    if (options.keyExists<IonTrapLogTransformCallback>("log-trans-cb")) {
+        logTransCallback = options.get<IonTrapLogTransformCallback>("log-trans-cb");
+    }
+    bool keepTrailingGates = options.keyExists<bool>("keep-trailing-gates")
+                             && options.get<bool>("keep-trailing-gates");
+    bool keepRzBeforeMeas = options.keyExists<bool>("keep-rz-before-meas")
+                            && options.get<bool>("keep-rz-before-meas");
+    bool keepRxBeforeXX = options.keyExists<bool>("keep-rx-before-xx")
+                          && options.get<bool>("keep-rx-before-xx");
+    bool keepLeadingRz = options.keyExists<bool>("keep-leading-rz")
+                         && options.get<bool>("keep-leading-rz");
+    double threshold = DEFAULT_THRESHOLD;
+    if (options.keyExists<double>("threshold")) {
+        threshold = options.get<double>("threshold");
+    }
+
+    std::string bufferName;
+    if (numDistinctBuffers(program, bufferName) > 1) {
+        // If there are multiple buffers, we cannot apply gate merging
+        // due to qubit Id ambiguity.
+        xacc::error("Cannot run single qubit merge optimizer on a program with multiple buffers!");
+        return;
+    }
+
+    iontrapFlattenComposite(program);
+    std::set<std::size_t> qubitsSeen;
+    std::map<std::size_t, arma::cx_mat> tracking;
+
+    for (std::size_t instIdx = 0; instIdx <= program->nInstructions();) {
+        GateSeqStart start;
+        GateSeqTerm term;
+        const auto sequence = findSingleQubitGateSequence(program, instIdx, qubitsSeen, start, term);
+
+        std::size_t decompSize;
+        if (sequence.empty()) {
+            // We don't need to consider GateSeqStart here because decomposeTracking() only
+            // considers qubits with tracking set. But tracking is set only when a
+            // one-qubit or two-qubit gate has been applied to a qubit, which means it may
+            // not be in state |0>.
+            Decomp decomp = keepRzBeforeMeas? Decomp::Exact : Decomp::RZ;
+
+            switch (term) {
+                case GateSeqTerm::CIRCUIT_END:
+                    if (keepTrailingGates) {
+                        decompSize = decomposeTracking(decomp, program, instIdx, tracking, threshold, bufferName, logTransCallback);
+                    } else {
+                        decompSize = 0;
+                    }
+                    break;
+                case GateSeqTerm::TWO_QUBIT_GATE:
+                    // This Rx(theta) still commutes past this XX gate, nothing to do
+                    decompSize = 0;
+                    break;
+                case GateSeqTerm::MEASUREMENT:
+                    decompSize = decomposeTracking(decomp, program, instIdx, tracking, threshold, bufferName, logTransCallback);
+                    break;
+            }
+
+            // +1 because we always want to skip whatever caused
+            // findSingleQubitGateSequence() to return an empty list
+            instIdx += decompSize + 1;
+        } else {
+            Decomp decompBeforeMeas, decompBeforeXX;
+            if (start == GateSeqStart::CIRCUIT_START && !keepLeadingRz) {
+                // Can safely extract leading Rz(theta) since this qubit is |0>
+                decompBeforeMeas = keepRzBeforeMeas ? Decomp::RZExact : Decomp::RZRZ;
+                decompBeforeXX = keepRxBeforeXX ? Decomp::RZExact : Decomp::RZRX;
+            } else {
+                decompBeforeMeas = keepRzBeforeMeas ? Decomp::Exact : Decomp::RZ;
+                decompBeforeXX = keepRxBeforeXX ? Decomp::Exact : Decomp::RX;
+            }
+
+            switch (term) {
+                case GateSeqTerm::CIRCUIT_END:
+                    if (keepTrailingGates) {
+                        decompSize = decomposeInPlace(decompBeforeMeas, program, sequence, tracking, threshold, bufferName, logTransCallback);
+                    } else {
+                        // If there was no measurement, no need to apply tracking
+                        // or these gates
+                        nukeGates(program, sequence);
+                        decompSize = 0;
+                    }
+                    break;
+                case GateSeqTerm::TWO_QUBIT_GATE:
+                    decompSize = decomposeInPlace(decompBeforeXX, program, sequence, tracking, threshold, bufferName, logTransCallback);
+                    break;
+                case GateSeqTerm::MEASUREMENT:
+                    decompSize = decomposeInPlace(decompBeforeMeas, program, sequence, tracking, threshold, bufferName, logTransCallback);
+                    break;
+            }
+
+            instIdx += decompSize;
+        }
+    }
+}
+
+} // namespace quantum
+} // namespace xacc

--- a/quantum/plugins/iontrap/transformations/IonTrapOneQubitPass.hpp
+++ b/quantum/plugins/iontrap/transformations/IonTrapOneQubitPass.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2021 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompanies this
+ * distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html and the Eclipse Distribution
+ * License is available at https://eclipse.org/org/documents/edl-v10.php
+ *
+ * Contributors:
+ *   Alexander J. McCaskey - initial API and implementation
+ *   Austin Adams - adapted for GTRI testbed
+ *******************************************************************************/
+#ifndef QUANTUM_ACCELERATORS_IONTRAPONEQUBITPASS_HPP_
+#define QUANTUM_ACCELERATORS_IONTRAPONEQUBITPASS_HPP_
+
+#include <armadillo>
+#include "Accelerator.hpp"
+#include "IRTransformation.hpp"
+#include "IonTrapDecomp.hpp"
+#include <Eigen/Dense>
+#include "IonTrapPassesCommon.hpp"
+
+namespace xacc {
+namespace quantum {
+
+// Based on MergeSingleQubitGatesOptimizer
+class IonTrapOneQubitPass : public IRTransformation {
+public:
+    static constexpr double DEFAULT_THRESHOLD = 0.0001;
+
+    IonTrapOneQubitPass() {}
+    void apply(std::shared_ptr<CompositeInstruction> program,
+               const std::shared_ptr<Accelerator> accelerator,
+               const HeterogeneousMap &options = {}) override;
+
+    const IRTransformationType type() const override {
+        return IRTransformationType::Optimization;
+    }
+    const std::string name() const override { return "iontrap-1q-pass"; }
+    const std::string description() const override { return ""; }
+
+private:
+    enum class GateSeqStart { CIRCUIT_START, TWO_QUBIT_GATE };
+    enum class GateSeqTerm { MEASUREMENT, TWO_QUBIT_GATE, CIRCUIT_END };
+
+    static void matrixMod(arma::mat &, double);
+
+    double distanceFromIdentity(arma::cx_mat);
+    std::vector<InstPtr> decompose(Decomp,
+                                   const arma::cx_mat,
+                                   double,
+                                   std::size_t,
+                                   std::string &,
+                                   arma::cx_mat &);
+    std::size_t numDistinctBuffers(const std::shared_ptr<CompositeInstruction>, std::string &);
+    arma::mat runOptimizer(Decomp, arma::cx_mat, int, double &);
+    std::vector<std::size_t> findSingleQubitGateSequence(const std::shared_ptr<CompositeInstruction>,
+                                                         std::size_t, std::set<std::size_t> &,
+                                                         GateSeqStart &, GateSeqTerm &);
+    void nukeGates(std::shared_ptr<CompositeInstruction>,
+                   const std::vector<std::size_t> &);
+    std::size_t decomposeInPlace(Decomp,
+                                 std::shared_ptr<CompositeInstruction>,
+                                 const std::vector<std::size_t> &,
+                                 std::map<std::size_t, arma::cx_mat> &,
+                                 double,
+                                 std::string &,
+                                 IonTrapLogTransformCallback);
+    std::size_t decomposeTracking(Decomp,
+                                  std::shared_ptr<CompositeInstruction>,
+                                  std::size_t,
+                                  std::map<std::size_t, arma::cx_mat> &,
+                                  double,
+                                  std::string &,
+                                  IonTrapLogTransformCallback);
+};
+
+} // namespace quantum
+} // namespace xacc
+
+#endif


### PR DESCRIPTION
This PR is for the one-qubit IRTransformation which decomposes sequences of single-qubit unitaries into R_phi(pi/2) gates. Described in Section III-C of https://arxiv.org/pdf/2111.00146.pdf

Next PR is the actual Accelerator

## Gradients from Mathematica

For future reference, I created the gradients hardcoded in `IonTrapOptFunction.cpp` using the following Mathematica notebook (gzipped so GitHub will let me upload it): [r-decomp-gradients.nb.gz](https://github.com/eclipse/xacc/files/7590468/r-decomp-gradients.nb.gz). It's not very organized, but it's only used to generate C++ code by running the gradients it finds through the following Python I had in a Jupyter notebook:

```python
def textToCpp(text, indent=''):
    text = text.strip('{}')
    terms = text.split(',')
    repl = [('Sqrt[', 'std::sqrt('),
            ('Conjugate[', 'std::conj('),
            ('Sin[', 'std::sin('),
            ('Cos[', 'std::cos('),
            ('phi1', 'phi(0,0)'),
            ('phi2', 'phi(1,0)'),
            ('phi3', 'phi(2,0)'),
            ('phi4', 'phi(3,0)'),
            (' ', '*'),
            ('I', 'i'),
            ('E^(', 'std::exp('),
            (']', ')'),
            ('u11', 'goal(0,0)'),
            ('u12', 'goal(0,1)'),
            ('u21', 'goal(1,0)'),
            ('u22', 'goal(1,1)')]
    re_repl = [(r'(?P<digit>\d)(?P<sym>[/*+-])', '\g<digit>.0\g<sym>'),
               (r'(?P<sym>[/*+-])(?P<digits>\d+)(?!\.)', '\g<sym>\g<digits>.0'),
               (r'\((?P<digits>\d+)\)', '(\g<digits>.0)'),
               (r'\)(?P<char>\w)', ')*\g<char>'),]
    re_repl = [(re.compile(pat), subst) for pat, subst in re_repl]
    
    for i in range(len(terms)):
        for old, new in repl:
            terms[i] = terms[i].replace(old, new)
        for pat, new in re_repl:
            terms[i] = pat.sub(new, terms[i])
        terms[i] = '{}gh({},0) = {};\n'.format(indent, i, terms[i])
    text = '\n'.join(terms)
    return text

def genNabla(suffix, grads):
    templ = '''void GTRIPulseTransform::GTRIOptFunction::nablaH{}_{}(const arma::mat &phi, arma::cx_mat &gh) {{
    const auto i = std::complex<double>(0, 1);

'''
    indent = ' '*4
    footer = '}\n'
    funcs = [templ.format(suffix, i+1) + textToCpp(line, indent) + footer for i, line in enumerate(grads) if line]
    return '\n'.join(funcs)

# example
print(genNabla('Rx', [
    '{-(1/2) I (Conjugate[u12]+Conjugate[u21]) Cos[phi1/2]-1/2 (Conjugate[u11]+Conjugate[u22]) Sin[phi1/2]}',
    '{1/Sqrt[2] E^(-I phi1) (-((Co...',
    # ...
]))
```

I'm not sure how best to include all that in the repository, so I've left it out for now. Ideally, we'd have a closed form decomposition of an arbitrary unitary into R_phi(pi/2) gates (possibly followed by or preceded by RX/RZ gates) and wouldn't need the optimizer or these gradients in the first place. Even if we never managed to find that that decomposition, there could still be a different optimizer that doesn't need gradients (e.g. the [scipy BFGS optimizer](https://docs.scipy.org/doc/scipy/reference/optimize.minimize-bfgs.html)), making all this gradient business obsolete as well

## Testing

`ctest`. I added a test for the one-qubit pass. Tried to make it have pretty reasonable expectations so that in the future, the optimizer won't flake out and fail the test randomly and annoy people