### PR TITLE
Honeywell retrieves job by id, gives job name

### DIFF
--- a/quantum/plugins/honeywell/honeywell.hpp
+++ b/quantum/plugins/honeywell/honeywell.hpp
@@ -16,6 +16,7 @@
 #include "InstructionIterator.hpp"
 #include "Accelerator.hpp"
 #include <bitset>
+#include <string>
 #include <type_traits>
 
 namespace xacc {
@@ -109,6 +110,8 @@ private:
   std::string time_str;
   std::string refresh_key;
   std::string email;
+  std::string job_name;
+  std::string job_id;
 
   int shots = 1024;
   std::string backend = "";

--- a/quantum/plugins/honeywell/tests/HoneywellAcceleratorTester.cpp
+++ b/quantum/plugins/honeywell/tests/HoneywellAcceleratorTester.cpp
@@ -15,7 +15,7 @@
 
 TEST(HoneywellAcceleratorTester, checkSimple) {
   xacc::set_verbose(true);
-  auto accelerator = xacc::getAccelerator("honeywell:HQS-LT-S1-APIVAL");
+  auto accelerator = xacc::getAccelerator("honeywell:H1-1SC");
   auto xasmCompiler = xacc::getCompiler("xasm");
   auto ir = xasmCompiler->compile(R"(__qpu__ void bell(qbit q) {
       H(q[0]);
@@ -35,7 +35,7 @@ TEST(HoneywellAcceleratorTester, checkSimple) {
 
 TEST(HoneywellAcceleratorTester, checkConditionalTeleport) {
   xacc::set_verbose(true);
-  auto accelerator = xacc::getAccelerator("honeywell:HQS-LT-S1-APIVAL");
+  auto accelerator = xacc::getAccelerator("honeywell:H1-1SC");
   auto buffer = xacc::qalloc(3);  
   auto xasmCompiler = xacc::getCompiler("xasm");
   auto ir = xasmCompiler->compile(R"(__qpu__ void teleport(qbit q) {
@@ -70,7 +70,7 @@ TEST(HoneywellAcceleratorTester, checkConditionalTeleport) {
 
 TEST(HoneywellAcceleratorTester, checkConditionalIQPE) {
   xacc::set_verbose(true);
-  auto accelerator = xacc::getAccelerator("honeywell:HQS-LT-S1-APIVAL");
+  auto accelerator = xacc::getAccelerator("honeywell:H1-1SC");
   auto buffer = xacc::qalloc(3);  
   auto xasmCompiler = xacc::getCompiler("xasm");
   // Make sure we can validate it.


### PR DESCRIPTION
This PR:
 - enables users to retrieve results from jobs submitted to the queue by the corresponding job id
 - enables users to enter a custom job name (defaults to job id if not provided)
 - updates tests to use the most recent syntax checker

Signed-off-by: Daniel Claudino <6d3@ornl.gov>