### PR TITLE
Minor improvements to TriQ placement plugin

### DIFF
--- a/quantum/plugins/placement/triq/BackendMachine.cpp
+++ b/quantum/plugins/placement/triq/BackendMachine.cpp
@@ -120,10 +120,10 @@ void XaccTargetter::print_header(std::ofstream &out_file) {
 }
 
 void XaccTargetter::add_gate_print_maps() {
-    gate_print_ibm[typeid(RX)] = "rx";
-	gate_print_ibm[typeid(RY)] = "ry";
-	gate_print_ibm[typeid(RZ)] = "rz";
-    gate_print_ibm[typeid(CZ)] = "cz";
+  gate_print_ibm[typeid(RX)] = "rx";
+  gate_print_ibm[typeid(RY)] = "ry";
+  gate_print_ibm[typeid(RZ)] = "rz";
+  gate_print_ibm[typeid(CZ)] = "cz";
 }
 
 void XaccTargetter::print_one_qubit_gate(::Gate *g, std::ofstream &out_file,

--- a/quantum/plugins/placement/triq/BackendMachine.cpp
+++ b/quantum/plugins/placement/triq/BackendMachine.cpp
@@ -119,6 +119,13 @@ void XaccTargetter::print_header(std::ofstream &out_file) {
   out_file << "creg c[" << nbQubits << "];\n";
 }
 
+void XaccTargetter::add_gate_print_maps() {
+    gate_print_ibm[typeid(RX)] = "rx";
+	gate_print_ibm[typeid(RY)] = "ry";
+	gate_print_ibm[typeid(RZ)] = "rz";
+    gate_print_ibm[typeid(CZ)] = "cz";
+}
+
 void XaccTargetter::print_one_qubit_gate(::Gate *g, std::ofstream &out_file,
                                          int is_last_gate) {
   int qid = g->vars[0]->id;

--- a/quantum/plugins/placement/triq/BackendMachine.hpp
+++ b/quantum/plugins/placement/triq/BackendMachine.hpp
@@ -11,9 +11,13 @@ public:
 // Override TriQ to print out QASM rather than Qiskit Python code:
 class XaccTargetter : public ::Targetter {
 public:
-  XaccTargetter(::Machine *m, ::Circuit *c, std::map<::Qubit*, int> * initialMap, std::vector<::Gate*> *gateOrder, map<::Gate*, ::BacktrackSolution*> bSol):
-    ::Targetter(m,c,initialMap,gateOrder, bSol)
-  {}
+  XaccTargetter(::Machine *m, ::Circuit *c,
+                std::map<::Qubit *, int> *initialMap,
+                std::vector<::Gate *> *gateOrder,
+                map<::Gate *, ::BacktrackSolution *> bSol)
+      : ::Targetter(m, c, initialMap, gateOrder, bSol) {
+    add_gate_print_maps();
+  }
 
   virtual void print_one_qubit_gate(::Gate *g, ofstream &out_file,
                             int is_last_gate) override;
@@ -22,5 +26,6 @@ public:
   virtual void print_header(ofstream &out_file) override;
   virtual void print_measure_ops(ofstream &out_file) override;
   virtual void print_footer(ofstream &out_file) override;
+  void add_gate_print_maps();
 };
 } // namespace xacc

--- a/quantum/plugins/placement/triq/triq_placement.hpp
+++ b/quantum/plugins/placement/triq/triq_placement.hpp
@@ -39,7 +39,7 @@ public:
   const std::string description() const override { return ""; }
 private:
   // Returns the QASM source string after placement
-  std::string runTriQ(Circuit& program, Machine& machine, int algorithmSelector) const;
+  std::string runTriQ(Circuit& program, Machine& machine, int algorithmSelector, double approxFactor) const;
 };
 } // namespace quantum
 } // namespace xacc


### PR DESCRIPTION
- Ability to handle a few more gates (rx, ry, rz)

- Input noise model directly (as `xacc::NoiseModel` ptr).

- Control the runtime via approximation factor.