### PR TITLE
Fixed a subtle issue in XASM variable handling

### DIFF
--- a/quantum/plugins/xasm/tests/XASMCompilerTester.cpp
+++ b/quantum/plugins/xasm/tests/XASMCompilerTester.cpp
@@ -358,6 +358,27 @@ TEST(XASMCompilerTester, checkCallingPreviousKernel) {
   std::cout << bell->toString() << "\n";
 }
 
+TEST(XASMCompilerTester, checkRepeatedVectorArg) {
+  auto compiler = xacc::getCompiler("xasm");
+  // Testing indexed arguments ganged together.
+  auto IR =
+      compiler->compile(R"(__qpu__ void ansatz(qbit q, std::vector<double> x) {
+  Ry(q[0], x[0]);
+  Ry(q[1], x[0]);
+  Rx(q[0], x[1]);
+  Rx(q[1], x[1]);
+  Measure(q[0]);
+  Measure(q[1]);
+})");
+  EXPECT_EQ(1, IR->getComposites().size());
+  std::cout << "KERNEL\n" << IR->getComposites()[0]->toString() << "\n";
+  // Check that we can expand with 2 arg values.
+  // i.e., the compiler properly registered two arguments 
+  // when some are repeated.
+  std::cout << "KERNEL\n"
+            << IR->getComposites()[0]->operator()({1.0, 2.0})->toString() << "\n";
+}
+
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);
   xacc::set_verbose(true);

--- a/quantum/plugins/xasm/xasm_listener.cpp
+++ b/quantum/plugins/xasm/xasm_listener.cpp
@@ -437,7 +437,13 @@ void XASMListener::enterBufferList(xasmParser::BufferListContext *ctx) {
         if (inIfStmt)
           if_stmt->replaceVariable(name, newVar);
       } else {
-        function->addVariable(newVar);
+        if (!xacc::container::contains(function->getVariables(), newVar)) {
+          // Only added the one that is not present yet
+          // e.g., same indexed variable (theta[0]) used in more than one locations.
+          // FIXME: the order of these variables might only be correct if users
+          // use them in the correct order in the circuit, like theta[0], then theta[1], ...
+          function->addVariable(newVar);
+        }
         if (inForLoop)
           for_function->addVariable(newVar);
         if (inIfStmt)


### PR DESCRIPTION
When adding indexed variable names, e.g., `theta0`, `theta1`, to the variable list, we need to handle the case whereby some of them are repeated (same variational angle in multiple rotation gates)

Added a simple test to verify the fix.

