### PR TITLE
Rework AssignmentErrorKernelDecorator 

### DIFF
--- a/quantum/plugins/decorators/AssignmentErrorKernelDecorator.hpp
+++ b/quantum/plugins/decorators/AssignmentErrorKernelDecorator.hpp
@@ -15,6 +15,7 @@
 
 #include "AcceleratorDecorator.hpp"
 #include <Eigen/Dense>
+#include <sstream>
 #include "xacc.hpp"
 
 namespace xacc {
@@ -119,12 +120,20 @@ protected:
       }
       row++;
     }
-    //std::cout << "MATRIX:\n" << K << "\n";
+    {
+      std::stringstream ss;
+      ss << "MATRIX:\n" << K << "\n";
+      xacc::info(ss.str());
+    }
     errorKernel = K.inverse();
-    //std::cout << "INVERSE:\n" << errorKernel << "\n";
+    {
+      std::stringstream ss;
+      ss << "INVERSE:\n" << errorKernel << "\n";
+      xacc::info(ss.str());
+    }
     std::vector<double> vec(errorKernel.data(), errorKernel.data() + errorKernel.rows()*errorKernel.cols());
     buffer->addExtraInfo("error-kernel", vec);
-
+    // No need to generate again
     gen_kernel = false;
   }
 

--- a/quantum/plugins/decorators/tests/CMakeLists.txt
+++ b/quantum/plugins/decorators/tests/CMakeLists.txt
@@ -29,3 +29,6 @@ target_link_libraries(RichExtrapDecoratorTester xacc xacc-pauli xacc-quantum-gat
 
 add_xacc_test(ImprovedSamplingDecorator)
 target_link_libraries(ImprovedSamplingDecoratorTester xacc)
+
+add_xacc_test(AssignmentErrorKernelDecorator)
+target_link_libraries(AssignmentErrorKernelDecoratorTester xacc xacc-quantum-gate)


### PR DESCRIPTION
- Handle the case where not all qubits are measured (e.g., observed circuits).

- Fix the "clip-and-renorm" logic after computing the error mitigated probabilities (multiplying the `errorKernel` matrix with the original probabilities). Add assert to verify that the total count after mitigation matched the original number of shots.

- Adding unit tests to CI.