### PR TITLE
Fixed #526

### DIFF
--- a/quantum/plugins/algorithms/adapt/adapt.cpp
+++ b/quantum/plugins/algorithms/adapt/adapt.cpp
@@ -104,13 +104,15 @@ bool ADAPT::initialize(const HeterogeneousMap &parameters) {
     return false;
   }
 
-  if (pool->isNumberOfParticlesRequired() &&
-      (parameters.keyExists<int>("n-electrons") ||
-       parameters.keyExists<int>("n-particles"))) {
-    pool->optionalParameters({{"n-electrons", _nParticles}});
-  } else {
-    xacc::error("The chosen pool requires the number of particles/electrons.");
-    return false;
+  if (pool->isNumberOfParticlesRequired()) {
+    if (parameters.keyExists<int>("n-electrons") ||
+        parameters.keyExists<int>("n-particles")) {
+      pool->optionalParameters({{"n-electrons", _nParticles}});
+    } else {
+      xacc::error(
+          "The chosen pool requires the number of particles/electrons.");
+      return false;
+    }
   }
 
   if (observable->toString().find("^") != std::string::npos) {

--- a/quantum/plugins/algorithms/adapt/operator_pools/QubitPool.hpp
+++ b/quantum/plugins/algorithms/adapt/operator_pools/QubitPool.hpp
@@ -137,13 +137,23 @@ public:
 
   }
 
+  double getNormalizationConstant(const int index) const override {
+
+    if (pool.empty()) {
+      xacc::error("You need to call generate() first.");
+    }
+    auto tmp = *std::dynamic_pointer_cast<PauliOperator>(pool[index]);
+    tmp -= tmp.hermitianConjugate();
+    return 1.0 / tmp.operatorNorm();
+  }
+
   std::shared_ptr<CompositeInstruction> 
   getOperatorInstructions(const int opIdx, const int varIdx) const override {
 
     // Instruction service for the operator to be added to the ansatz
     auto gate = std::dynamic_pointer_cast<quantum::Circuit>(
         xacc::getService<Instruction>("exp_i_theta"));
-xacc::info(std::to_string(varIdx));
+
     // Create instruction for new operator
     gate->expand(
         {std::make_pair("pauli", pool[opIdx]->toString()),


### PR DESCRIPTION
This PR fixes the issue with `QubitPool::isNumberOfParticlesRequired()` in `ADAPT::initialize()` and also adds `QubitPool::getNormalizationConstant()` so it can take advantage of a better initial guess for the parameter added at the present iteration.

Signed-off-by: Daniel Claudino <6d3@ornl.gov>