### PR TITLE
Various improvements for gradients

### DIFF
--- a/quantum/plugins/algorithms/gradient_strategies/BackwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/BackwardDifferenceGradient.hpp
@@ -54,7 +54,7 @@ public:
     obs = parameters.get<std::shared_ptr<Observable>>("observable");
 
     // Default step size
-    step = 1.0e-7; 
+    step = 1.0e-7;
     // Change step size if need be
     if (parameters.keyExists<double>("step")) {
       step = parameters.get<double>("step");
@@ -110,15 +110,16 @@ public:
           }
         }
       } else {
-        kernels = obs->observe(circuit);
+        auto evaled = circuit->operator()(tmpX);
+        kernels = obs->observe(evaled);
 
         // loop over circuit instructions
         // and gather coefficients/instructions
         for (auto &f : kernels) {
           if (containMeasureGates(f)) {
-            auto evaled = f->operator()(tmpX);
+
             coefficients.push_back(std::real(f->getCoefficient()));
-            gradientInstructions.push_back(evaled);
+            gradientInstructions.push_back(f);
           }
         }
       }
@@ -171,9 +172,7 @@ public:
     return;
   }
 
-  const std::string name() const override {
-    return "backward";
-  }
+  const std::string name() const override { return "backward"; }
   const std::string description() const override { return ""; }
 };
 

--- a/quantum/plugins/algorithms/gradient_strategies/CentralDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/CentralDifferenceGradient.hpp
@@ -106,15 +106,16 @@ public:
             }
           }
         } else {
-          kernels = obs->observe(circuit);
+          auto evaled = circuit->operator()(tmpX);
+          kernels = obs->observe(evaled);
 
           // loop over circuit instructions
           // and gather coefficients/instructions
           for (auto &f : kernels) {
             if (containMeasureGates(f)) {
-              auto evaled = f->operator()(tmpX);
+              
               coefficients.push_back(std::real(f->getCoefficient()));
-              gradientInstructions.push_back(evaled);
+              gradientInstructions.push_back(f);
             }
           }
         }

--- a/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/ForwardDifferenceGradient.hpp
@@ -54,7 +54,7 @@ public:
     obs = parameters.get<std::shared_ptr<Observable>>("observable");
 
     // Default step size
-    step = 1.0e-7; 
+    step = 1.0e-7;
     // Change step size if need be
     if (parameters.keyExists<double>("step")) {
       step = parameters.get<double>("step");
@@ -113,15 +113,16 @@ public:
           }
         }
       } else {
-        kernels = obs->observe(circuit);
+        auto evaled = circuit->operator()(tmpX);
+        kernels = obs->observe(evaled);
 
         // loop over circuit instructions
         // and gather coefficients/instructions
         for (auto &f : kernels) {
           if (containMeasureGates(f)) {
-            auto evaled = f->operator()(tmpX);
+
             coefficients.push_back(std::real(f->getCoefficient()));
-            gradientInstructions.push_back(evaled);
+            gradientInstructions.push_back(f);
           }
         }
       }

--- a/quantum/plugins/algorithms/gradient_strategies/autodiff/Autodiff.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/autodiff/Autodiff.cpp
@@ -386,8 +386,9 @@ std::vector<double> Autodiff::computeDerivative(
                   "vector size.");
     }
 
+    auto varNames = getOrderedVector(CompositeInstruction->getVariables());
     for (size_t i = 0; i < vars.size(); ++i) {
-      varMap.emplace(CompositeInstruction->getVariables()[i], vars[i]);
+      varMap.emplace(varNames[i], vars[i]);
     }
 
     AutodiffCircuitVisitor visitor(nbQubits, varMap);

--- a/quantum/plugins/algorithms/gradient_strategies/autodiff/Autodiff.hpp
+++ b/quantum/plugins/algorithms/gradient_strategies/autodiff/Autodiff.hpp
@@ -34,6 +34,13 @@ using cxdual = std::complex<autodiff::dual>;
 typedef Eigen::Matrix<cxdual, -1, 1, 0> VectorXcdual;
 typedef Eigen::Matrix<cxdual, -1, -1, 0> MatrixXcdual;
 
+
+template <typename T> std::vector<T> getOrderedVector(const std::vector<T> unorderedVector) {
+  std::set<T> s(unorderedVector.begin(), unorderedVector.end());
+  std::vector<T> orderedVector(s.begin(), s.end());
+  return orderedVector;
+}
+
 namespace xacc {
 namespace quantum {
 class Autodiff : public AlgorithmGradientStrategy {

--- a/quantum/plugins/algorithms/gradient_strategies/autodiff/tests/AutodiffTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/autodiff/tests/AutodiffTester.cpp
@@ -54,8 +54,8 @@ TEST(AutodiffTester, checkGates) {
 .parameters theta0, theta1
 X 0
 H 1
-Ry(theta0) 1
-Rx(theta1) 0
+Rx(theta0) 0
+Ry(theta1) 1
 CNOT 1 0
 )");
   auto ansatz = xacc::getCompiled("test1");
@@ -139,8 +139,8 @@ TEST(AutodiffTester, checkGradientH3) {
 .parameters t0, t1
 .qbit q
 X(q[0]);
-exp_i_theta(q, t0, {{"pauli", "X0 Y1 - Y0 X1"}});
-exp_i_theta(q, t1, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
+exp_i_theta(q, t1, {{"pauli", "X0 Y1 - Y0 X1"}});
+exp_i_theta(q, t0, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
 )");
   auto ansatz = xacc::getCompiled("ansatz_h3");
   auto autodiff = std::make_shared<xacc::quantum::Autodiff>();

--- a/quantum/plugins/algorithms/qaoa/tests/QAOATester.cpp
+++ b/quantum/plugins/algorithms/qaoa/tests/QAOATester.cpp
@@ -102,7 +102,7 @@ TEST(QAOATester, checkP1TriangleGraph) {
     for (auto beta : all_betas) {
       auto buffer = xacc::qalloc(3);
       auto cost =
-          qaoa->execute(buffer, std::vector<double>{gamma, beta})[0];
+          qaoa->execute(buffer, std::vector<double>{beta, gamma})[0];
       auto d = 1;
       auto e = 1;
       auto f = 1;
@@ -116,6 +116,7 @@ TEST(QAOATester, checkP1TriangleGraph) {
     }
   }
 }
+
 
 // Making sure that a set of Hadamards can be passed
 // as the "initial-state" to the QAOA algorithm and 
@@ -296,7 +297,7 @@ TEST(QAOATester, checkP1TriangleGraphGroupingExpVal) {
   for (auto gamma : all_gammas) {
     for (auto beta : all_betas) {
       auto buffer = xacc::qalloc(3);
-      auto cost = qaoa->execute(buffer, std::vector<double>{gamma, beta})[0];
+      auto cost = qaoa->execute(buffer, std::vector<double>{beta, gamma})[0];
       auto d = 1;
       auto e = 1;
       auto f = 1;

--- a/quantum/plugins/algorithms/vqe/vqe.cpp
+++ b/quantum/plugins/algorithms/vqe/vqe.cpp
@@ -112,9 +112,7 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
         std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
 
         // call CompositeInstruction::operator()()
-        auto tmp_x = x;
-        std::reverse(tmp_x.begin(), tmp_x.end());
-        auto evaled = kernel->operator()(tmp_x);
+        auto evaled = kernel->operator()(x);
         // observe
         auto kernels = observable->observe(evaled);
 
@@ -259,6 +257,7 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
         for (auto &b : buffers) {
           buffer->appendChild(b->name(), b);
         }
+
         std::stringstream ss;
         ss << "E(" << (!x.empty() ? std::to_string(x[0]) : "");
         for (int i = 1; i < x.size(); i++)
@@ -273,7 +272,7 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
           min_child_buffers.push_back(idBuffer);
           for (auto b : buffers) {
             min_child_buffers.push_back(b);
-          } 
+          }
           last_energy = energy;
         }
 
@@ -294,7 +293,7 @@ void VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer) const {
       children_coeffs.push_back(
           child->getInformation("coefficient").as<double>());
       children_names.push_back(child->name());
-    } 
+    }
   }
 
   buffer->addExtraInfo("opt-exp-vals", opt_exp_vals);
@@ -317,9 +316,7 @@ VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer,
   std::vector<std::shared_ptr<CompositeInstruction>> fsToExec;
 
   double identityCoeff = 0.0;
-  auto tmp_x = x;
-  std::reverse(tmp_x.begin(), tmp_x.end());
-  auto evaled = xacc::as_shared_ptr(kernel)->operator()(tmp_x);
+  auto evaled = xacc::as_shared_ptr(kernel)->operator()(x);
   auto kernels = observable->observe(evaled);
   for (auto &f : kernels) {
     kernelNames.push_back(f->name());
@@ -408,6 +405,7 @@ VQE::execute(const std::shared_ptr<AcceleratorBuffer> buffer,
   for (auto &b : buffers) {
     buffer->appendChild(b->name(), b);
   }
+
   std::stringstream ss;
   ss << "E(" << (!x.empty() ? std::to_string(x[0]) : "");
   for (int i = 1; i < x.size(); i++)

--- a/xacc/service/ServiceRegistry.hpp
+++ b/xacc/service/ServiceRegistry.hpp
@@ -26,6 +26,7 @@
 #include "Optimizer.hpp"
 #include "IRTransformation.hpp"
 #include "AcceleratorDecorator.hpp"
+#include "AlgorithmGradientStrategy.hpp"
 
 #include <cppmicroservices/FrameworkFactory.h>
 #include <cppmicroservices/Framework.h>
@@ -35,6 +36,7 @@
 
 #include <map>
 #include <dirent.h>
+#include <memory>
 
 using namespace cppmicroservices;
 
@@ -44,7 +46,7 @@ using ContributableService =
     Variant<std::shared_ptr<Instruction>, std::shared_ptr<Accelerator>,
             std::shared_ptr<Compiler>, std::shared_ptr<Optimizer>, std::shared_ptr<Algorithm>,
             std::shared_ptr<IRTransformation>, std::shared_ptr<Observable>,
-            std::shared_ptr<AcceleratorDecorator>>;
+            std::shared_ptr<AcceleratorDecorator>, std::shared_ptr<AlgorithmGradientStrategy>>;
 
 class ServiceRegistry {
 

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -11,6 +11,7 @@
  *   Alexander J. McCaskey - initial API and implementation
  *******************************************************************************/
 #include "xacc.hpp"
+//#include "AlgorithmGradientStrategy.hpp"
 #include "InstructionIterator.hpp"
 #include "IRProvider.hpp"
 #include "CLIParser.hpp"
@@ -848,6 +849,39 @@ void Finalize() {
     allocated_buffers.clear();
     xacc::ServiceAPI_Finalize();
   }
+}
+
+std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name) {
+  if (!xacc::xaccFrameworkInitialized) {
+    error("XACC not initialized before use. Please execute "
+          "xacc::Initialize() before using API.");
+  }
+
+  auto g = xacc::getService<AlgorithmGradientStrategy>(name, false);
+
+  if (!g) {
+    if (xacc::hasContributedService<AlgorithmGradientStrategy>(name)) {
+      g = xacc::getContributedService<AlgorithmGradientStrategy>(name);
+
+    } else {
+      error("Invalid Gradient Strategy. Could not find " + name +
+            " in Service Registry.");
+    }
+  }
+  return g;
+}
+
+std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name,
+                                        const xacc::HeterogeneousMap &params) {
+  auto g = xacc::getGradient(name);
+  if (!g->initialize(params)) {
+    error("Error initializing " + name + " gradient strategy.");
+  }
+  return g;
+}
+std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name,
+                                        const xacc::HeterogeneousMap &&params) {
+  return getGradient(name, params);
 }
 
 } // namespace xacc

--- a/xacc/xacc.hpp
+++ b/xacc/xacc.hpp
@@ -13,6 +13,7 @@
 #ifndef XACC_XACC_HPP_
 #define XACC_XACC_HPP_
 
+#include "AlgorithmGradientStrategy.hpp"
 #include "Compiler.hpp"
 #include "RemoteAccelerator.hpp"
 #include "IRProvider.hpp"
@@ -165,6 +166,12 @@ std::shared_ptr<Optimizer> getOptimizer(const std::string name,
                                         const HeterogeneousMap &opts);
 std::shared_ptr<Optimizer> getOptimizer(const std::string name,
                                         const HeterogeneousMap &&opts);
+
+std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name,
+                                        const xacc::HeterogeneousMap &params);
+std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name,
+                                        const xacc::HeterogeneousMap &&params);
+std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name);
 
 void write_string_to_file_and_close(std::string file_Name, std::string s);
 


### PR DESCRIPTION
This PR proposes several changes in order to better apply gradients. The main problem stems from `xacc::quantum::Circuit::getVariables()` returning a `std::unordered_set`. Prior to this PR, we worked around it in VQE by calling `std::reverse()` on the incoming vector of parameters. This _hack_ probably came about when dealing with two parameters (I did this). When `Observable::observe()` is called prior to `CompositeInstruction::operator()()`, the former calls `xacc::quantum::Circuit::getVariables()`, and this may cause mismatches in how `CompositeInstruction::operator()()` maps the parameters in the observed circuits. This problem arises in dealing with gradients for circuits with several parameters and is fixed by ensuring `CompositeInstruction::operator()()` is called before `Observable::observe()`. In order to accomplish this, the following was introduced/modified:

 - `CompositeInstruction::operator()()` is called before `Observable::observe()` in VQE, QAOA, and all gradient strategies
 - Default shift in `ParameterShiftGradient.hpp` was changed to match literature
 - `Autodiff.cpp` calls `Observable::observe()` directly, so a helper to order the outcoming vector is provided
 - `xacc::getGradient()` wrapper is introduced (modified `xacc.cpp`, `xacc.hpp`, and `ServiceRegistry.hpp`)
 - All related tests were modified to reflect these changes

Signed-off-by: Daniel Claudino <6d3@ornl.gov>