### PR TITLE
Minimized number of Accelerator::execute() and Observable::observe() calls

### DIFF
--- a/quantum/plugins/algorithms/qcmx/qcmx.cpp
+++ b/quantum/plugins/algorithms/qcmx/qcmx.cpp
@@ -317,7 +317,7 @@ std::shared_ptr<Observable> QCMX::getUniqueTerms(
       auto coeff = std::dynamic_pointer_cast<PauliOperator>(term)
                        ->begin()
                        ->second.coeff();
-      if (std::fabs(coeff) < threshold)
+      if (std::fabs(coeff.real()) < threshold)
         continue;
       uniqueTermsPtr->operator+=(*std::make_shared<PauliOperator>(op));
     }

--- a/quantum/plugins/algorithms/qcmx/qcmx.hpp
+++ b/quantum/plugins/algorithms/qcmx/qcmx.hpp
@@ -33,17 +33,12 @@ protected:
 
   // CMX order, also K in the paper
   int maxOrder;
-  // cache measurements
-  mutable std::unordered_map<std::string, double> cachedMeasurements;
   // threshold below which we ignore measurement
   double threshold = 0.0;
   // x is the vector of parameters if the provided ansatz is parameterized
   std::vector<double> x;
   // spectrum is only for PDS
   mutable std::vector<double> spectrum;
-
-  double measureOperator(const std::shared_ptr<Observable> obs,
-                         const int bufferSize) const;
 
   // Compute energy from PDS CMX
   double PDS(const std::vector<double> &moments, const int order) const;
@@ -56,6 +51,15 @@ protected:
 
   // Compute energy from Soldatov's approximate functional
   double Soldatov(const std::vector<double> &moments) const;
+
+  // get unique Pauli words
+  std::shared_ptr<Observable>
+  getUniqueTerms(const std::vector<std::shared_ptr<Observable>>) const;
+
+  // get moments from measured unique Pauli words
+  std::vector<double>
+  getMoments(const std::vector<std::shared_ptr<Observable>>,
+             const std::vector<std::shared_ptr<AcceleratorBuffer>>) const;
 
 public:
   bool initialize(const HeterogeneousMap &parameters) override;

--- a/quantum/plugins/algorithms/qeom/qeom.hpp
+++ b/quantum/plugins/algorithms/qeom/qeom.hpp
@@ -37,9 +37,12 @@ protected:
   HeterogeneousMap parameters;
   bool computeDeexcitations = true;
   std::vector<std::shared_ptr<Observable>> operators;
-  mutable std::unordered_map<std::string, double> cachedMeasurements;
 
-  double measureOperator(const std::shared_ptr<Observable> obs, const std::shared_ptr<AcceleratorBuffer> buffer) const;
+  std::shared_ptr<Observable>
+  getUniqueTerms(const std::vector<std::shared_ptr<Observable>>) const;
+  double computeOperatorExpValue(
+      const std::shared_ptr<Observable> &,
+      const std::vector<std::shared_ptr<AcceleratorBuffer>> &) const;
 
 public:
   bool initialize(const HeterogeneousMap &parameters) override;


### PR DESCRIPTION
This PR modifies the qEOM and qCMX algorithms to gather all necessary terms to be measured, calling `Observable::observe()` only once on them, returning a single `vector<CompositeInstruction>` for the entire algorithms, thus requiring a single `Accelerator::execute()` call.

Signed-off-by: Daniel Claudino <6d3@ornl.gov>