### PR TITLE
Add multi-control gate simulation shortcut for qpp and qsim

### DIFF
--- a/quantum/gate/utils/GateModifier.hpp
+++ b/quantum/gate/utils/GateModifier.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "Instruction.hpp"
+// Common interface for modifier circuit class:
+// helping other plugins (e.g., Accelerator) to access information
+// specific to these modifier block
+namespace xacc {
+namespace quantum {
+struct GateModifier {
+  virtual std::shared_ptr<Instruction> getBaseInstruction() const = 0;
+};
+// We only have control modifier at the moment...
+struct ControlModifier : public GateModifier {
+  // Returns list of qubits as <qreg name, index> pairs
+  virtual std::vector<std::pair<std::string, size_t>>
+  getControlQubits() const = 0;
+};
+} // namespace quantum
+} // namespace xacc

--- a/quantum/plugins/algorithms/qpe/ControlledGateApplicator.cpp
+++ b/quantum/plugins/algorithms/qpe/ControlledGateApplicator.cpp
@@ -245,7 +245,7 @@ bool ControlledU::expand(const xacc::HeterogeneousMap &runtimeOptions) {
   auto uComposite = std::shared_ptr<CompositeInstruction>(
       runtimeOptions.getPointerLike<CompositeInstruction>("U"),
       xacc::empty_delete<CompositeInstruction>());
-
+  m_originalU = uComposite;
   const std::vector<std::pair<std::string, size_t>> ctrlIdxs =
       [&runtimeOptions,
        uComposite]() -> std::vector<std::pair<std::string, size_t>> {
@@ -309,7 +309,7 @@ bool ControlledU::expand(const xacc::HeterogeneousMap &runtimeOptions) {
   }
 
   auto ctrlU = uComposite;
-
+  m_ctrlIdxs = ctrlIdxs;
   auto should_run_gray_mcu_synth = [ctrlU, &ctrlIdxs]() {
     if (ctrlU->nInstructions() == 1) {
       std::vector<std::string> allowed{"X", "Rx", "Z", "Rz"};
@@ -364,6 +364,7 @@ bool ControlledU::expand(const xacc::HeterogeneousMap &runtimeOptions) {
       addInstruction(inst);
     }
   }
+  m_expanded = true;
   return true;
 }
 

--- a/quantum/plugins/algorithms/qpe/ControlledGateApplicator.cpp
+++ b/quantum/plugins/algorithms/qpe/ControlledGateApplicator.cpp
@@ -245,7 +245,7 @@ bool ControlledU::expand(const xacc::HeterogeneousMap &runtimeOptions) {
   auto uComposite = std::shared_ptr<CompositeInstruction>(
       runtimeOptions.getPointerLike<CompositeInstruction>("U"),
       xacc::empty_delete<CompositeInstruction>());
-  m_originalU = uComposite;
+  m_originalU = uComposite->clone();
   const std::vector<std::pair<std::string, size_t>> ctrlIdxs =
       [&runtimeOptions,
        uComposite]() -> std::vector<std::pair<std::string, size_t>> {

--- a/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
+++ b/quantum/plugins/atos_qlm/accelerator/QlmAccelerator.hpp
@@ -10,7 +10,7 @@
  * Contributors:
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
-#pragma one
+#pragma once
 #include "xacc.hpp"
 #include "AllGateVisitor.hpp"
 #include <pybind11/embed.h>

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
@@ -10,7 +10,7 @@
  * Contributors:
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
-#pragma one
+#pragma once
 #include "xacc.hpp"
 #include <nlohmann/json.hpp>
 

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -10,7 +10,7 @@
  * Contributors:
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
-#pragma one
+#pragma once
 #include "xacc.hpp"
 #include "QppVisitor.hpp"
 #include "NoiseModel.hpp"

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -11,6 +11,11 @@
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
 
+#include "Circuit.hpp"
+#include "Instruction.hpp"
+#include "InstructionVisitor.hpp"
+#include <functional>
+#include <memory>
 #pragma one
 #include "Identifiable.hpp"
 #include "AllGateVisitor.hpp"
@@ -23,7 +28,7 @@ using KetVectorType = qpp::ket;
 
 namespace xacc {
 namespace quantum {
-class QppVisitor : public AllGateVisitor, public OptionsProvider, public xacc::Cloneable<QppVisitor> {
+class QppVisitor : public AllGateVisitor, public InstructionVisitor<Circuit>, public OptionsProvider, public xacc::Cloneable<QppVisitor> {
 public:
   void initialize(std::shared_ptr<AcceleratorBuffer> buffer, bool shotsMode = false);
   void finalize();
@@ -53,6 +58,7 @@ public:
   void visit(iSwap& in_iSwapGate) override;
   void visit(fSim& in_fsimGate) override;
   void visit(Reset& in_resetGate) override;
+  void visit(Circuit& in_circuit) override;
   virtual std::shared_ptr<QppVisitor> clone() override { return std::make_shared<QppVisitor>(); }
   const KetVectorType& getStateVec() const { return m_stateVec; }
   static double calcExpectationValueZ(const KetVectorType& in_stateVec, const std::vector<qpp::idx>& in_bits);
@@ -76,5 +82,6 @@ private:
   bool m_shotsMode;
   std::string m_bitString;
   bool m_initialized = false;
+  std::vector<std::reference_wrapper<xacc::quantum::Circuit>> m_controlledBlocks;
 };
 }}

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -10,7 +10,7 @@
  * Contributors:
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
-#pragma one
+#pragma once
 #include "Circuit.hpp"
 #include "Instruction.hpp"
 #include "InstructionVisitor.hpp"

--- a/quantum/plugins/qpp/accelerator/QppVisitor.hpp
+++ b/quantum/plugins/qpp/accelerator/QppVisitor.hpp
@@ -10,13 +10,12 @@
  * Contributors:
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
-
+#pragma one
 #include "Circuit.hpp"
 #include "Instruction.hpp"
 #include "InstructionVisitor.hpp"
 #include <functional>
 #include <memory>
-#pragma one
 #include "Identifiable.hpp"
 #include "AllGateVisitor.hpp"
 #include "AcceleratorBuffer.hpp"

--- a/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
+++ b/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
@@ -673,8 +673,7 @@ TEST(QppAcceleratorTester, testMultiControlledGateNativeSim)
       xacc::getService<xacc::Instruction>("C-U"));
   // Testing many controls, only possible (complete in reasonable time) with
   // custom C-U handler
-  const std::vector<int> ctrl_idxs{1, 2,  3,  4,  5,  6,  7, 8,
-                                   9, 10, 11, 12, 13, 14, 15};
+  const std::vector<int> ctrl_idxs{1, 2,  3,  4,  5};
   const auto nQubits = ctrl_idxs.size() + 1;
   mcx->expand({{"U", comp}, {"control-idx", ctrl_idxs}});
   std::cout << "HOWDY: Gate count: " << mcx->nInstructions() << "\n";

--- a/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
+++ b/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
@@ -17,7 +17,8 @@
 #include "xacc_observable.hpp"
 #include "xacc_service.hpp"
 #include "Algorithm.hpp"
-
+#include "CommonGates.hpp"
+#include <random>
 namespace {
     template <typename T>
     std::vector<T> linspace(T a, T b, size_t N)
@@ -659,6 +660,98 @@ TEST(QppAcceleratorTester, testFtqcApply)
     }
     // Make sure we have both values.
     EXPECT_TRUE(nb00 > 100 && nb11 > 100);
+}
+
+TEST(QppAcceleratorTester, testMultiControlledGateNativeSim)
+{
+  auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+  auto x = std::make_shared<xacc::quantum::X>(0);
+  std::shared_ptr<xacc::CompositeInstruction> comp =
+      gateRegistry->createComposite("__COMPOSITE__X");
+  comp->addInstruction(x);
+  auto mcx = std::dynamic_pointer_cast<xacc::CompositeInstruction>(
+      xacc::getService<xacc::Instruction>("C-U"));
+  // Testing many controls, only possible (complete in reasonable time) with
+  // custom C-U handler
+  const std::vector<int> ctrl_idxs{1, 2,  3,  4,  5,  6,  7, 8,
+                                   9, 10, 11, 12, 13, 14, 15};
+  const auto nQubits = ctrl_idxs.size() + 1;
+  mcx->expand({{"U", comp}, {"control-idx", ctrl_idxs}});
+  std::cout << "HOWDY: Gate count: " << mcx->nInstructions() << "\n";
+  // Test truth table
+  auto acc = xacc::getAccelerator("qpp", {std::make_pair("shots", 8192)});
+  std::vector<std::shared_ptr<xacc::Instruction>> xGateVec;
+  std::vector<std::shared_ptr<xacc::Instruction>> measGateVec;
+  for (size_t i = 0; i < nQubits; ++i) {
+    xGateVec.emplace_back(gateRegistry->createInstruction("X", {i}));
+    measGateVec.emplace_back(gateRegistry->createInstruction("Measure", {i}));
+  }
+
+  const auto runTestCase = [&](const std::vector<bool> &bitVals) {
+    static int counter = 0;
+    auto composite = gateRegistry->createComposite("__TEMP_COMPOSITE__" +
+                                                   std::to_string(counter));
+    counter++;
+    // State prep:
+    assert(bitVals.size() == nQubits);
+    std::string inputBitString;
+    for (int i = 0; i < bitVals.size(); ++i) {
+      if (bitVals[i]) {
+        composite->addInstruction(xGateVec[i]);
+      }
+      inputBitString.append((bitVals[i] ? "1" : "0"));
+    }
+
+    // Add mcx
+    composite->addInstruction(mcx);
+    // Mesurement:
+    composite->addInstructions(measGateVec);
+    auto buffer = xacc::qalloc(nQubits);
+    acc->execute(buffer, composite);
+    std::cout << "Input bitstring: " << inputBitString << "\n";
+    buffer->print();
+    // MCX gate:
+    const auto expectedBitString = [&inputBitString]() -> std::string {
+      // If all control bits are 1's
+      // q0q1q2q3q4
+      const std::string pattern1(inputBitString.size(), '1');
+      const std::string pattern0 = [&]() {
+        std::string tmp(inputBitString.size(), '1');
+        tmp[0] = '0';
+        return tmp;
+      }();
+      if (inputBitString == pattern0) {
+        return pattern1;
+      }
+      if (inputBitString == pattern1) {
+        return pattern0;
+      }
+      // Otherwise, no changes
+      return inputBitString;
+    }();
+    // Check bit string
+    EXPECT_NEAR(buffer->computeMeasurementProbability(expectedBitString), 1.0,
+                0.1);
+    // std::cout << "Circuit: \n" << composite->toString() << "\n";
+  };
+
+  // Run some test cases randomly (since there are many)
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  // Max run
+  constexpr int N_RUNS = 8;
+  const int N_STATES = 1 << nQubits;
+  const double prob = static_cast<double>(N_RUNS) / N_STATES;
+  std::bernoulli_distribution d(prob);
+  for (int i = 0; i < (1 << nQubits); ++i) {
+    if (d(gen)) {
+      std::vector<bool> bits;
+      for (int q = 0; q < nQubits; ++q) {
+        bits.emplace_back((i & (1 << q)) == (1 << q));
+      }
+      runTestCase(bits);
+    }
+  }
 }
 
 int main(int argc, char **argv) {

--- a/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
+++ b/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
@@ -10,7 +10,7 @@
  * Contributors:
  *   Thien Nguyen - initial API and implementation
  *******************************************************************************/
-#pragma one
+#pragma once
 #include "xacc.hpp"
 #include "AllGateVisitor.hpp"
 

--- a/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
+++ b/quantum/plugins/qsim/accelerator/QsimAccelerator.hpp
@@ -194,7 +194,8 @@ public:
 
   void visit(Circuit &in_circuit) override {
     // std::cout << "HOWDY: Visit quantum circuit: " << in_circuit.name() << "\n";
-    if (in_circuit.name() == "C-U") {
+    if (in_circuit.name() == "C-U" &&
+        dynamic_cast<xacc::quantum::ControlModifier *>(&in_circuit)) {
       auto *asControlledBlock =
           dynamic_cast<xacc::quantum::ControlModifier *>(&in_circuit);
       assert(asControlledBlock);

--- a/quantum/plugins/qsim/tests/QsimAcceleratorTester.cpp
+++ b/quantum/plugins/qsim/tests/QsimAcceleratorTester.cpp
@@ -290,8 +290,7 @@ TEST(QsimAcceleratorTester, testMultiControlledGateNativeSim) {
       xacc::getService<xacc::Instruction>("C-U"));
   // Testing many controls, only possible (complete in reasonable time) with
   // custom C-U handler
-  const std::vector<int> ctrl_idxs{1, 2,  3,  4,  5,  6,  7, 8,
-                                   9, 10, 11, 12, 13, 14, 15};
+  const std::vector<int> ctrl_idxs{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   const auto nQubits = ctrl_idxs.size() + 1;
   mcx->expand({{"U", comp}, {"control-idx", ctrl_idxs}});
   std::cout << "HOWDY: Gate count: " << mcx->nInstructions() << "\n";

--- a/quantum/plugins/qsim/tests/QsimAcceleratorTester.cpp
+++ b/quantum/plugins/qsim/tests/QsimAcceleratorTester.cpp
@@ -16,6 +16,8 @@
 #include "xacc_service.hpp"
 #include "Algorithm.hpp"
 #include "xacc_observable.hpp"
+#include <random>
+#include "CommonGates.hpp"
 
 namespace {
 template <typename T> std::vector<T> linspace(T a, T b, size_t N) {
@@ -276,6 +278,97 @@ TEST(QsimAcceleratorTester, testConditional) {
   }
 
   EXPECT_EQ(resultCount, nbTests);
+}
+
+TEST(QsimAcceleratorTester, testMultiControlledGateNativeSim) {
+  auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+  auto x = std::make_shared<xacc::quantum::X>(0);
+  std::shared_ptr<xacc::CompositeInstruction> comp =
+      gateRegistry->createComposite("__COMPOSITE__X");
+  comp->addInstruction(x);
+  auto mcx = std::dynamic_pointer_cast<xacc::CompositeInstruction>(
+      xacc::getService<xacc::Instruction>("C-U"));
+  // Testing many controls, only possible (complete in reasonable time) with
+  // custom C-U handler
+  const std::vector<int> ctrl_idxs{1, 2,  3,  4,  5,  6,  7, 8,
+                                   9, 10, 11, 12, 13, 14, 15};
+  const auto nQubits = ctrl_idxs.size() + 1;
+  mcx->expand({{"U", comp}, {"control-idx", ctrl_idxs}});
+  std::cout << "HOWDY: Gate count: " << mcx->nInstructions() << "\n";
+  // Test truth table
+  auto acc = xacc::getAccelerator("qsim", {std::make_pair("shots", 8192)});
+  std::vector<std::shared_ptr<xacc::Instruction>> xGateVec;
+  std::vector<std::shared_ptr<xacc::Instruction>> measGateVec;
+  for (size_t i = 0; i < nQubits; ++i) {
+    xGateVec.emplace_back(gateRegistry->createInstruction("X", {i}));
+    measGateVec.emplace_back(gateRegistry->createInstruction("Measure", {i}));
+  }
+
+  const auto runTestCase = [&](const std::vector<bool> &bitVals) {
+    static int counter = 0;
+    auto composite = gateRegistry->createComposite("__TEMP_COMPOSITE__" +
+                                                   std::to_string(counter));
+    counter++;
+    // State prep:
+    assert(bitVals.size() == nQubits);
+    std::string inputBitString;
+    for (int i = 0; i < bitVals.size(); ++i) {
+      if (bitVals[i]) {
+        composite->addInstruction(xGateVec[i]);
+      }
+      inputBitString.append((bitVals[i] ? "1" : "0"));
+    }
+
+    // Add mcx
+    composite->addInstruction(mcx);
+    // Mesurement:
+    composite->addInstructions(measGateVec);
+    auto buffer = xacc::qalloc(nQubits);
+    acc->execute(buffer, composite);
+    // std::cout << "Input bitstring: " << inputBitString << "\n";
+    // buffer->print();
+    // MCX gate:
+    const auto expectedBitString = [&inputBitString]() -> std::string {
+      // If all control bits are 1's
+      // q0q1q2q3q4
+      const std::string pattern1(inputBitString.size(), '1');
+      const std::string pattern0 = [&]() {
+        std::string tmp(inputBitString.size(), '1');
+        tmp[0] = '0';
+        return tmp;
+      }();
+      if (inputBitString == pattern0) {
+        return pattern1;
+      }
+      if (inputBitString == pattern1) {
+        return pattern0;
+      }
+      // Otherwise, no changes
+      return inputBitString;
+    }();
+    // Check bit string
+    EXPECT_NEAR(buffer->computeMeasurementProbability(expectedBitString), 1.0,
+                0.1);
+    // std::cout << "Circuit: \n" << composite->toString() << "\n";
+  };
+
+  // Run some test cases randomly (since there are many)
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  // Max run
+  const int N_RUNS = 32;
+  const int N_STATES = 1 << nQubits;
+  const double prob = static_cast<double>(N_RUNS) / N_STATES;
+  std::bernoulli_distribution d(prob);
+  for (int i = 0; i < (1 << nQubits); ++i) {
+    if (d(gen)) {
+      std::vector<bool> bits;
+      for (int q = 0; q < nQubits; ++q) {
+        bits.emplace_back((i & (1 << q)) == (1 << q));
+      }
+      runTestCase(bits);
+    }
+  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Most state-vector-based simulators support direct simulation of multi-control gates since it's quite expensive to simulate the decomposed circuit gate-by-gate when the number of control bits is large.

This changeset implements this for `qpp` and `qsim`:

- Use `visit(Circuit&)` to detect if a sub-circuit is a controlled gate block.

- If so, simulate the whole sub-circuit natively. Then, bypass the whole controlled-gate sub-circuit in the accelerator's visitor.

- Adding unit tests.
 

