### PR TITLE
Qrack: move default layer arrangement into Qrack library method

### DIFF
--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.cpp
@@ -40,9 +40,9 @@ namespace quantum {
             m_use_qunit = params.get<bool>("use_qunit");
         }
 
-        if (params.keyExists<bool>("use_opencl_multi"))
+        if (params.keyExists<bool>("use_qunit_multi"))
         {
-            m_use_opencl_multi = params.get<bool>("use_opencl_multi");
+            m_use_qunit_multi = params.get<bool>("use_qunit_multi");
         }
 
         if (params.keyExists<bool>("use_stabilizer"))
@@ -131,7 +131,7 @@ namespace quantum {
         }
 
         const auto runCircuit = [&](int shots){
-            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_opencl_multi, m_use_stabilizer, m_use_binary_decision_tree, m_use_paging, m_use_z_x_fusion, m_use_cpu_gpu_hybrid, m_device_id, m_do_normalize, m_zero_threshold);
+            m_visitor->initialize(buffer, shots, m_use_opencl, m_use_qunit, m_use_qunit_multi, m_use_stabilizer, m_use_binary_decision_tree, m_use_paging, m_use_z_x_fusion, m_use_cpu_gpu_hybrid, m_device_id, m_do_normalize, m_zero_threshold);
 
             // Walk the IR tree, and visit each node
             InstructionIterator it(compositeInstruction);

--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
@@ -39,7 +39,7 @@ private:
     int m_shots = -1;
     bool m_use_opencl = true;
     bool m_use_qunit = true;
-    bool m_use_opencl_multi = true;
+    bool m_use_qunit_multi = true;
     bool m_use_stabilizer = true;
     bool m_use_binary_decision_tree = false;
     bool m_use_paging = true;

--- a/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackAccelerator.hpp
@@ -43,7 +43,7 @@ private:
     bool m_use_stabilizer = true;
     bool m_use_binary_decision_tree = false;
     bool m_use_paging = true;
-    bool m_use_z_x_fusion = true;
+    bool m_use_z_x_fusion = false;
     bool m_use_cpu_gpu_hybrid = true;
     int m_device_id = -1;
     bool m_do_normalize = false;

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
@@ -15,68 +15,16 @@
 #include "QrackVisitor.hpp"
 #include "xacc.hpp"
 
-#define MAKE_ENGINE(num_qubits, perm) Qrack::CreateQuantumInterface(simulatorType, num_qubits, perm, nullptr, Qrack::CMPLX_DEFAULT_ARG, doNormalize, false, false, device_id, true, zero_threshold)
+#define MAKE_ENGINE(num_qubits, perm) Qrack::CreateArrangedLayers(use_qunit_multi, use_qunit, use_stabilizer, use_binary_decision_tree, use_paging, use_z_x_fusion, use_cpu_gpu_hybrid, use_opencl, num_qubits, perm, nullptr, Qrack::CMPLX_DEFAULT_ARG, doNormalize, false, false, device_id, true, zero_threshold)
 
 namespace xacc {
 namespace quantum {
-    void QrackVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, bool use_stabilizer, bool use_binary_decision_tree, bool use_paging, bool use_z_x_fusion, bool use_cpu_gpu_hybrid, int device_id, bool doNormalize, double zero_threshold)
+    void QrackVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_qunit_multi, bool use_stabilizer, bool use_binary_decision_tree, bool use_paging, bool use_z_x_fusion, bool use_cpu_gpu_hybrid, int device_id, bool doNormalize, double zero_threshold)
     {
         m_buffer = std::move(buffer);
         m_measureBits.clear();
         m_shots = shots;
         m_shotsMode = shots > 1;
-
-#if ENABLE_OPENCL
-        bool isOcl = use_opencl && (Qrack::OCLEngine::Instance().GetDeviceCount() > 0);
-        bool isOclMulti = isOcl && use_opencl_multi && (Qrack::OCLEngine::Instance().GetDeviceCount() > 1);
-#else
-        bool isOcl = false;
-        bool isOclMulti = false;
-#endif
-
-        // Construct backwards, then reverse:
-        std::vector<Qrack::QInterfaceEngine> simulatorType;
-
-#if ENABLE_OPENCL
-        if (!use_cpu_gpu_hybrid || !isOcl) {
-            simulatorType.push_back(isOcl ? Qrack::QINTERFACE_OPENCL : Qrack::QINTERFACE_CPU);
-        }
-#endif
-
-        if (use_z_x_fusion && (!use_paging || simulatorType.size())) {
-            simulatorType.push_back(Qrack::QINTERFACE_MASK_FUSION);
-        }
-
-        if (use_paging && (use_binary_decision_tree || !use_stabilizer || simulatorType.size())) {
-            simulatorType.push_back(Qrack::QINTERFACE_QPAGER);
-        }
-
-        if (use_binary_decision_tree) {
-            simulatorType.push_back(Qrack::QINTERFACE_BDT);
-        }
-
-        if (use_stabilizer && (!use_qunit || simulatorType.size())) {
-            simulatorType.push_back(Qrack::QINTERFACE_STABILIZER_HYBRID);
-        }
-
-        if (use_qunit) {
-            simulatorType.push_back(isOclMulti ? Qrack::QINTERFACE_QUNIT_MULTI : Qrack::QINTERFACE_QUNIT);
-        }
-
-        // (...then reverse:)
-        std::reverse(simulatorType.begin(), simulatorType.end());
-
-        if (!simulatorType.size()) {
-#if ENABLE_OPENCL
-            if (use_cpu_gpu_hybrid && isOcl) {
-                simulatorType.push_back(Qrack::QINTERFACE_HYBRID);
-            } else {
-                simulatorType.push_back(isOcl ? Qrack::QINTERFACE_OPENCL : Qrack::QINTERFACE_CPU);
-            }
-#else
-            simulatorType.push_back(Qrack::QINTERFACE_CPU);
-#endif
-        }
 
         m_qReg = MAKE_ENGINE(m_buffer->size(), 0);
     }

--- a/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.hpp
@@ -34,7 +34,7 @@ namespace xacc {
 namespace quantum {
 class QrackVisitor : public AllGateVisitor, public OptionsProvider, public xacc::Cloneable<QrackVisitor> {
 public:
-  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_opencl_multi, bool use_stabilizer, bool use_binary_decision_tree, bool use_paging, bool use_z_x_fusion, bool use_cpu_gpu_hybrid, int device_id, bool doNormalize, double zero_threshold);
+  void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int shots, bool use_opencl, bool use_qunit, bool use_qunit_multi, bool use_stabilizer, bool use_binary_decision_tree, bool use_paging, bool use_z_x_fusion, bool use_cpu_gpu_hybrid, int device_id, bool doNormalize, double zero_threshold);
   void finalize();
 
   void visit(Hadamard& h) override;


### PR DESCRIPTION
Signed-off-by: Daniel Strano <stranoj@gmail.com>

Hi, the default optimization layer arrangement of Qrack has changed, again. However, rather than having to open a PR on XACC for the plugin every time this happens, I've instead wrapped the default layer arrangement logic in a factory method in the Qrack library itself. This way, moving forward, no one has to update the plugin when default optimal layers are rearranged, which is likely to happen again, relatively frequently. New layers might be added, once in a long while, but the old factory method will be supported in the interim, before a plugin update.

The major drawback is that this will no longer work for versions of the Qrack library prior to vm6502q/qrack@e9f505f. However, it's an easier solution to maintain, moving forward.

Also, sorry to introduce a breaking change to the external API, but `use_opencl_multi` is more correctly renamed `use_qunit_multi`, as Qrack has multiple forms of multi-device simulation support, and this option controls the distribution of separable qubit subsystems to different OpenCL devices, rather than Intel-QS-like "paging" over multiple devices.

Thank you!