### PR TITLE
Update dev deploy docker image (theia IDE)

### DIFF
--- a/docker/deploy/dev/Dockerfile
+++ b/docker/deploy/dev/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
     && python3 -m pip install setuptools \
     && python3 -m pip install python-language-server flake8 autopep8 \
     cmake ipopo pint numpy scipy pydantic qiskit pylint pyquil cirq matplotlib openfermion pyscf  \
+    qsearch qfactor scikit-quant myqlm qlmaas \
     && apt-get install -y gpg && rm -rf /var/lib/apt/lists/* \
     #Install node and yarn
     #From: https://github.com/nodejs/docker-node/blob/6b8d86d6ad59e0d1e7a94cec2e909cad137a028f/8/Dockerfile

--- a/docker/deploy/dev/Dockerfile
+++ b/docker/deploy/dev/Dockerfile
@@ -1,5 +1,109 @@
-from xacc/deploy-base
-workdir /home/dev
+from xacc/ubuntu:20.04
+ARG NODE_VERSION=12.18.3
+ENV NODE_VERSION $NODE_VERSION
+ENV YARN_VERSION 1.22.5
+ARG LLVM=14
+# use "latest" or "next" version for Theia packages
+ARG version=latest
+
+# Optionally build a striped Theia application with no map file or .ts sources.
+# Makes image ~150MB smaller when enabled
+ARG strip=false
+ENV strip=$strip
+
+WORKDIR /home/dev
+ADD settings.json /home/dev/.theia/
+
+# More deps (not in the xacc/ubuntu:20.04)
+RUN apt-get update && \
+    apt-get --no-install-recommends -y install libsecret-1-dev gfortran\
+                       curl vim  xz-utils \
+                       && python3 -m pip install --upgrade pip --user \
+                       && python3 -m pip install setuptools \
+                       && python3 -m pip install python-language-server flake8 autopep8 \
+                                cmake ipopo pint numpy scipy pydantic qiskit pylint pyquil cirq matplotlib openfermion pyscf  \
+    && apt-get install -y gpg && rm -rf /var/lib/apt/lists/* \
+
+#Install node and yarn
+#From: https://github.com/nodejs/docker-node/blob/6b8d86d6ad59e0d1e7a94cec2e909cad137a028f/8/Dockerfile
+# gpg keys listed at https://github.com/nodejs/node#release-keys
+
+    && set -ex \
+    && for key in \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    ; do \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-key "$key" || \
+    gpg --batch --keyserver keys.openpgp.org --recv-key "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    done \
+
+    && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+    esac \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+    && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+
+
+    && set -ex \
+    && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+    ; do \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-key "$key" || \
+    gpg --batch --keyserver keys.openpgp.org --recv-key "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" ; \
+    done \
+    && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+    && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+    && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+    && mkdir -p /opt/yarn \
+    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/yarn --strip-components=1 \
+    && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+    && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
+    && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+
+#C/C++ Developer tools
+# install clangd and clang-tidy from the public LLVM PPA (nightly build / development version)
+# and also the GDB debugger, cmake from the Ubuntu repos
+
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+                       clang-tools-$LLVM \
+                       clangd-$LLVM \
+                       clang-tidy-$LLVM \
+                       gdb && \
+    ln -s /usr/bin/clang-$LLVM /usr/bin/clang && \
+    ln -s /usr/bin/clang++-$LLVM /usr/bin/clang++ && \
+    ln -s /usr/bin/clang-cl-$LLVM /usr/bin/clang-cl && \
+    ln -s /usr/bin/clang-cpp-$LLVM /usr/bin/clang-cpp && \
+    ln -s /usr/bin/clang-tidy-$LLVM /usr/bin/clang-tidy && \
+    ln -s /usr/bin/clangd-$LLVM /usr/bin/clangd && \
+    rm -rf /var/lib/apt/lists/* 
 
 run cd /home/dev && git clone --recursive https://github.com/eclipse/xacc && cd xacc && mkdir build && cd build \
     && cmake .. -DXACC_BUILD_EXAMPLES=TRUE \
@@ -18,5 +122,5 @@ RUN yarn --cache-folder ./ycache && rm -rf ./ycache && \
 EXPOSE 3000
 ENV SHELL=/bin/bash \
     THEIA_DEFAULT_PLUGINS=local-dir:/home/dev/plugins
-ENV PYTHONPATH "${PYTHONPATH}:/root/.xacc:/root/.local/lib/python3.6/site-packages/psi4/lib"
+ENV PYTHONPATH "${PYTHONPATH}:/root/.xacc"
 ENTRYPOINT [ "yarn", "theia", "start", "/home/dev", "--hostname=0.0.0.0" ]

--- a/docker/deploy/dev/Dockerfile
+++ b/docker/deploy/dev/Dockerfile
@@ -1,4 +1,4 @@
-from xacc/ubuntu:20.04
+FROM xacc/ubuntu:20.04
 ARG NODE_VERSION=12.18.3
 ENV NODE_VERSION $NODE_VERSION
 ENV YARN_VERSION 1.22.5
@@ -17,17 +17,15 @@ ADD settings.json /home/dev/.theia/
 # More deps (not in the xacc/ubuntu:20.04)
 RUN apt-get update && \
     apt-get --no-install-recommends -y install libsecret-1-dev gfortran\
-                       curl vim  xz-utils \
-                       && python3 -m pip install --upgrade pip --user \
-                       && python3 -m pip install setuptools \
-                       && python3 -m pip install python-language-server flake8 autopep8 \
-                                cmake ipopo pint numpy scipy pydantic qiskit pylint pyquil cirq matplotlib openfermion pyscf  \
+    curl vim  xz-utils \
+    && python3 -m pip install --upgrade pip --user \
+    && python3 -m pip install setuptools \
+    && python3 -m pip install python-language-server flake8 autopep8 \
+    cmake ipopo pint numpy scipy pydantic qiskit pylint pyquil cirq matplotlib openfermion pyscf  \
     && apt-get install -y gpg && rm -rf /var/lib/apt/lists/* \
-
-#Install node and yarn
-#From: https://github.com/nodejs/docker-node/blob/6b8d86d6ad59e0d1e7a94cec2e909cad137a028f/8/Dockerfile
-# gpg keys listed at https://github.com/nodejs/node#release-keys
-
+    #Install node and yarn
+    #From: https://github.com/nodejs/docker-node/blob/6b8d86d6ad59e0d1e7a94cec2e909cad137a028f/8/Dockerfile
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
     && set -ex \
     && for key in \
     4ED778F539E3634C779C87C6D7062848A1AB005C \
@@ -47,7 +45,6 @@ RUN apt-get update && \
     gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
     gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" ; \
     done \
-
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
     amd64) ARCH='x64';; \
@@ -65,8 +62,6 @@ RUN apt-get update && \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-
-
     && set -ex \
     && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
@@ -84,19 +79,17 @@ RUN apt-get update && \
     && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
     && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
     && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-
-#C/C++ Developer tools
-# install clangd and clang-tidy from the public LLVM PPA (nightly build / development version)
-# and also the GDB debugger, cmake from the Ubuntu repos
-
+    #C/C++ Developer tools
+    # install clangd and clang-tidy from the public LLVM PPA (nightly build / development version)
+    # and also the GDB debugger, cmake from the Ubuntu repos
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-                       clang-tools-$LLVM \
-                       clangd-$LLVM \
-                       clang-tidy-$LLVM \
-                       gdb && \
+    clang-tools-$LLVM \
+    clangd-$LLVM \
+    clang-tidy-$LLVM \
+    gdb && \
     ln -s /usr/bin/clang-$LLVM /usr/bin/clang && \
     ln -s /usr/bin/clang++-$LLVM /usr/bin/clang++ && \
     ln -s /usr/bin/clang-cl-$LLVM /usr/bin/clang-cl && \
@@ -105,14 +98,14 @@ RUN apt-get update && \
     ln -s /usr/bin/clangd-$LLVM /usr/bin/clangd && \
     rm -rf /var/lib/apt/lists/* 
 
-run cd /home/dev && git clone --recursive https://github.com/eclipse/xacc && cd xacc && mkdir build && cd build \
+RUN cd /home/dev && git clone --recursive https://github.com/eclipse/xacc && cd xacc && mkdir build && cd build \
     && cmake .. -DXACC_BUILD_EXAMPLES=TRUE \
     && make -j$(nproc) install \
     && cd ../../ && git clone https://github.com/ornl-qci/tnqvm && cd tnqvm && mkdir build && cd build \
     && cmake .. -DXACC_DIR=~/.xacc && make -j$(nproc) install 
 
 # Theia application
-workdir /home/dev
+WORKDIR /home/dev
 ARG version=latest
 ADD $version.package.json ./package.json
 

--- a/docker/deploy/dev/latest.package.json
+++ b/docker/deploy/dev/latest.package.json
@@ -3,7 +3,7 @@
     "theia": {
         "frontend": {
             "config": {
-                "applicationName": "XACC IDE", 
+                "applicationName": "XACC IDE",
                 "preferences": {
                     "files.enableTrash": false,
                     "ruby.useLanguageServer": true
@@ -15,7 +15,6 @@
         "@theia/callhierarchy": "latest",
         "@theia/console": "latest",
         "@theia/core": "latest",
-        "@theia/cpp-debug": "latest",
         "@theia/debug": "latest",
         "@theia/editor": "latest",
         "@theia/editor-preview": "latest",
@@ -51,6 +50,9 @@
     "devDependencies": {
         "@theia/cli": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",
@@ -71,6 +73,7 @@
         "vscode-builtin-handlebars": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/handlebars-1.39.1-prel.vsix",
         "vscode-builtin-hlsl": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/hlsl-1.39.1-prel.vsix",
         "vscode-builtin-html": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/html-1.39.1-prel.vsix",
+        "vscode-builtin-html-language-features": "https://open-vsx.org/api/vscode/html-language-features/1.49.0/file/vscode.html-language-features-1.49.0.vsix",
         "vscode-builtin-ini": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/ini-1.39.1-prel.vsix",
         "vscode-builtin-jake": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/jake-1.39.1-prel.vsix",
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
@@ -82,15 +85,12 @@
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",
         "vscode-builtin-make": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/make-1.39.1-prel.vsix",
         "vscode-builtin-markdown": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/markdown-1.39.1-prel.vsix",
-        "vscode-builtin-markdown-language-features": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/markdown-language-features-1.39.1-prel.vsix",
         "vscode-builtin-merge-conflicts": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/merge-conflict-1.39.1-prel.vsix",
         "vscode-builtin-npm": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/npm-1.39.1-prel.vsix",
         "vscode-builtin-node-debug": "https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix",
         "vscode-builtin-node-debug2": "https://github.com/theia-ide/vscode-node-debug2/releases/download/v1.33.0/node-debug2-1.33.0.vsix",
         "vscode-builtin-objective-c": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/objective-c-1.39.1-prel.vsix",
         "vscode-builtin-perl": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/perl-1.39.1-prel.vsix",
-        "vscode-builtin-php": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/php-1.39.1-prel.vsix",
-        "vscode-builtin-php-language-features": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/php-language-features-1.39.1-prel.vsix",
         "vscode-builtin-powershell": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/powershell-1.39.1-prel.vsix",
         "vscode-builtin-pug": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/pug-1.39.1-prel.vsix",
         "vscode-builtin-python": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/python-1.39.1-prel.vsix",
@@ -117,21 +117,10 @@
         "vscode-builtin-vb": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vb-1.39.1-prel.vsix",
         "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
-        "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
+        "vscode.editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "cdt-gdb-vscode": "https://open-vsx.org/api/eclipse-cdt/cdt-gdb-vscode/0.0.92/file/eclipse-cdt.cdt-gdb-vscode-0.0.92.vsix",
         "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.7/file/llvm-vs-code-extensions.vscode-clangd-0.1.7.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
-        "vscode-eslint": "https://github.com/theia-ide/vscode-eslint/releases/download/release%2F2.0.15/vscode-eslint-2.0.15.vsix",
-        "vscode-go": "https://github.com/microsoft/vscode-go/releases/download/0.12.0/Go-0.12.0.vsix",
-        "vscode-java-debug": "https://github.com/microsoft/vscode-java-debug/releases/download/0.24.0/vscjava.vscode-java-debug-0.24.0.vsix",
-        "vscode-java-dependency-viewer": "https://github.com/microsoft/vscode-java-dependency/releases/download/0.6.0/vscode-java-dependency-0.6.0.vsix",
-        "vscode-java-redhat": "https://github.com/redhat-developer/vscode-java/releases/download/v0.54.2/redhat.java-0.54.2.vsix",
-        "vscode-java-test": "https://github.com/microsoft/vscode-java-test/releases/download/0.22.0/vscjava.vscode-java-test-0.22.0.vsix",
-        "vscode-php-intellisense": "https://github.com/felixfbecker/vscode-php-intellisense/releases/download/v2.3.14/php-intellisense.vsix",
-        "vscode-php-debug": "https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix",
-        "vscode-python": "https://github.com/microsoft/vscode-python/releases/download/2020.1.58038/ms-python-release.vsix",
-        "vscode-ruby": "https://github.com/rubyide/vscode-ruby/releases/download/v0.25.0/ruby-0.25.0.vsix",
-        "vscode-dart": "https://github.com/Dart-Code/Dart-Code/releases/download/v3.8.1/Dart-Code.dart-code-3.8.1.vsix",
-        "vscode-flutter": "https://github.com/Dart-Code/Flutter/releases/download/v3.8.1/Dart-Code.flutter-3.8.1.vsix",
-        "yangster": "https://open-vsx.org/api/typefox/yang-vscode/2.0.3/file/typefox.yang-vscode-2.0.3.vsix"
+        "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.14.0/file/jebbs.plantuml-2.14.0.vsix"
     }
 }


### PR DESCRIPTION
Fixed https://github.com/eclipse/xacc/issues/511

- Fixed the `xacc/xacc` dev deploy image build.

- Pulled in the base image definition as well so that it's fully automatic. We only run this nightly so the extra CI load is manageable.

- Updated the base Ubuntu to 20.04 to be consistent with CI build and added some Python packages to enable built-in Python plugins.

Will monitor DockerHub to make sure the image gets pushed.

