### PR TITLE
New HPC virtualization decorator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,17 @@ if (XACC_BUILD_TESTS)
 endif()
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
+
+# check MPI status
+# if MPI_CXX_COMPILER is not empty and cmake can find MPI
+# turn MPI_ENABLED on
+if(NOT MPI_CXX_COMPILER STREQUAL "")
+  find_package(MPI)
+  if(MPI_FOUND)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMPI_ENABLED")
+  endif()
+endif()
+
 include_directories(${CMAKE_BINARY_DIR}/tpls/cppmicroservices/include)
 add_subdirectory(tpls)
 

--- a/quantum/examples/hpc_virtualization/CMakeLists.txt
+++ b/quantum/examples/hpc_virtualization/CMakeLists.txt
@@ -13,6 +13,15 @@
 add_executable(tnqvm_hpc_virt tnqvm_hpc_virtualization.cpp)
 target_link_libraries(tnqvm_hpc_virt PRIVATE xacc xacc-quantum-gate)
 
+add_executable(parameter_shift parameter_shift.cpp)
+target_link_libraries(parameter_shift PRIVATE xacc xacc-quantum-gate)
+
+add_executable(mc_vqe mc_vqe.cpp)
+target_link_libraries(mc_vqe PRIVATE xacc xacc-quantum-gate xacc-pauli)
+
+add_executable(h2_hwe h2_hwe.cpp)
+target_link_libraries(h2_hwe PRIVATE xacc xacc-quantum-gate)
+
 configure_file(tnqvm_h4_chain_8qbit_adapt_gs.in.cpp
                ${CMAKE_BINARY_DIR}/quantum/examples/hpc_virtualization/tnqvm_h4_chain_8qbit_adapt_gs.cpp)
 

--- a/quantum/examples/hpc_virtualization/h2_hwe.cpp
+++ b/quantum/examples/hpc_virtualization/h2_hwe.cpp
@@ -1,0 +1,74 @@
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "xacc_observable.hpp"
+#include <random>
+// Generate rando
+auto random_vector(const double l_range, const double r_range,
+                   const std::size_t size) {
+  // Generate a random initial parameter set
+  std::random_device rnd_device;
+  std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
+  std::uniform_real_distribution<double> dist{l_range, r_range};
+  auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+  std::vector<double> vec(size);
+  std::generate(vec.begin(), vec.end(), gen);
+  return vec;
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+  std::vector<std::string> arguments(argv + 1, argv + argc);
+  int n_virt_qpus = 1,  n_layers = 10;
+  std::string acc;
+  xacc::set_verbose(true);
+  xacc::setLoggingLevel(10);
+  for (int i = 0; i < arguments.size(); i++) {
+    if (arguments[i] == "--n-virtual-qpus") {
+      n_virt_qpus = std::stoi(arguments[i + 1]);
+    }
+    if (arguments[i] == "--n-layers") {
+      n_layers = std::stoi(arguments[i + 1]);
+    }
+    if (arguments[i] == "--accelerator") {
+      acc = arguments[i + 1];
+    }
+  }
+
+  xacc::ScopeTimer timer("mpi_timing", false);
+  auto accelerator = xacc::getAccelerator(acc, {{"tnqvm-visitor", "exatn-mps"}});
+  accelerator = xacc::getAcceleratorDecorator("hpc-virtualization", accelerator,
+                                              {{"vqe-mode", false},
+                                              {"n-virtual-qpus", n_virt_qpus}});
+  auto buffer = xacc::qalloc(2);
+  auto observable = xacc::quantum::getObservable("pauli", 
+      std::string("-0.349833 - 0.388748 Z0 - 0.388748 Z1 + 0.181771 X0X1 + 0.0111772 Z0Z1"));
+
+  auto ansatz = std::dynamic_pointer_cast<xacc::CompositeInstruction>(
+      xacc::getService<xacc::Instruction>("hwe"));
+
+  ansatz->expand({
+          std::make_pair("nq", 2),
+          std::make_pair("layers", n_layers),
+          std::make_pair("coupling", std::vector<std::pair<int,int>>{{0, 1}})
+          });
+
+  std::vector<double> params = random_vector(-1.0, 1.0, ansatz->nVariables());
+
+  auto parameterShift = xacc::getGradient("parameter-shift", {{"observable", observable}, {"shift-scalar", 0.5}});
+  auto gradientInstructions =
+      parameterShift->getGradientExecutions(ansatz, params);
+  accelerator->execute(buffer, gradientInstructions);
+
+
+  auto isRank0 = buffer->hasExtraInfoKey("rank")
+                             ? ((*buffer)["rank"].as<int>() == 0)
+                             : true;
+
+  if(isRank0) {
+    std::vector<double> dx(ansatz->nVariables());
+    parameterShift->compute(dx, buffer->getChildren());
+    auto run_time = timer.getDurationMs();
+    std::cout << run_time << "\n";
+  }
+  xacc::Finalize();
+}

--- a/quantum/examples/hpc_virtualization/mc_vqe.cpp
+++ b/quantum/examples/hpc_virtualization/mc_vqe.cpp
@@ -1,0 +1,208 @@
+#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "xacc_observable.hpp"
+#include "PauliOperator.hpp"
+#include <random>
+// Generate rando
+auto random_vector(const double l_range, const double r_range,
+                   const std::size_t size) {
+  // Generate a random initial parameter set
+  std::random_device rnd_device;
+  std::mt19937 mersenne_engine{rnd_device()}; // Generates random integers
+  std::uniform_real_distribution<double> dist{l_range, r_range};
+  auto gen = [&dist, &mersenne_engine]() { return dist(mersenne_engine); };
+  std::vector<double> vec(size);
+  std::generate(vec.begin(), vec.end(), gen);
+  return vec;
+}
+
+std::shared_ptr<xacc::CompositeInstruction> getCircuit(const int nq) {
+  auto provider = xacc::getIRProvider("quantum");
+  auto circuit = provider->createComposite("circuit");
+  std::vector<std::shared_ptr<xacc::Instruction>> gates;
+  std::vector<double> x(2 * nq + 1, 1.0);
+  
+  int varIdx = 0;
+  auto ry = provider->createInstruction("Ry", {0}, {x[varIdx++]});
+  gates.push_back(ry);
+
+  for (int i = 1; i < nq; i++) {
+
+    std::size_t control = i - 1, target = i;
+    // Ry(-theta/2)
+    auto ry_minus =
+        provider->createInstruction("Ry", {target}, {x[varIdx++]});
+    gates.push_back(ry_minus);
+
+    auto hadamard1 = provider->createInstruction("H", {target});
+    gates.push_back(hadamard1);
+
+    auto cnot = provider->createInstruction("CNOT", {control, target});
+    gates.push_back(cnot);
+
+    auto hadamard2 = provider->createInstruction("H", {target});
+    gates.push_back(hadamard2);
+
+    // Ry(+theta/2)
+    auto ry_plus =
+        provider->createInstruction("Ry", {target}, {x[varIdx++]});
+    gates.push_back(ry_plus);
+  }
+
+  // Wall of CNOTs
+  for (int i = nq - 2; i >= 0; i--) {
+    for (int j = nq - 1; j > i; j--) {
+
+      std::size_t control = j, target = i;
+      auto cnot = provider->createInstruction("CNOT", {control, target});
+      gates.push_back(cnot);
+    }
+  }
+
+  circuit->addInstructions(gates);
+
+  // end CIS
+
+  
+
+  auto entangler = [&](const std::size_t control, const std::size_t target) {
+
+    std::vector<std::shared_ptr<xacc::Instruction>> gates;
+    std::vector<std::string> varNames;
+    auto cnot = provider->createInstruction("CNOT", {control, target});
+    gates.push_back(cnot);
+
+    std::string varName = "t" + std::to_string(varIdx++);
+    auto ry = provider->createInstruction("Ry", {target}, {varName});
+    gates.push_back(ry);
+    varNames.push_back(varName);
+
+    varName = "t" + std::to_string(varIdx++);
+    ry = provider->createInstruction("Ry", {control}, {varName});
+    gates.push_back(ry);
+    varNames.push_back(varName);
+
+    cnot = provider->createInstruction("CNOT", {control, target});
+    gates.push_back(cnot);
+
+    varName = "t" + std::to_string(varIdx++);
+    ry = provider->createInstruction("Ry", {target}, {varName});
+    gates.push_back(ry);
+    varNames.push_back(varName);
+
+    varName = "t" + std::to_string(varIdx++);
+    ry = provider->createInstruction("Ry", {control},{varName});
+    gates.push_back(ry);
+    varNames.push_back(varName);
+
+    circuit->addVariables(varNames);
+    circuit->addInstructions(gates);
+  };
+
+  varIdx = 0;
+  for (std::size_t i = 0; i < nq; i++) {
+    std::string varName = "t" + std::to_string(varIdx++);
+    auto ry = provider->createInstruction("Ry", {i}, {varName});
+    circuit->addVariable(varName);
+    circuit->addInstruction(ry);
+  }
+
+  for (int layer : {0, 1}) {
+    for (int i = layer; i < nq - layer; i += 2) {
+      std::size_t control = i, target = i + 1;
+      entangler(control, target);
+    }
+  }
+
+  return circuit;
+}
+
+std::shared_ptr<xacc::Observable> getH(const int nq) {
+
+  xacc::quantum::PauliOperator hamiltonian;
+  std::vector<double> coeff(2 * nq, 1.0);
+
+  int A = 0;
+  for (int A = 0; A < nq; A++) {
+    hamiltonian += xacc::quantum::PauliOperator({{A, "Z"}}, coeff[2 * A]);
+    hamiltonian += xacc::quantum::PauliOperator({{A, "X"}}, coeff[2 * A + 1]);
+  }
+
+  std::vector<std::vector<int>> pairs(nq);
+  for (int A = 0; A < nq; A++) {
+   if (A == 0) {
+      pairs[A] = {A + 1};
+    } else if (A == nq - 1) {
+      pairs[A] = {A - 1};
+    } else {
+      pairs[A] = {A - 1, A + 1};
+    }
+  }
+
+  coeff.resize(6 * nq);
+  coeff = std::vector<double>(6 * nq, 1.0);
+  int i = 0;
+  for (int A = 0; A < nq; A++) {
+    for (int B : pairs[A]) {
+
+      hamiltonian += xacc::quantum::PauliOperator({{A, "X"}, {B, "X"}}, coeff[i++]);
+      hamiltonian += xacc::quantum::PauliOperator({{A, "X"}, {B, "Z"}}, coeff[i++]);
+      hamiltonian += xacc::quantum::PauliOperator({{A, "Z"}, {B, "X"}}, coeff[i]);
+      hamiltonian += xacc::quantum::PauliOperator({{A, "Z"}, {B, "Z"}}, coeff[i++]);
+    }
+  }
+
+    return std::make_shared<xacc::quantum::PauliOperator>(hamiltonian);
+
+}
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+  std::vector<std::string> arguments(argv + 1, argv + argc);
+  int n_virt_qpus = 1,  nq = 4;
+  std::string acc = "aer";
+  for (int i = 0; i < arguments.size(); i++) {
+    if (arguments[i] == "--n-virtual-qpus") {
+      n_virt_qpus = std::stoi(arguments[i + 1]);
+    }
+    if (arguments[i] == "--n-qubits") {
+      nq = std::stoi(arguments[i + 1]);
+    }
+    if (arguments[i] == "--accelerator") {
+      acc = arguments[i + 1];
+    }
+  }
+
+  xacc::ScopeTimer timer("mpi_timing", false);
+  auto accelerator = xacc::getAccelerator(acc, {{"tnqvm-visitor", "exatn-mps"}});
+  accelerator = xacc::getAcceleratorDecorator("hpc-virtualization", accelerator,
+                                              {{"vqe-mode", false},
+                                              {"n-virtual-qpus", n_virt_qpus}});
+  auto buffer = xacc::qalloc(nq);
+
+  auto ansatz = getCircuit(nq);
+  std::vector<double> params(ansatz->nVariables(), 0.0); 
+  
+  auto observable = getH(nq);
+
+  auto parameterShift = xacc::getGradient("parameter-shift", {{"observable", observable}, {"shift-scalar", 0.5}});
+  auto gradientInstructions =
+      parameterShift->getGradientExecutions(ansatz, params);
+  std::cout << "Circuit depth: " << ansatz->depth() << "\n";
+  std::cout << "Number of parameters: " << ansatz->nVariables() << "\n";
+  std::cout << "Number of circuit executions: " << gradientInstructions.size() << "\n"; 
+
+  accelerator->execute(buffer, gradientInstructions);
+
+  auto isRank0 = buffer->hasExtraInfoKey("rank")
+                             ? ((*buffer)["rank"].as<int>() == 0)
+                             : true;
+
+  if(isRank0) {
+    std::vector<double> dx(ansatz->nVariables());
+    parameterShift->compute(dx, buffer->getChildren());
+    auto run_time = timer.getDurationMs();
+    std::cout << "\nRuntime: " << run_time << "\n";
+  }
+  xacc::Finalize();
+}

--- a/quantum/examples/hpc_virtualization/parameter_shift.cpp
+++ b/quantum/examples/hpc_virtualization/parameter_shift.cpp
@@ -1,0 +1,51 @@
+#include "xacc.hpp"
+#include "xacc_observable.hpp"
+
+int main(int argc, char **argv) {
+  xacc::Initialize(argc, argv);
+
+  auto accelerator = xacc::getAccelerator("qpp");
+  accelerator = xacc::getAcceleratorDecorator("hpc-virtualization", accelerator,
+                                              {{"n-virtual-qpus", 2}});
+  auto buffer = xacc::qalloc(3);
+  auto observable = xacc::quantum::getObservable("pauli", std::string("Y0 Z2"));
+
+  auto provider = xacc::getIRProvider("quantum");
+  auto ansatz = provider->createComposite("testCircuit");
+  std::vector<std::string> varNames = {"x0", "x1", "x2", "x3", "x4", "x5"};
+  ansatz->addVariables(varNames);
+  ansatz->addInstruction(provider->createInstruction("Rx", {0}, {"x0"}));
+  ansatz->addInstruction(provider->createInstruction("Ry", {1}, {"x1"}));
+  ansatz->addInstruction(provider->createInstruction("Rz", {2}, {"x2"}));
+  ansatz->addInstruction(provider->createInstruction("CNOT", {0, 1}));
+  ansatz->addInstruction(provider->createInstruction("CNOT", {1, 2}));
+  ansatz->addInstruction(provider->createInstruction("CNOT", {2, 0}));
+  ansatz->addInstruction(provider->createInstruction("Rx", {0}, {"x3"}));
+  ansatz->addInstruction(provider->createInstruction("Ry", {1}, {"x4"}));
+  ansatz->addInstruction(provider->createInstruction("Rz", {2}, {"x5"}));
+  ansatz->addInstruction(provider->createInstruction("CNOT", {0, 1}));
+  ansatz->addInstruction(provider->createInstruction("CNOT", {1, 2}));
+  ansatz->addInstruction(provider->createInstruction("CNOT", {2, 0}));
+
+
+  std::vector<double> params{0.37454012, 0.95071431, 0.73199394, 0.59865848, 0.15601864, 0.15599452};
+  auto parameterShift = xacc::getGradient("parameter-shift", {{"observable", observable}, {"shift-scalar", 0.5}});
+  xacc::ScopeTimer timer("mpi_timing", false);
+  auto gradientInstructions =
+      parameterShift->getGradientExecutions(ansatz, params);
+      accelerator->execute(buffer, gradientInstructions);
+
+
+  auto isRank0 = buffer->hasExtraInfoKey("rank")
+                             ? ((*buffer)["rank"].as<int>() == 0)
+                             : true;
+
+  if(isRank0) {
+    std::vector<double> dx(6);
+    parameterShift->compute(dx, buffer->getChildren());
+    auto run_time = timer.getDurationMs();
+    for (auto grad : dx) std::cout << grad << ", ";
+      std::cout << "\nRuntime: " << run_time << " ms.\n";
+    }
+  xacc::Finalize();
+}

--- a/quantum/plugins/decorators/hpc-virtualization/CMakeLists.txt
+++ b/quantum/plugins/decorators/hpc-virtualization/CMakeLists.txt
@@ -48,8 +48,8 @@ if(MPI_FOUND)
                            FILES
                            manifest.json)
 
-  target_include_directories(${LIBRARY_NAME} PUBLIC .)
-  target_link_libraries(${LIBRARY_NAME} PUBLIC xacc ${MPI_CXX_LIBRARIES})
+  target_include_directories(${LIBRARY_NAME} PUBLIC . ${MPI_CXX_HEADER_DIR})
+  target_link_libraries(${LIBRARY_NAME} PUBLIC xacc)
 
   if(APPLE)
     set_target_properties(${LIBRARY_NAME}

--- a/quantum/plugins/decorators/hpc-virtualization/CMakeLists.txt
+++ b/quantum/plugins/decorators/hpc-virtualization/CMakeLists.txt
@@ -15,7 +15,7 @@ if(MPI_FOUND)
   set(LIBRARY_NAME xacc-hpc-virt-decorator)
 
   file(GLOB_RECURSE HEADERS *.hpp)
-  file(GLOB SRC hpc_virt_decorator.cpp)
+  file(GLOB SRC hpc_virt_decorator.cpp MPIProxy.cpp)
 
   # Set up dependencies to resources to track changes
   usfunctiongetresourcesource(TARGET
@@ -49,7 +49,7 @@ if(MPI_FOUND)
                            manifest.json)
 
   target_include_directories(${LIBRARY_NAME} PUBLIC .)
-  target_link_libraries(${LIBRARY_NAME} PUBLIC xacc Boost::mpi)
+  target_link_libraries(${LIBRARY_NAME} PUBLIC xacc ${MPI_CXX_LIBRARIES})
 
   if(APPLE)
     set_target_properties(${LIBRARY_NAME}

--- a/quantum/plugins/decorators/hpc-virtualization/MPIProxy.cpp
+++ b/quantum/plugins/decorators/hpc-virtualization/MPIProxy.cpp
@@ -1,0 +1,132 @@
+/** ExaTN: MPI Communicator Proxy & Process group
+REVISION: 2021/09/26
+Copyright (C) 2018-2021 Dmitry I. Lyakh (Liakh)
+Copyright (C) 2018-2021 Oak Ridge National Laboratory (UT-Battelle) **/
+
+#include "MPIProxy.hpp"
+
+#include "mpi.h"
+
+#include <cstdlib>
+
+#include <iostream>
+#include <algorithm>
+
+namespace xacc {
+
+//Temporary buffers:
+constexpr std::size_t MAX_NUM_MPI_PROCESSES = 65536;
+std::vector<unsigned int> processes1;
+std::vector<unsigned int> processes2;
+
+
+MPICommProxy::~MPICommProxy()
+{
+ if(destroy_on_free_){
+  if(!(this->isEmpty())){
+   if(mpi_comm_ptr_.use_count() == 1){
+    auto * mpicomm = this->get<MPI_Comm>();
+    int res;
+    auto errc = MPI_Comm_compare(*mpicomm,MPI_COMM_WORLD,&res); assert(errc == MPI_SUCCESS);
+    if(res != MPI_IDENT){
+     errc = MPI_Comm_compare(*mpicomm,MPI_COMM_SELF,&res); assert(errc == MPI_SUCCESS);
+     if(res != MPI_IDENT){
+      errc = MPI_Comm_free(mpicomm); assert(errc == MPI_SUCCESS);
+     }
+    }
+   }
+  }
+ }
+}
+
+
+bool MPICommProxy::operator==(const MPICommProxy & another) const
+{
+ bool equal = true;
+ auto * lhs_comm = this->get<MPI_Comm>();
+ auto * rhs_comm = another.get<MPI_Comm>();
+ int res;
+ auto errc = MPI_Comm_compare(*lhs_comm,*rhs_comm,&res); assert(errc == MPI_SUCCESS);
+ equal = (res == MPI_IDENT);
+ return equal;
+}
+
+
+bool ProcessGroup::isCongruentTo(const ProcessGroup & another) const
+{
+ bool is_congruent = (*this == another);
+ if(!is_congruent){
+  is_congruent = (this->process_ranks_.size() == another.process_ranks_.size());
+  if(is_congruent && this->process_ranks_.size() > 0){
+   processes1.reserve(MAX_NUM_MPI_PROCESSES);
+   processes2.reserve(MAX_NUM_MPI_PROCESSES);
+   processes1 = this->process_ranks_;
+   std::sort(processes1.begin(),processes1.end());
+   processes2 = another.process_ranks_;
+   std::sort(processes2.begin(),processes2.end());
+   is_congruent = (processes1 == processes2);
+  }
+ }
+ return is_congruent;
+}
+
+
+bool ProcessGroup::isContainedIn(const ProcessGroup & another) const
+{
+ bool is_contained = (*this == another);
+ if(!is_contained){
+  is_contained = (this->process_ranks_.size() <= another.process_ranks_.size());
+  if(is_contained){
+   processes1.reserve(MAX_NUM_MPI_PROCESSES);
+   processes2.reserve(MAX_NUM_MPI_PROCESSES);
+   processes1 = this->process_ranks_;
+   std::sort(processes1.begin(),processes1.end());
+   processes2 = another.process_ranks_;
+   std::sort(processes2.begin(),processes2.end());
+   is_contained = std::includes(processes2.begin(),processes2.end(),processes1.begin(),processes1.end());
+  }
+ }
+ return is_contained;
+}
+
+
+std::shared_ptr<ProcessGroup> ProcessGroup::split(int my_subgroup) const
+{
+ std::shared_ptr<ProcessGroup> subgroup(nullptr);
+ if(this->getSize() == 1){
+  if(my_subgroup >= 0) subgroup = std::make_shared<ProcessGroup>(*this);
+ }else{
+  if(my_subgroup >= 0) subgroup = std::make_shared<ProcessGroup>(*this);
+  if(!(intra_comm_.isEmpty())){
+   auto & mpicomm = intra_comm_.getRef<MPI_Comm>();
+   int color = MPI_UNDEFINED;
+   if(my_subgroup >= 0) color = my_subgroup;
+   int my_orig_rank;
+   auto errc = MPI_Comm_rank(mpicomm,&my_orig_rank); assert(errc == MPI_SUCCESS);
+   MPI_Comm subgroup_mpicomm;
+   errc = MPI_Comm_split(mpicomm,color,my_orig_rank,&subgroup_mpicomm); assert(errc == MPI_SUCCESS);
+   if(color != MPI_UNDEFINED){
+    int subgroup_size;
+    errc = MPI_Comm_size(subgroup_mpicomm,&subgroup_size); assert(errc == MPI_SUCCESS);
+    MPI_Group orig_group,new_group;
+    errc = MPI_Comm_group(mpicomm,&orig_group); assert(errc == MPI_SUCCESS);
+    errc = MPI_Comm_group(subgroup_mpicomm,&new_group); assert(errc == MPI_SUCCESS);
+    int sub_ranks[subgroup_size],orig_ranks[subgroup_size];
+    for(int i = 0; i < subgroup_size; ++i) sub_ranks[i] = i;
+    errc = MPI_Group_translate_ranks(new_group,subgroup_size,sub_ranks,orig_group,orig_ranks);
+    std::vector<unsigned int> subgroup_ranks(subgroup_size); //vector of global MPI ranks
+    const auto & ranks = this->getProcessRanks();
+    for(int i = 0; i < subgroup_size; ++i) subgroup_ranks[i] = ranks[orig_ranks[i]];
+    subgroup = std::make_shared<ProcessGroup>(MPICommProxy(subgroup_mpicomm,true),
+                                              subgroup_ranks,
+                                              this->getMemoryLimitPerProcess());
+   }
+  }else{
+   std::cout << "#ERROR(xacc::ProcessGroup::split): Empty MPI communicator!\n" << std::flush;
+   assert(false);
+  }
+ }
+ return subgroup;
+}
+
+} //namespace xacc

--- a/quantum/plugins/decorators/hpc-virtualization/MPIProxy.hpp
+++ b/quantum/plugins/decorators/hpc-virtualization/MPIProxy.hpp
@@ -1,0 +1,154 @@
+/** ExaTN: MPI Communicator Proxy & Process group
+REVISION: 2021/09/27
+Copyright (C) 2018-2021 Dmitry I. Lyakh (Liakh)
+Copyright (C) 2018-2021 Oak Ridge National Laboratory (UT-Battelle) **/
+
+#ifndef XACC_MPI_COMM_PROXY_HPP_
+#define XACC_MPI_COMM_PROXY_HPP_
+
+#include <vector>
+#include <memory>
+#include <cassert>
+
+namespace xacc {
+
+class MPICommProxy {
+public:
+
+ /** Default constructor constructs an empty communicator. **/
+ MPICommProxy(): mpi_comm_ptr_(nullptr), destroy_on_free_(false) {}
+
+ /** Constructs a portable MPI communicator proxy by type-erasing
+     the concrete MPI communicator type MPICommType (e.g., MPI_Comm). **/
+ template<typename MPICommType>
+ MPICommProxy(MPICommType mpi_comm,          //in: MPI intra-communicator
+              bool destroy_on_free = false): //in: if TRUE, the stored MPI communicator will be explicitly destroyed when freed
+  mpi_comm_ptr_(new MPICommType{mpi_comm}), destroy_on_free_(destroy_on_free) {}
+
+ MPICommProxy(const MPICommProxy &) = default;
+ MPICommProxy & operator=(const MPICommProxy &) = default;
+ MPICommProxy(MPICommProxy &&) noexcept = default;
+ MPICommProxy & operator=(MPICommProxy &&) noexcept = default;
+ ~MPICommProxy();
+
+ bool operator==(const MPICommProxy & another) const;
+ bool operator!=(const MPICommProxy & another) const {return !(*this == another);}
+
+ /** Returns TRUE if the MPI communicator is empty (non-existing). **/
+ bool isEmpty() const {return (mpi_comm_ptr_ == nullptr);}
+
+ /** Retrieves back a pointer to the stored MPI communicator with a proper type. **/
+ template<typename MPICommType>
+ MPICommType * get() const {return static_cast<MPICommType*>(mpi_comm_ptr_.get());}
+
+ /** Retrieves back a reference to the stored MPI communicator with a proper type. **/
+ template<typename MPICommType>
+ MPICommType & getRef() const {return *(std::static_pointer_cast<MPICommType>(mpi_comm_ptr_));}
+
+private:
+
+ std::shared_ptr<void> mpi_comm_ptr_; //owning pointer to an MPI communicator (MPI_Comm type)
+ bool destroy_on_free_; //whether or not to call MPI_Comm_free in destructor
+};
+
+
+class ProcessGroup {
+public:
+
+ static constexpr const std::size_t MAX_MEM_PER_PROCESS = 1UL * 1024UL * 1024UL * 1024UL; //bytes
+
+ /** Constructs a process group from provided global MPI process ranks and their
+     associated intra-comunicator, with an optional memory limit per process. **/
+ ProcessGroup(const MPICommProxy & intra_comm,
+              const std::vector<unsigned int> & global_process_ranks,
+              std::size_t mem_per_process = MAX_MEM_PER_PROCESS):
+  process_ranks_(global_process_ranks), intra_comm_(intra_comm), mem_per_process_(mem_per_process)
+ {
+  assert(!process_ranks_.empty());
+ }
+
+ /** Constructs the default process group with the given number of MPI process ranks and
+     their associated intra-comunicator, with an optional memory limit per process. **/
+ ProcessGroup(const MPICommProxy & intra_comm,
+              const unsigned int group_size,
+              std::size_t mem_per_process = MAX_MEM_PER_PROCESS):
+  process_ranks_(group_size), intra_comm_(intra_comm), mem_per_process_(mem_per_process)
+ {
+  assert(process_ranks_.size() > 0);
+  for(unsigned int i = 0; i < process_ranks_.size(); ++i) process_ranks_[i] = i;
+ }
+
+ ProcessGroup(const ProcessGroup &) = default;
+ ProcessGroup & operator=(const ProcessGroup &) = default;
+ ProcessGroup(ProcessGroup &&) noexcept = default;
+ ProcessGroup & operator=(ProcessGroup &&) noexcept = default;
+ ~ProcessGroup() = default;
+
+ /** Checks whether the process group has the same
+     intra-communicator as another process group,
+     hence both process groups being fully identical. **/
+ inline bool operator==(const ProcessGroup & another) const
+ {
+  return (intra_comm_ == another.intra_comm_);
+ }
+
+ /** Returns TRUE if the process group is composed
+     of the same processes as another process group,
+     with no regard to their intra-communicators. **/
+ bool isCongruentTo(const ProcessGroup & another) const;
+
+ /** Returns TRUE if the process group is contained in
+     or congruent to another process group. **/
+ bool isContainedIn(const ProcessGroup & another) const;
+
+ /** Returns the size of the process group (number of MPI processes). **/
+ unsigned int getSize() const {return process_ranks_.size();}
+
+ /** Returns the process group composition in terms of global MPI process ranks. **/
+ const std::vector<unsigned int> & getProcessRanks() const {return process_ranks_;}
+
+ /** Returns the MPI communicator proxy associated with the process group. **/
+ const MPICommProxy & getMPICommProxy() const {return intra_comm_;}
+
+ /** Returns TRUE if the provided global MPI process rank belongs to the process group. **/
+ bool rankIsIn(const unsigned int global_process_rank,
+               unsigned int * local_process_rank = nullptr) const
+ {
+  for(unsigned int i = 0; i < process_ranks_.size(); ++i){
+   if(process_ranks_[i] == global_process_rank){
+    if(local_process_rank != nullptr) *local_process_rank = i;
+    return true;
+   }
+  }
+  return false;
+ }
+
+ /** Resets the memory limit per MPI process in bytes. **/
+ void resetMemoryLimitPerProcess(std::size_t memory_limit = MAX_MEM_PER_PROCESS){
+  mem_per_process_ = memory_limit;
+  return;
+ }
+
+ /** Returns the current memory limit per MPI process in bytes. **/
+ std::size_t getMemoryLimitPerProcess() const {return mem_per_process_;}
+
+ /** Splits the existing process group into subgroups and returns
+     the process subgroup the current MPI process belongs to (or none).
+     The argument my_subgroup must be non-negative, otherwise no new
+     process subgroup will be returned for the current MPI process.
+     All MPI processes with the same (non-negative) my_subgroup value
+     will join a new process subgroup returned by this function.
+     Note that the (non-negative) my_subgroup value may differ between
+     different MPI processes, thus putting them into disjoint subgroups. **/
+ std::shared_ptr<ProcessGroup> split(int my_subgroup) const;
+
+protected:
+
+ std::vector<unsigned int> process_ranks_; //global ranks of the MPI processes forming the process group
+ MPICommProxy intra_comm_;                 //associated MPI intra-communicator
+ std::size_t mem_per_process_;             //dynamic memory limit per process (bytes)
+};
+
+} //namespace xacc
+
+#endif //XACC_MPI_COMM_PROXY_HPP_

--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.cpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.cpp
@@ -9,18 +9,13 @@
  *
  * Contributors:
  *   Alexander J. McCaskey - initial API and implementation
+ *   Daniel Claudino - MPI native implementation
  *******************************************************************************/
 #include "hpc_virt_decorator.hpp"
 #include "InstructionIterator.hpp"
 #include "Utils.hpp"
 #include "xacc.hpp"
-
-#include <boost/mpi.hpp>
-#include <boost/mpi/collectives/all_gather.hpp>
-#include <boost/serialization/string.hpp>
-#include <boost/serialization/vector.hpp>
-
-#include <mpi.h>
+#include <numeric>
 
 namespace xacc {
 namespace quantum {
@@ -68,25 +63,19 @@ void HPCVirtDecorator::execute(
   // we wish to evaluate the <O> for each by partitioning
   // their quantum execution across the node sub-groups.
 
-  using namespace boost;
-  int initialized;
-  MPI_Initialized(&initialized);
-  if (!initialized) {
-    MPI_Init(&xacc::argc, &xacc::argv);
-  }
-
-  mpi::communicator world;
-
   // Get the rank and size in the original communicator
-  int world_rank = world.rank(), world_size = world.size();
+  int world_size, world_rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  auto world = std::make_shared<ProcessGroup>(MPI_COMM_WORLD, world_size);
 
   if (world_size < n_virtual_qpus) {
     // The number of MPI processes is less than the number of requested virtual
     // QPUs, just execute as if there is only one virtual QPU and give the QPU
     // the whole MPI_COMM_WORLD.
-    void *qpu_comm_ptr = reinterpret_cast<void *>((MPI_Comm)world);
+    void *qpu_comm_ptr = reinterpret_cast<void *>(world.get());
     if (!qpuComm) {
-      qpuComm = std::make_shared<boost::mpi::communicator>(world);
+      qpuComm = world;
     }
     decoratedAccelerator->updateConfiguration(
         {{"mpi-communicator", qpu_comm_ptr}});
@@ -95,26 +84,37 @@ void HPCVirtDecorator::execute(
     return;
   }
 
-  // Get the color for this rank
-  int color = world_rank % n_virtual_qpus;
+  // get ranks in each comm
+  std::vector<int> ranks(world_size);
+  std::iota(ranks.begin(), ranks.end(), 0);
+  auto ranksPerComm = split_vector(ranks, n_virtual_qpus);
+
+  // get color
+  int color;
+  for (int i = 0; i < n_virtual_qpus; i++) {
+    auto ranks = ranksPerComm[i];
+    if (std::find(ranks.begin(), ranks.end(), world_rank) != ranks.end()) {
+      color = i;
+    }
+  }
 
   // Split the communicator based on the color and use the
   // original rank for ordering
   if (!qpuComm) {
     // Splits MPI_COMM_WORLD into sub-communicators if not already.
-    qpuComm = std::make_shared<boost::mpi::communicator>(
-        world.split(color, world_rank));
+    qpuComm = world->split(color);
   }
-  auto qpu_comm = *qpuComm;
 
   // current rank now has a color to indicate which sub-comm it belongs to
   // Give that sub communicator to the accelerator
-  void *qpu_comm_ptr = reinterpret_cast<void *>((MPI_Comm)qpu_comm);
+  void *qpu_comm_ptr =
+      reinterpret_cast<void *>(qpuComm->getMPICommProxy().getRef<MPI_Comm>());
   decoratedAccelerator->updateConfiguration(
       {{"mpi-communicator", qpu_comm_ptr}});
 
+  // get the number of sub-communicators
   // Everybody split the CompositeInstructions vector into n_virtual_qpu
-  // segments
+  // segments and get the color for the given process
   auto split_vecs = split_vector(functions, n_virtual_qpus);
 
   // Get the segment corresponding to this color
@@ -124,104 +124,141 @@ void HPCVirtDecorator::execute(
   auto my_buffer = xacc::qalloc(buffer->size());
   decoratedAccelerator->execute(my_buffer, my_circuits);
 
-  // Create a mapping of all local buffer names to the buffer
-  std::map<std::string, std::shared_ptr<AcceleratorBuffer>>
-      local_name_to_buffer;
-  for (auto &child : my_buffer->getChildren()) {
-    local_name_to_buffer.insert({child->name(), child});
+  // Split world along rank-0 in each sub-communicator and reduce the local
+  // energies
+  auto zeroRanksComm =
+      world->split(world_rank == qpuComm->getProcessRanks()[0]);
+
+  // Here we get the number of children buffers
+  // and the number of children per comm
+  int nGlobalChildren = 0;
+  std::vector<int> nLocalChildren(n_virtual_qpus);
+  if (world_rank == qpuComm->getProcessRanks()[0]) {
+
+    // reduce the number of children
+    auto nChildren = my_buffer->nChildren();
+    MPI_Allreduce(&nChildren, &nGlobalChildren, 1, MPI_INT, MPI_SUM,
+                  zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
+
+    // get number of children in each subcommunicator
+    MPI_Allgather(&nChildren, 1, MPI_INT, nLocalChildren.data(), 1, MPI_INT,
+                  zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
   }
 
-  // Every sub-group compute local energy
-  double local_energy = 0.0;
-  for (auto &my_circuit : my_circuits) {
-    local_energy +=
-        std::real(my_circuit->getCoefficient()) *
-        local_name_to_buffer[my_circuit->name()]->getExpectationValueZ();
-  }
-  
-  // for all rank 0s on qpu_comms, split
-  // and add them to a new communicator, then
-  // all_gather each local_energy to all these ranks
-  auto split_along_rank_zeros = world.split(qpu_comm.rank() == 0, world_rank);
-  double global_energy = 0.0;
-  if (qpu_comm.rank() == 0) {
-    
-    // This will put every computed local_energy into each
-    // qpu sub-comm group, but on rank 0 only
-    std::vector<double> all_local_energies;
-    mpi::all_gather(split_along_rank_zeros, local_energy, all_local_energies);
-    // Sum them all up on all rank 0s to get the global energy
-    global_energy =
-        std::accumulate(all_local_energies.begin(), all_local_energies.end(),
-                        decltype(all_local_energies)::value_type(0));
+  // broadcast the total number of children
+  MPI_Bcast(&nGlobalChildren, 1, MPI_INT, 0,
+            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+
+  // broadcast the number of children in each communicator
+  MPI_Bcast(nLocalChildren.data(), nLocalChildren.size(), MPI_INT, 0,
+            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+
+  // get expectation values and the size of the key of each child buffer
+  std::vector<double> globalExpVals(nGlobalChildren);
+  std::vector<int> globalKeySizes(nGlobalChildren);
+  if (world_rank == qpuComm->getProcessRanks()[0]) {
+
+    // get displacements for the keys in each comm
+    std::vector<int> nKeyShift(n_virtual_qpus);
+    for (int i = 0; i < n_virtual_qpus; i++) {
+      nKeyShift[i] = std::accumulate(nLocalChildren.begin(),
+                                     nLocalChildren.begin() + i, 0);
+    }
+
+    // get size of each key in the communicator
+    std::vector<double> localExpVals;
+    std::vector<int> localKeySizes;
+    for (auto child : my_buffer->getChildren()) {
+      localKeySizes.push_back(child->name().size());
+      localExpVals.push_back(child->getExpectationValueZ());
+    }
+
+    // gather all expectation values
+    MPI_Allgatherv(localExpVals.data(), localExpVals.size(), MPI_DOUBLE,
+                   globalExpVals.data(), nLocalChildren.data(),
+                   nKeyShift.data(), MPI_DOUBLE,
+                   zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
+
+    // gather the size of each child key
+    MPI_Allgatherv(localKeySizes.data(), localKeySizes.size(), MPI_INT,
+                   globalKeySizes.data(), nLocalChildren.data(),
+                   nKeyShift.data(), MPI_INT,
+                   zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
   }
 
-  qpu_comm.barrier();
+  // broadcast expectation values
+  MPI_Bcast(globalExpVals.data(), globalExpVals.size(), MPI_DOUBLE, 0,
+            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
 
-  // Now broadcast that global_energy to all
-  // other ranks in the sub groups
-  mpi::broadcast(qpu_comm, global_energy, 0);
+  // broadcast size of each key
+  MPI_Bcast(globalKeySizes.data(), globalKeySizes.size(), MPI_INT, 0,
+            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+
+  // get the size of all keys
+  auto nGlobalKeyChars =
+      std::accumulate(globalKeySizes.begin(), globalKeySizes.end(), 0);
+
+  // gather all keys chars
+  std::vector<char> globalKeyChars(nGlobalKeyChars);
+  if (world_rank == qpuComm->getProcessRanks()[0]) {
+
+    // get local key char arrays
+    std::vector<char> localKeys;
+    for (auto child : my_buffer->getChildren()) {
+      for (auto c : child->name()) {
+        localKeys.push_back(c);
+      }
+    }
+
+    // get the size of keys in the communicator
+    std::vector<int> commKeySize(n_virtual_qpus);
+    int shift = 0;
+    for (int i = 0; i < n_virtual_qpus; i++) {
+      auto it = globalKeySizes.begin() + shift;
+      commKeySize[i] = std::accumulate(it, it + nLocalChildren[i], 0);
+      shift += nLocalChildren[i];
+    }
+
+    // shifts for key sizes
+    std::vector<int> keySizeShift(n_virtual_qpus);
+    for (int i = 1; i < n_virtual_qpus; i++) {
+      keySizeShift[i] =
+          std::accumulate(commKeySize.begin(), commKeySize.begin() + i, 0);
+    }
+
+    // gather all key chars
+    MPI_Allgatherv(localKeys.data(), localKeys.size(), MPI_CHAR,
+                   globalKeyChars.data(), commKeySize.data(),
+                   keySizeShift.data(), MPI_CHAR,
+                   zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
+  }
+
+  // broadcast all keys
+  MPI_Bcast(globalKeyChars.data(), globalKeyChars.size(), MPI_CHAR, 0,
+            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+
+  // now every process has everything to rebuild the buffer
+  int shift = 0;
+  for (int i = 0; i < nGlobalChildren; i++) {
+
+    // get child name
+    auto it = globalKeyChars.begin() + shift;
+    std::string name(it, it + globalKeySizes[i]);
+
+    // create child buffer and append it to buffer
+    auto child = xacc::qalloc(buffer->size());
+    child->setName(name);
+    child->addExtraInfo("exp-val-z", globalExpVals[i]);
+    buffer->appendChild(name, child);
+    shift += globalKeySizes[i];
+  }
 
   // Setup a barrier
-  qpu_comm.barrier();
-  world.barrier();
-
-  // every rank should have global_energy now
-  buffer->addExtraInfo("__internal__decorator_aggregate_vqe__", global_energy);
-
-  // Strategy:
-  // Every process in a sub-communicator has the same
-  // children buffer data. I want each sub-group to share
-  // its results with the other subgroups. My thinking is
-  // to do an all_gather on all world ranks, all ranks will then
-  // have multiple copies of the data strings, so lets filter them
-  // out by using a std::set. Then just load the buffers and add them
-  // to the buffer.
-
-  // Need to distribute resultant children buffers to all ranks
-  //   std::vector<std::vector<std::string>> all_child_buffer_strings;
-  //   mpi::all_gather(world, my_child_buffer_strings,
-  //   all_child_buffer_strings);
-
-  //   // Everyone has all copies of child buffer strings, filter them out to be
-  //   // unique
-  //   std::set<std::string> unique_buffer_strings;
-  //   for (auto &child_buffer_strings : all_child_buffer_strings) {
-  //     for (auto child_buffer_string : child_buffer_strings) {
-  //       unique_buffer_strings.insert(child_buffer_string);
-  //     }
-  //   }
-
-  //   // everyone add the children buffers to the incoming buffer
-  //   std::map<std::string, std::shared_ptr<AcceleratorBuffer>> name_to_buffer;
-  //   for (auto &buffer_string : unique_buffer_strings) {
-  //     auto child_buffer = xacc::qalloc(buffer->size());
-  //     std::istringstream s(buffer_string);
-  //     child_buffer->load(s);
-  //     name_to_buffer.insert({child_buffer->name(), child_buffer});
-  //   }
-
-  //   // buffers need to be in same order as functions coming in
-  //   for (auto &f : functions) {
-  //     buffer->appendChild(f->name(), name_to_buffer[f->name()]);
-  //   }
-
-  //   qpu_comm.barrier();
-  //   world.barrier();
-
+  MPI_Barrier(qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+  MPI_Barrier(world->getMPICommProxy().getRef<MPI_Comm>());
   buffer->addExtraInfo("rank", world_rank);
-  return;
-}
 
-void HPCVirtTearDown::tearDown() {
-  int finalized, initialized;
-  MPI_Initialized(&initialized);
-  if (initialized) {
-    MPI_Finalized(&finalized);
-    if (!finalized) {
-      MPI_Finalize();
-    }
-  }
+  return;
 }
 
 } // namespace quantum
@@ -245,9 +282,6 @@ public:
 
     context.RegisterService<xacc::AcceleratorDecorator>(c);
     context.RegisterService<xacc::Accelerator>(c);
-
-    context.RegisterService<xacc::TearDown>(
-        std::make_shared<xacc::quantum::HPCVirtTearDown>());
   }
 
   /**

--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
@@ -9,18 +9,16 @@
  *
  * Contributors:
  *   Alexander J. McCaskey - initial API and implementation
+ *   Daniel Claudino - MPI native implementation
  *******************************************************************************/
 #ifndef XACC_HPC_VIRT_DECORATOR_HPP_
 #define XACC_HPC_VIRT_DECORATOR_HPP_
 
+#include "mpi.h"
+#include "xacc.hpp"
+#include "MPIProxy.hpp"
 #include "AcceleratorDecorator.hpp"
-#include "TearDown.hpp"
-namespace boost {
-namespace mpi {
-// Forward declaration
-class communicator;
-} // namespace mpi
-} // namespace boost
+
 namespace xacc {
 
 namespace quantum {
@@ -29,9 +27,8 @@ class HPCVirtDecorator : public AcceleratorDecorator {
 protected:
 
   int n_virtual_qpus = 1;
-  // The MPI communitor for each QPU.
-  std::shared_ptr<boost::mpi::communicator> qpuComm;
-
+  // The MPI communicator for each QPU
+  std::shared_ptr<ProcessGroup> qpuComm;
 
 public:
   void initialize(const HeterogeneousMap &params = {}) override;
@@ -75,11 +72,6 @@ private:
   }
 };
 
-class HPCVirtTearDown : public xacc::TearDown {
-public:
-  virtual void tearDown() override;
-  virtual std::string name() const override { return "xacc-hpc-virt"; }
-};
 } // namespace quantum
 } // namespace xacc
 #endif

--- a/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
+++ b/quantum/plugins/qpp/tests/QppAcceleratorTester.cpp
@@ -143,8 +143,8 @@ TEST(QppAcceleratorTester, testDeuteronVqeH3)
         .parameters t0, t1
         .qbit q
         X(q[0]);
-        exp_i_theta(q, t0, {{"pauli", "X0 Y1 - Y0 X1"}});
-        exp_i_theta(q, t1, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
+        exp_i_theta(q, t1, {{"pauli", "X0 Y1 - Y0 X1"}});
+        exp_i_theta(q, t0, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
     )");
     auto ansatz = xacc::getCompiled("deuteron_ansatz_h3");
 

--- a/quantum/python/xacc-quantum-py.cpp
+++ b/quantum/python/xacc-quantum-py.cpp
@@ -243,5 +243,12 @@ void bind_quantum(py::module &m) {
       .def("setFunctionValue", &AlgorithmGradientStrategy::setFunctionValue)
       .def("getGradientExecutions",
            &AlgorithmGradientStrategy::getGradientExecutions)
-      .def("compute", &AlgorithmGradientStrategy::compute);
+      .def("compute", (void (AlgorithmGradientStrategy::*)(
+                          std::vector<double> &,
+                          std::vector<std::shared_ptr<AcceleratorBuffer>>)) &
+                          AlgorithmGradientStrategy::compute)
+      .def("compute",
+           (std::vector<double>(AlgorithmGradientStrategy::*)(
+               const int, std::vector<std::shared_ptr<AcceleratorBuffer>>)) &
+               AlgorithmGradientStrategy::compute);
 }

--- a/quantum/python/xacc-quantum-py.hpp
+++ b/quantum/python/xacc-quantum-py.hpp
@@ -119,6 +119,11 @@ public:
     PYBIND11_OVERLOAD(void, xacc::AlgorithmGradientStrategy, setFunctionValue, expValue);        
   }
 
+  std::vector<double> compute(const int n,
+    std::vector<std::shared_ptr<AcceleratorBuffer>> results) override {
+    PYBIND11_OVERLOAD(std::vector<double>, xacc::AlgorithmGradientStrategy, compute, n, results) ;
+  }
+
 };
 
 #define QUICK_WRITE_VISIT_METHOD(GATE) void visit(GATE& gate) override { PYBIND11_OVERLOAD(void, AllGateVisitor, visit, gate); }

--- a/tpls/CMakeLists.txt
+++ b/tpls/CMakeLists.txt
@@ -82,7 +82,7 @@ else()
 endif()
 
 set(BUILD_SHARED_LIBS FALSE)
-set(BOOST_LIBS_OPTIONAL graph mpi CACHE STRING "" FORCE)
+set(BOOST_LIBS_OPTIONAL graph CACHE STRING "" FORCE)
 add_subdirectory(boost-cmake)
 
 install(DIRECTORY staq DESTINATION ${CMAKE_INSTALL_PREFIX}/include) 

--- a/xacc/CMakeLists.txt
+++ b/xacc/CMakeLists.txt
@@ -73,10 +73,18 @@ message(
                                     ${CMAKE_SOURCE_DIR}/tpls/mpark-variant
                                     ${CMAKE_SOURCE_DIR}/tpls/nlohmann)
 
-  target_link_libraries(xacc
+  # linking against MPI libraries found by cmake
+  if(MPI_FOUND)
+    target_link_libraries(xacc
+                        PUBLIC CppMicroServices ${MPI_CXX_LIBRARIES}
+                        PRIVATE cpr ${LIBUNWIND_LIBRARIES}
+                                ${LIBUNWINDX86_LIBRARIES})
+  else()
+    target_link_libraries(xacc
                         PUBLIC CppMicroServices
                         PRIVATE cpr ${LIBUNWIND_LIBRARIES}
                                 ${LIBUNWINDX86_LIBRARIES})
+  endif()
 
 else()
 
@@ -98,7 +106,13 @@ else()
                                     optimizer
                                     ${CMAKE_SOURCE_DIR}/tpls/mpark-variant
                                     ${CMAKE_SOURCE_DIR}/tpls/nlohmann)
-  target_link_libraries(xacc PUBLIC CppMicroServices PRIVATE cpr)
+
+  # linking against MPI libraries found by cmake
+  if(MPI_FOUND)
+    target_link_libraries(xacc PUBLIC CppMicroServices ${MPI_CXX_LIBRARIES} PRIVATE cpr)
+  else()
+    target_link_libraries(xacc PUBLIC CppMicroServices PRIVATE cpr)
+  endif()
 
 endif()
 

--- a/xacc/CMakeLists.txt
+++ b/xacc/CMakeLists.txt
@@ -49,6 +49,10 @@ add_library(xacc SHARED
 
 add_dependencies(xacc cpr)
 
+if(MPI_FOUND)
+  include_directories(${MPI_CXX_HEADER_DIR})
+endif()
+
 if(LIBUNWIND_FOUND)
 message(
     STATUS "${BoldGreen}Building xacc with libunwind support.${ColorReset}")

--- a/xacc/algorithm/AlgorithmGradientStrategy.hpp
+++ b/xacc/algorithm/AlgorithmGradientStrategy.hpp
@@ -56,6 +56,17 @@ public:
   virtual void
   compute(std::vector<double> &dx,
           std::vector<std::shared_ptr<AcceleratorBuffer>> results) = 0;
+
+  virtual std::vector<double>
+  compute(const int nParams,
+          std::vector<std::shared_ptr<AcceleratorBuffer>> results) {
+    XACCLogger::instance()->error("AlgorithmGradientStrategy::compute(int, "
+                                  "vector<AcceleratorBuffer>) not implemented "
+                                  "for " +
+                                  name());
+    exit(0);
+    return {};
+  }
 };
 
 } // namespace xacc

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -11,7 +11,6 @@
  *   Alexander J. McCaskey - initial API and implementation
  *******************************************************************************/
 #include "xacc.hpp"
-//#include "AlgorithmGradientStrategy.hpp"
 #include "InstructionIterator.hpp"
 #include "IRProvider.hpp"
 #include "CLIParser.hpp"
@@ -30,6 +29,10 @@
 #include <sys/stat.h>
 #include "TearDown.hpp"
 
+#ifdef MPI_ENABLED
+#include "mpi.h"
+#endif
+
 using namespace cxxopts;
 
 namespace xacc {
@@ -45,6 +48,10 @@ std::map<std::string, std::shared_ptr<CompositeInstruction>>
 std::map<std::string, std::shared_ptr<AcceleratorBuffer>> allocated_buffers{};
 
 std::string rootPathString = "";
+
+#ifdef MPI_ENABLED
+int isMPIInitialized;
+#endif
 
 void set_verbose(bool v) { verbose = v; }
 
@@ -105,6 +112,18 @@ void Initialize(int arc, char **arv) {
   if (!optionExists("queue-preamble")) {
     XACCLogger::instance()->dumpQueue();
   }
+
+  // Initializing MPI here
+#ifdef MPI_ENABLED
+  int provided;
+  MPI_Initialized(&isMPIInitialized);
+  if (!isMPIInitialized) {
+    MPI_Init_thread(0, NULL, MPI_THREAD_MULTIPLE, &provided);
+    if (provided != MPI_THREAD_MULTIPLE) {
+      xacc::warning("MPI_THREAD_MULTIPLE not provided.");
+    }
+  }
+#endif
 }
 
 void setIsPyApi() { isPyApi = true; }
@@ -823,26 +842,21 @@ void Finalize() {
     auto tearDowns = xacc::getServices<TearDown>();
     debug("Tearing down " + std::to_string(tearDowns.size()) +
           " registered TearDown services..");
-    std::vector<std::shared_ptr<TearDown>> frameworkTearDowns;
     for (auto &td : tearDowns) {
       try {
-        // If this is XACC HPC TearDown,
-        // add it to the list of XACC internal TearDown services to be executed
-        // after all plugins' TearDowns.
-        if (td->name() == "xacc-hpc-virt") {
-          frameworkTearDowns.emplace_back(td);
-        } else {
-          td->tearDown();
-        }
+        td->tearDown();
       } catch (int exception) {
         xacc::error("Error while tearing down a service. Code: " +
                     std::to_string(exception));
       }
     }
-    // Runs XACC internal TearDowns
-    for (auto &td : frameworkTearDowns) {
-      td->tearDown();
+
+    // This replaces the HPC virtualization TearDown
+#ifdef MPI_ENABLED
+    if (isMPIInitialized) {
+      MPI_Finalize();
     }
+#endif
 
     xacc::xaccFrameworkInitialized = false;
     compilation_database.clear();
@@ -871,16 +885,16 @@ std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name) {
   return g;
 }
 
-std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name,
-                                        const xacc::HeterogeneousMap &params) {
+std::shared_ptr<AlgorithmGradientStrategy>
+getGradient(const std::string name, const xacc::HeterogeneousMap &params) {
   auto g = xacc::getGradient(name);
   if (!g->initialize(params)) {
     error("Error initializing " + name + " gradient strategy.");
   }
   return g;
 }
-std::shared_ptr<AlgorithmGradientStrategy> getGradient(const std::string name,
-                                        const xacc::HeterogeneousMap &&params) {
+std::shared_ptr<AlgorithmGradientStrategy>
+getGradient(const std::string name, const xacc::HeterogeneousMap &&params) {
   return getGradient(name, params);
 }
 


### PR DESCRIPTION
This PR provides an overhaul of the HPC virtualization decorator where it relies solely on native the OpenMPI/MPICH compiler and header (`mpi.h`). The following changes/additions are introduced:

- The main `CMakeLists.txt` checks if the `MPI_CXX_COMPILER` flag was given and looks for MPI.
- `xacc/CMakeLists.txt` add the MPI libraries and where `mpi.h` can be found
- MPI initialization/teardown is now moved from the application to `xacc.cpp`
- `Boost::mpi` is no longer needed, so `tpls/boost-cmake` is updated accordingly
- HPC virtualization decorator revamped
- `MPIProxy.hpp` and `MPIProxy.cpp` are C++ wrappers for some common MPI C functions
- `AlgorithmGradientStrategy.hpp` introduces a method to return the gradient vector instead of passing it by reference (easier on the python side) and bindings are updated accordingly
- parameter shift now keeps track of all parameters and variables
- Added a few examples for the HPC virtualization decorator