### PR TITLE
Update Qrack plugin for v7 API

### DIFF
--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
@@ -50,6 +50,26 @@ namespace quantum {
             m_use_stabilizer = params.get<bool>("use_stabilizer");
         }
 
+        if (params.keyExists<bool>("use_binary_decision_tree"))
+        {
+            m_use_binary_decision_tree = params.get<bool>("use_binary_decision_tree");
+        }
+
+        if (params.keyExists<bool>("use_paging"))
+        {
+            m_use_paging = params.get<bool>("use_paging");
+        }
+
+        if (params.keyExists<bool>("use_z_x_fusion"))
+        {
+            m_use_z_x_fusion = params.get<bool>("use_z_x_fusion");
+        }
+
+        if (params.keyExists<bool>("use_cpu_gpu_hybrid"))
+        {
+            m_use_cpu_gpu_hybrid = params.get<bool>("use_cpu_gpu_hybrid");
+        }
+
         if (params.keyExists<int>("device_id"))
         {
             m_device_id = params.get<int>("device_id");
@@ -111,7 +131,7 @@ namespace quantum {
         }
 
         const auto runCircuit = [&](int shots){
-            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_opencl_multi, m_use_stabilizer, m_device_id, m_do_normalize, m_zero_threshold);
+            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_opencl_multi, m_use_stabilizer, m_use_binary_decision_tree, m_use_paging, m_use_z_x_fusion, m_use_cpu_gpu_hybrid, m_device_id, m_do_normalize, m_zero_threshold);
 
             // Walk the IR tree, and visit each node
             InstructionIterator it(compositeInstruction);

--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
@@ -39,8 +39,12 @@ private:
     int m_shots = -1;
     bool m_use_opencl = true;
     bool m_use_qunit = true;
-    bool m_use_opencl_multi = false;
+    bool m_use_opencl_multi = true;
     bool m_use_stabilizer = true;
+    bool m_use_binary_decision_tree = false;
+    bool m_use_paging = true;
+    bool m_use_z_x_fusion = true;
+    bool m_use_cpu_gpu_hybrid = true;
     int m_device_id = -1;
     bool m_do_normalize = false;
     double m_zero_threshold = REAL1_EPSILON;

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
@@ -28,7 +28,7 @@ namespace quantum {
 
 #if ENABLE_OPENCL
         bool isOcl = use_opencl && (Qrack::OCLEngine::Instance()->GetDeviceCount() > 0);
-        bool isOclMulti = use_opencl_multi && (Qrack::OCLEngine::Instance()->GetDeviceCount() > 1);
+        bool isOclMulti = isOcl && use_opencl_multi && (Qrack::OCLEngine::Instance()->GetDeviceCount() > 1);
 #else
         bool isOcl = false;
         bool isOclMulti = false;

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
@@ -34,7 +34,7 @@ namespace xacc {
 namespace quantum {
 class QrackVisitor : public AllGateVisitor, public OptionsProvider, public xacc::Cloneable<QrackVisitor> {
 public:
-  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, bool use_stabilizer, int device_id, bool doNormalize, double zero_threshold);
+  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, bool use_stabilizer, bool use_binary_decision_tree, bool use_paging, bool use_z_x_fusion, bool use_cpu_gpu_hybrid, int device_id, bool doNormalize, double zero_threshold);
   void finalize();
 
   void visit(Hadamard& h) override;


### PR DESCRIPTION
Signed-off-by: Daniel Strano <stranoj@gmail.com>

This is Dan Strano over at the Qrack framework. I'm prepping for the official release of Qrack API v7 on 2022-01-01, and part of the work is cleaning house with all our external integrations. It looks like the Qrack plugin for XACC was already compliant with the new API version, but I took the opportunity to expose all the same simulator layer stack options and defaults to XACC as we do with our shared library. This also lets an OpenCL build of Qrack work on a system with 0 available OpenCL ICDs, by falling back to pure CPU. Thank you!