### PR TITLE
Fixes for latest gcc and add CI for all supported compilers

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -34,3 +34,37 @@ jobs:
       - name: Test
         working-directory: build/
         run: ctest --output-on-failure
+  
+  check-compilers:
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - "gcc:7"
+          - "gcc:8"
+          - "gcc:9"
+          - "gcc:10"
+          - "gcc:11"
+          - "gcc:12"
+        build_type: [Debug, Release]
+
+    runs-on: ubuntu-latest
+    container:
+      image: ${{matrix.image}}
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Install dependencies
+        run: apt -y update && apt install -y --no-install-recommends ninja-build libssl-dev libcurl4-openssl-dev python3 libpython3-dev python3-pip cmake libblas-dev liblapack-dev
+      
+    - name: Create Build Environment
+      run: cmake -E make_directory build
+
+    - name: Configure
+      working-directory: build/
+      run: cmake -GNinja $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DXACC_BUILD_TESTS=TRUE -DXACC_BUILD_EXAMPLES=TRUE
+    
+    - name: Build
+      working-directory: build/
+      run: cmake --build . --target install

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Install dependencies
-        run: apt -y update && apt install -y --no-install-recommends ninja-build libssl-dev libcurl4-openssl-dev python3 libpython3-dev python3-pip cmake libblas-dev liblapack-dev
+      run: apt -y update && apt install -y --no-install-recommends ninja-build libssl-dev libcurl4-openssl-dev python3 libpython3-dev python3-pip cmake libblas-dev liblapack-dev
       
     - name: Create Build Environment
       run: cmake -E make_directory build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ if (XACC_BUILD_TESTS)
    endmacro()
 endif()
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
+add_compile_flags_if_supported(-Wno-attributes)
+add_compile_flags_if_supported(-Wno-deprecated-declarations)
+add_compile_flags_if_supported(-Wno-maybe-uninitialized)
 
 # NOTE: to enable MPI, need to configure CMAKE with -DXACC_ENABLE_MPI=TRUE
 # (some XACC Python binding is not compatible with MPI, hence not building with MPI as default)

--- a/xacc/utils/Stream.hpp
+++ b/xacc/utils/Stream.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include <iostream>
+#include <vector>
+#include <map>
+#include <string>
+
+namespace xacc {
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const std::pair<T, T> &p) {
+  os << "[" << p.first << "," << p.second << "]";
+  return os;
+}
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
+  os << "[";
+  for (int i = 0; i < v.size(); ++i) {
+    os << v[i];
+    if (i != v.size() - 1)
+      os << ",";
+  }
+  os << "]";
+  return os;
+}
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const std::map<int, T> &m) {
+  os << "[";
+  int i = 0;
+  for (auto &kv : m) {
+    os << "(" << kv.first << "," << kv.second << ")";
+    if (i != m.size() - 1) {
+      os << ",";
+    }
+    i++;
+  }
+  os << "]";
+  return os;
+}
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const std::map<std::string, T> &m) {
+  os << "[";
+  int i = 0;
+  for (auto &kv : m) {
+    os << "(" << kv.first << "," << kv.second << ")";
+    if (i != m.size() - 1) {
+      os << ",";
+    }
+    i++;
+  }
+  os << "]";
+  return os;
+}
+} // namespace xacc

--- a/xacc/utils/Utils.hpp
+++ b/xacc/utils/Utils.hpp
@@ -14,7 +14,7 @@
 #define XACC_UTILS_UTILS_HPP_
 
 #include "Singleton.hpp"
-
+#include "Stream.hpp"
 #include <memory>
 #include <queue>
 #include <functional>
@@ -64,53 +64,6 @@ inline std::vector<std::string> split(const std::string &s, char delim) {
   return elems;
 }
 
-template <typename T>
-std::ostream &operator<<(std::ostream &os, const std::pair<T, T> &p) {
-  os << "[" << p.first << "," << p.second << "]";
-  return os;
-}
-
-template <typename T>
-std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
-  os << "[";
-  for (int i = 0; i < v.size(); ++i) {
-    os << v[i];
-    if (i != v.size() - 1)
-      os << ",";
-  }
-  os << "]";
-  return os;
-}
-
-template <typename T>
-std::ostream &operator<<(std::ostream &os, const std::map<int, T> &m) {
-  os << "[";
-  int i = 0;
-  for (auto &kv : m) {
-    os << "(" << kv.first << "," << kv.second << ")";
-    if (i != m.size() - 1) {
-      os << ",";
-    }
-    i++;
-  }
-  os << "]";
-  return os;
-}
-
-template <typename T>
-std::ostream &operator<<(std::ostream &os, const std::map<std::string, T> &m) {
-  os << "[";
-  int i = 0;
-  for (auto &kv : m) {
-    os << "(" << kv.first << "," << kv.second << ")";
-    if (i != m.size() - 1) {
-      os << ",";
-    }
-    i++;
-  }
-  os << "]";
-  return os;
-}
 static inline bool is_base64(unsigned char c);
 
 std::string base64_decode(std::string const &encoded_string);

--- a/xacc/utils/heterogeneous.hpp
+++ b/xacc/utils/heterogeneous.hpp
@@ -22,6 +22,7 @@
 
 #include <any>
 #include <sstream>
+#include "Stream.hpp"
 
 // If this is a GNU compiler
 #if defined(__GNUC__) || defined(__GNUG__)


### PR DESCRIPTION
There are a couple of new warnings introduced in `gcc-12`, causing problems with some `tpls` with `Werror` setting.

- Disable these warnings.

- Add a CI pipeline to test all gcc compilers: 7 -> 12.

- There is a problem with templated function lookup for `operator<<` (required by `Variant`). Seems like `gcc` is now stricter in its lookup.

Resolved: https://github.com/eclipse/xacc/issues/543