### PR TITLE
Some improvements to C-U expansion

### DIFF
--- a/quantum/plugins/algorithms/qpe/ControlledGateApplicator.cpp
+++ b/quantum/plugins/algorithms/qpe/ControlledGateApplicator.cpp
@@ -327,6 +327,27 @@ bool ControlledU::expand(const xacc::HeterogeneousMap &runtimeOptions) {
     return false;
   };
 
+  // Always decomposed
+  bool should_decompose = true;
+  if (xacc::optionExists("skip-control-gate-decompose")) {
+    should_decompose = false;
+  }
+  if (runtimeOptions.keyExists<bool>("skip-decompose")) {
+    should_decompose = !(runtimeOptions.get<bool>("skip-decompose"));
+  }
+
+  if (!should_decompose) {
+    if (!should_run_gray_mcu_synth()) {
+      // If not simple Gray code, use recursive method to roll up control bits
+      // but skip the final expansion.
+      for (const auto &ctrlIdx : ctrlIdxs) {
+        ctrlU = applyControl(ctrlU, ctrlIdx);
+      }
+    }
+    m_expanded = true;
+    return true;
+  }
+
   if (should_run_gray_mcu_synth()) {
     ctrlU = __gray_code_mcu_gen(ctrlU, ctrlIdxs);
     std::vector<int> zero_rotation_idxs;

--- a/quantum/plugins/algorithms/qpe/ControlledGateApplicator.hpp
+++ b/quantum/plugins/algorithms/qpe/ControlledGateApplicator.hpp
@@ -80,6 +80,8 @@ private:
   std::shared_ptr<xacc::CompositeInstruction>
   applyControl(const std::shared_ptr<xacc::CompositeInstruction> &in_program,
                const std::pair<std::string, size_t> &in_ctrlIdx);
+  // Adding more control bits to a ctrl instruction
+  void addMoreControlBits(std::shared_ptr<xacc::Instruction> ctrlInst);
 
 private:
   std::shared_ptr<xacc::CompositeInstruction> m_composite;
@@ -89,6 +91,7 @@ private:
   bool m_expanded;
   std::vector<std::pair<std::string, size_t>> m_ctrlIdxs;
   std::shared_ptr<Instruction> m_originalU;
+  bool m_shouldRollupMultipleControls = true;
 };
 } // namespace circuits
 } // namespace xacc

--- a/quantum/plugins/algorithms/qpe/tests/ControlledGateTester.cpp
+++ b/quantum/plugins/algorithms/qpe/tests/ControlledGateTester.cpp
@@ -1,11 +1,13 @@
 #include <gtest/gtest.h>
+#include "Utils.hpp"
 #include "xacc.hpp"
 #include "xacc_service.hpp"
 #include "CommonGates.hpp"
 #include <Eigen/Dense>
+#include <memory>
 #include "CountGatesOfTypeVisitor.hpp"
 #include "GateFusion.hpp"
-
+#include "GateModifier.hpp"
 using namespace xacc;
 using namespace xacc::quantum;
 
@@ -489,6 +491,41 @@ TEST(ControlledGateTester, checkMultipleControlRollup) {
     xacc::quantum::CountGatesOfTypeVisitor<U> visu(multi_ctrl_z);
     EXPECT_EQ(vis.countGates(), 44);
     EXPECT_EQ(visu.countGates(), 52);
+  }
+}
+
+TEST(ControlledGateTester, checkControlRollUpComplex) {
+  auto gateRegistry = xacc::getService<xacc::IRProvider>("quantum");
+  {
+    auto cz = std::make_shared<CZ>(1, 0);
+    auto cn = std::make_shared<CNOT>(1, 0);
+    std::shared_ptr<xacc::CompositeInstruction> comp =
+        gateRegistry->createComposite("__COMPOSITE__");
+    comp->addInstruction(cz);
+    comp->addInstruction(cn);
+    const std::vector<int> ctrl_idxs{2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                     12, 13, 14, 15, 16, 17, 18, 19, 20};
+    auto multi_ctrl = std::dynamic_pointer_cast<CompositeInstruction>(
+        xacc::getService<Instruction>("C-U"));
+    multi_ctrl->expand(
+        {{"U", comp}, {"control-idx", ctrl_idxs}, {"skip-decompose", true}});
+    for (int i = 0; i < multi_ctrl->nInstructions(); ++i) {
+      auto inst = multi_ctrl->getInstruction(i);
+      EXPECT_EQ(inst->name(), "C-U");
+      auto ctlGate = std::dynamic_pointer_cast<ControlModifier>(inst);
+      EXPECT_TRUE(ctlGate != nullptr);
+      EXPECT_EQ(ctlGate->getControlQubits().size(), ctrl_idxs.size() + 1);
+      for (const auto &[reg, qId] : ctlGate->getControlQubits()) {
+        const bool isValid =
+            xacc::container::contains(ctrl_idxs, qId) || qId == 1;
+        EXPECT_TRUE(isValid);
+      }
+      auto baseInst = xacc::ir::asComposite(ctlGate->getBaseInstruction());
+      EXPECT_EQ(baseInst->nInstructions(), 1);
+      const std::vector<std::string> EXPECTED_BASE_GATE{"Z", "X"};
+      EXPECT_EQ(baseInst->getInstruction(0)->name(), EXPECTED_BASE_GATE[i]);
+      EXPECT_EQ(baseInst->getInstruction(0)->bits()[0], 0);
+    }
   }
 }
 


### PR DESCRIPTION
Adding the ability to recognize `C-U` on top of control-like native gates, such as `CZ` and `CNOT`, as well as another `C-U` composite.

For example, when seeing `C-U` on a `CNOT`, this is equivalent to `C-U` on `X`, whereby the control bit of CNOT is combined into the list of control bits in `C-U`.

Also, adding the option to skip the decomposition: e.g., when we use a simulator that can run `C-U` efficiently for many control bits.
