### PR TITLE
Ability to set random seed in simulator backends

### DIFF
--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.cpp
@@ -68,6 +68,10 @@ void AerAccelerator::initialize(const HeterogeneousMap &params) {
   if (params.keyExists<int>("shots")) {
     m_shots = params.get<int>("shots");
   }
+
+  if (params.keyExists<int>("seed")) {
+    m_seed = params.get<int>("seed");
+  }
   if (params.stringExists("sim-type")) {
     if (!xacc::container::contains(
             std::vector<std::string>{"qasm", "statevector", "pulse", "density_matrix"},
@@ -185,7 +189,10 @@ void AerAccelerator::execute(
     nlohmann::json j = nlohmann::json::parse(qobj_str)["qObject"];
     j["config"]["shots"] = m_shots;
     j["config"]["noise_model"] = noise_model;
-
+    // If a seed was set:
+    if (m_seed > 0) {
+      j["config"]["seed_simulator"] = m_seed;
+    }
     // xacc::set_verbose(true);
     // xacc::info("Shots Qobj:\n" + j.dump(2));
     auto results_json = nlohmann::json::parse(

--- a/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
+++ b/quantum/plugins/ibm/aer/accelerator/aer_accelerator.hpp
@@ -80,7 +80,8 @@ private:
   bool initialized = false;
   std::shared_ptr<AER::Noise::NoiseModel> noiseModelObj;
   HeterogeneousMap physical_backend_properties;
-
+  // No seed
+  int m_seed = -1;
 };
 } // namespace quantum
 } // namespace xacc

--- a/quantum/plugins/ibm/aer/tests/AerAcceleratorTester.cpp
+++ b/quantum/plugins/ibm/aer/tests/AerAcceleratorTester.cpp
@@ -456,6 +456,30 @@ TEST(AerAcceleratorTester, checkConditional) {
   xacc::set_verbose(false);
 }
 
+// Test ability to set random seed
+// For deterministic testing.
+TEST(AerAcceleratorTester, checkRandomSeed) {
+  auto accelerator =
+      xacc::getAccelerator("aer", {{"shots", 8192}, {"seed", 123}});
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void bell(qbit q) {
+      H(q[0]);
+      CX(q[0], q[1]);
+      Measure(q[0]);
+      Measure(q[1]);
+    })",
+                                  accelerator);
+
+  auto program = ir->getComposite("bell");
+
+  auto buffer = xacc::qalloc(2);
+  accelerator->execute(buffer, program);
+  buffer->print();
+  // The result will be deterministic since we seed the simulator
+  EXPECT_EQ(buffer->getMeasurementCounts()["00"], 4073);
+  EXPECT_EQ(buffer->getMeasurementCounts()["11"], 4119);
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize();
 

--- a/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
+++ b/quantum/plugins/qpp/accelerator/QppAccelerator.hpp
@@ -17,6 +17,22 @@
 
 namespace xacc {
 namespace quantum {
+struct randomEngine {
+  randomEngine() {
+    std::random_device rd;
+    setSeed(rd());
+  }
+  randomEngine(size_t seed) { setSeed(seed); }
+  void setSeed(size_t seed) {
+    m_engine.seed(seed);
+    m_seed = seed;
+  }
+  double randProb() {
+    return std::uniform_real_distribution<double>(0.0, 1.0)(m_engine);
+  }
+  std::mt19937_64 m_engine;
+  size_t m_seed;
+};
 
 class QppAccelerator : public Accelerator {
 public:
@@ -50,6 +66,7 @@ public:
     std::vector<std::pair<int,int>> m_connectivity;
     xacc::HeterogeneousMap m_executionInfo;
     std::pair<AcceleratorBuffer*, size_t> m_currentBuffer;
+    randomEngine m_rng;
 };
 
 class DefaultNoiseModelUtils : public NoiseModelUtils 


### PR DESCRIPTION
So that we can set it for testing purposes (prevent intermittent test failures due to shot noises)

- `qsim` and `aer` already supported it. Just need to send on the seed.

- `qpp`: add a random engine as a member variable.