### PR TITLE
Made excitation levels and bases more flexible for qEOM

### DIFF
--- a/quantum/plugins/algorithms/qeom/qeom.hpp
+++ b/quantum/plugins/algorithms/qeom/qeom.hpp
@@ -35,6 +35,7 @@ protected:
   CompositeInstruction *kernel;
   Accelerator *accelerator;
   HeterogeneousMap parameters;
+  bool computeDeexcitations = true;
   std::vector<std::shared_ptr<Observable>> operators;
   mutable std::unordered_map<std::string, double> cachedMeasurements;
 


### PR DESCRIPTION
This PR enables one to restrict the types of excitations to be included in the excited state basis and also whether deexcitations are included in the qEOM algorithm.

Signed-off-by: Daniel Claudino <6d3@ornl.gov>