### PR TITLE
Performance improvement for Circuit clone

### DIFF
--- a/quantum/gate/ir/Circuit.hpp
+++ b/quantum/gate/ir/Circuit.hpp
@@ -398,11 +398,11 @@ public:
   DEFINE_VISITABLE()
   std::shared_ptr<Instruction> clone() override {
     auto cloned = std::make_shared<Circuit>(name(), variables, buffer_names);
-
-    for (auto i : instructions) {
-      cloned->addInstruction(i->clone());
+    cloned->instructions.reserve(instructions.size());
+    for (const auto &i : instructions) {
+      cloned->instructions.emplace_back(i->clone());
     }
-    return cloned; // std::make_shared<Circuit>(*this);
+    return cloned;
   }
 
   virtual ~Circuit() {}


### PR DESCRIPTION
Since we're doing a deep copy of the Circuit, we can safely bypass the pointer validation performed in `addInstruction` (each new instruction is a newly-allocated memory).

This will significantly speed up the cloning of big circuits.

