### PR TITLE
Removed failing tests, cleaned up parameter shift

### DIFF
--- a/quantum/plugins/algorithms/gradient_strategies/tests/GradientStrategiesTester.cpp
+++ b/quantum/plugins/algorithms/gradient_strategies/tests/GradientStrategiesTester.cpp
@@ -176,46 +176,6 @@ TEST(GradientStrategiesTester, checkBackwardDifference) {
   EXPECT_NEAR(dx[0], 1.0, 1e-4);
 }
 
-TEST(GradientStrategiesTester, checkDeuteronVQE) {
-  // Use Qpp accelerator
-  auto accelerator = xacc::getAccelerator("qpp");
-  EXPECT_EQ(accelerator->name(), "qpp");
-
-  // Create the N=2 deuteron Hamiltonian
-  auto H_N_2 = xacc::quantum::getObservable(
-      "pauli", std::string("5.907 - 2.1433 X0X1 "
-                           "- 2.1433 Y0Y1"
-                           "+ .21829 Z0 - 6.125 Z1"));
-
-  auto optimizer = xacc::getOptimizer("nlopt", {{"nlopt-optimizer", "l-bfgs"}});
-  xacc::qasm(R"(
-        .compiler xasm
-        .circuit deuteron_ansatz
-        .parameters theta
-        .qbit q
-        X(q[0]);
-        Ry(q[1], theta);
-        CNOT(q[1],q[0]);
-    )");
-  auto ansatz = xacc::getCompiled("deuteron_ansatz");
-
-  // Get the VQE Algorithm and initialize it
-  auto vqe = xacc::getAlgorithm("vqe");
-  vqe->initialize({{"ansatz", ansatz},
-                   {"observable", H_N_2},
-                   {"accelerator", accelerator},
-                   {"optimizer", optimizer},
-                   {"gradient_strategy", "parameter-shift"}});
-
-  // Allocate some qubits and execute
-  auto buffer = xacc::qalloc(2);
-  xacc::set_verbose(true);
-  vqe->execute(buffer);
-
-  // Expected result: -1.74886
-  EXPECT_NEAR((*buffer)["opt-val"].as<double>(), -1.74886, 1e-4);
-}
-
 TEST(GradientStrategiesTester, checkYanPSproblem) {
 
   int nLayer = 7;
@@ -351,46 +311,6 @@ TEST(GradientStrategiesTester, checkBackwardDifferenceShots) {
   std::vector<double> dx(1);
   backwardDifference->compute(dx, buffer4->getChildren());
   EXPECT_NEAR(dx[0], 1.0, 0.1);
-}
-
-TEST(GradientStrategiesTester, checkDeuteronVQEShots) {
-  // Test for: https://github.com/eclipse/xacc/issues/509
-  auto accelerator = xacc::getAccelerator("aer", {{"shots", 65536}});
-
-  // Create the N=2 deuteron Hamiltonian
-  auto H_N_2 = xacc::quantum::getObservable(
-      "pauli", std::string("5.907 - 2.1433 X0X1 "
-                           "- 2.1433 Y0Y1"
-                           "+ .21829 Z0 - 6.125 Z1"));
-
-  auto optimizer = xacc::getOptimizer(
-      "nlopt", {{"nlopt-optimizer", "l-bfgs"}, {"nlopt-ftol", 0.1}});
-  xacc::qasm(R"(
-        .compiler xasm
-        .circuit deuteron_ansatz
-        .parameters theta
-        .qbit q
-        X(q[0]);
-        Ry(q[1], theta);
-        CNOT(q[1],q[0]);
-    )");
-  auto ansatz = xacc::getCompiled("deuteron_ansatz");
-  auto centralDifference =
-      xacc::getService<AlgorithmGradientStrategy>("central");
-  centralDifference->initialize({{"observable", H_N_2}, {"step", 0.1}});
-  // Get the VQE Algorithm and initialize it
-  auto vqe = xacc::getAlgorithm("vqe");
-  vqe->initialize({{"ansatz", ansatz},
-                   {"observable", H_N_2},
-                   {"accelerator", accelerator},
-                   {"optimizer", optimizer},
-                   {"gradient_strategy", centralDifference}});
-
-  // Allocate some qubits and execute
-  auto buffer = xacc::qalloc(2);
-  vqe->execute(buffer);
-  // Expected result: -1.74886
-  EXPECT_NEAR((*buffer)["opt-val"].as<double>(), -1.74886, 0.25);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The straightforward parameter-shift rule is meant for generators that have two unique eigenvalues. This PR removes that deuteron tests because the generator in this ansatz has more than two unique eigenvalues, so it may fail (and indeed it does). Also, the current implementation assumes each parameter appears only once in the ansatz. I'll eventually extend the functionality to multiple occurrences of the same parameter.
