### PR TITLE
Enabled shots in HPC virtualization

### DIFF
--- a/quantum/plugins/decorators/hpc-virtualization/MPIProxy.cpp
+++ b/quantum/plugins/decorators/hpc-virtualization/MPIProxy.cpp
@@ -5,12 +5,26 @@ Copyright (C) 2018-2021 Oak Ridge National Laboratory (UT-Battelle) **/
 
 #include "MPIProxy.hpp"
 
-#include "mpi.h"
 
 #include <cstdlib>
 
 #include <iostream>
 #include <algorithm>
+
+template <>
+MPI_Datatype MPIDataTypeResolver<int>::getMPIDatatype() {
+    return MPI_INT;
+}
+
+template <>
+MPI_Datatype MPIDataTypeResolver<double>::getMPIDatatype() {
+    return MPI_DOUBLE;
+}
+
+template <>
+MPI_Datatype MPIDataTypeResolver<char>::getMPIDatatype() {
+    return MPI_CHAR;
+}
 
 namespace xacc {
 

--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.cpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.cpp
@@ -14,13 +14,32 @@
 #include "hpc_virt_decorator.hpp"
 #include "InstructionIterator.hpp"
 #include "Utils.hpp"
-#include "xacc.hpp"
+#include "xacc_service.hpp"
+#include "TearDown.hpp"
 #include <numeric>
+
+namespace {
+  static bool hpcVirtDecoratorInitializedMpi = false;
+}
 
 namespace xacc {
 namespace quantum {
 
 void HPCVirtDecorator::initialize(const HeterogeneousMap &params) {
+
+  if (!qpuComm) {
+    // Initializing MPI here
+    int provided, isMPIInitialized;
+    MPI_Initialized(&isMPIInitialized);
+    if (!isMPIInitialized) {
+      MPI_Init_thread(0, NULL, MPI_THREAD_MULTIPLE, &provided);
+      hpcVirtDecoratorInitializedMpi = true;
+      if (provided != MPI_THREAD_MULTIPLE) {
+        xacc::warning("MPI_THREAD_MULTIPLE not provided.");
+      }
+    }
+  }
+
   decoratedAccelerator->initialize(params);
 
   if (params.keyExists<int>("n-virtual-qpus")) {
@@ -33,6 +52,21 @@ void HPCVirtDecorator::initialize(const HeterogeneousMap &params) {
           "Dynamically changing the number of virtual QPU's is not supported.");
     }
     n_virtual_qpus = params.get<int>("n-virtual-qpus");
+  }
+
+  if (params.keyExists<int>("shots")) {
+    shots = params.get<int>("shots");
+    if (shots < 1) {
+      xacc::error("Invalid 'shots' parameter.");
+    }
+  }
+
+  isVqeMode = (shots < 1);
+  if (params.keyExists<bool>("vqe-mode")) {
+    isVqeMode = params.get<bool>("vqe-mode");
+    if (isVqeMode) {
+      xacc::info("Enable VQE Mode.");
+    }
   }
 }
 
@@ -64,6 +98,7 @@ void HPCVirtDecorator::execute(
   // their quantum execution across the node sub-groups.
 
   // Get the rank and size in the original communicator
+  auto start = std::chrono::high_resolution_clock::now();
   int world_size, world_rank;
   MPI_Comm_size(MPI_COMM_WORLD, &world_size);
   MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
@@ -109,8 +144,14 @@ void HPCVirtDecorator::execute(
   // Give that sub communicator to the accelerator
   void *qpu_comm_ptr =
       reinterpret_cast<void *>(qpuComm->getMPICommProxy().getRef<MPI_Comm>());
-  decoratedAccelerator->updateConfiguration(
-      {{"mpi-communicator", qpu_comm_ptr}});
+
+  // this enables shot-based simulation
+  HeterogeneousMap properties;
+  properties.insert("mpi-communicator", qpu_comm_ptr);
+  if (!isVqeMode) {
+    properties.insert("shots", shots);
+  }
+  decoratedAccelerator->updateConfiguration(properties);
 
   // get the number of sub-communicators
   // Everybody split the CompositeInstructions vector into n_virtual_qpu
@@ -146,16 +187,21 @@ void HPCVirtDecorator::execute(
   }
 
   // broadcast the total number of children
-  MPI_Bcast(&nGlobalChildren, 1, MPI_INT, 0,
-            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+  qpuComm->broadcast(nGlobalChildren);
 
   // broadcast the number of children in each communicator
-  MPI_Bcast(nLocalChildren.data(), nLocalChildren.size(), MPI_INT, 0,
-            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+  qpuComm->broadcast(nLocalChildren);
 
-  // get expectation values and the size of the key of each child buffer
-  std::vector<double> globalExpVals(nGlobalChildren);
+  // get expectation values/bitstrings and the size of the key of each child buffer
   std::vector<int> globalKeySizes(nGlobalChildren);
+  std::vector<int> globalNumberBitStrings;
+  std::vector<double> globalExpVals;
+  if (isVqeMode) {
+    globalExpVals.resize(nGlobalChildren);
+  } else {
+    globalNumberBitStrings.resize(nGlobalChildren);
+  }
+
   if (world_rank == qpuComm->getProcessRanks()[0]) {
 
     // get displacements for the keys in each comm
@@ -167,46 +213,81 @@ void HPCVirtDecorator::execute(
 
     // get size of each key in the communicator
     std::vector<double> localExpVals;
-    std::vector<int> localKeySizes;
+    std::vector<int> localKeySizes, localNumberBitStrings;
     for (auto child : my_buffer->getChildren()) {
       localKeySizes.push_back(child->name().size());
-      localExpVals.push_back(child->getExpectationValueZ());
+
+      if (isVqeMode) {
+        localExpVals.push_back(child->getExpectationValueZ());
+      } else {
+        localNumberBitStrings.push_back(child->getMeasurementCounts().size());
+      }
     }
 
-    // gather all expectation values
-    MPI_Allgatherv(localExpVals.data(), localExpVals.size(), MPI_DOUBLE,
-                   globalExpVals.data(), nLocalChildren.data(),
-                   nKeyShift.data(), MPI_DOUBLE,
-                   zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
-
     // gather the size of each child key
-    MPI_Allgatherv(localKeySizes.data(), localKeySizes.size(), MPI_INT,
-                   globalKeySizes.data(), nLocalChildren.data(),
-                   nKeyShift.data(), MPI_INT,
-                   zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
+    zeroRanksComm->allGatherv(localKeySizes, globalKeySizes, nLocalChildren, nKeyShift);
+
+    if (isVqeMode) {
+      // gather all expectation values
+      zeroRanksComm->allGatherv(localExpVals, globalExpVals, nLocalChildren, nKeyShift);
+    } else {
+      // gather all bitstrings
+      zeroRanksComm->allGatherv(localNumberBitStrings, globalNumberBitStrings, nLocalChildren, nKeyShift);
+    }
+
   }
 
-  // broadcast expectation values
-  MPI_Bcast(globalExpVals.data(), globalExpVals.size(), MPI_DOUBLE, 0,
-            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
-
   // broadcast size of each key
-  MPI_Bcast(globalKeySizes.data(), globalKeySizes.size(), MPI_INT, 0,
-            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+  qpuComm->broadcast(globalKeySizes);
+
+  // broadcast results
+  if (isVqeMode) {
+    // broadcast expectation values
+    qpuComm->broadcast(globalExpVals);
+  } else {
+    // broadcast number of bit strings
+    qpuComm->broadcast(globalNumberBitStrings);
+  }
 
   // get the size of all keys
   auto nGlobalKeyChars =
       std::accumulate(globalKeySizes.begin(), globalKeySizes.end(), 0);
 
+  // get total number of measured bitstrings
+  auto nGlobalBitStrings =
+      std::accumulate(globalNumberBitStrings.begin(), globalNumberBitStrings.end(), 0);
+
   // gather all keys chars
   std::vector<char> globalKeyChars(nGlobalKeyChars);
+  std::vector<int> globalBitStrings, globalCounts;
+  if (!isVqeMode) {
+    globalBitStrings.resize(nGlobalBitStrings);
+    globalCounts.resize(nGlobalBitStrings);
+  }
   if (world_rank == qpuComm->getProcessRanks()[0]) {
 
     // get local key char arrays
+    // and local bitstrings and counts
     std::vector<char> localKeys;
+    std::vector<int> localBitStringIndices, localCounts;
     for (auto child : my_buffer->getChildren()) {
+
       for (auto c : child->name()) {
         localKeys.push_back(c);
+      }
+
+      // get bitstring decimals and counts
+      if (!isVqeMode) {
+        for (auto & count : child->getMeasurementCounts()) {
+          auto bitString = count.first;
+          // stoi is MSB
+          if (decoratedAccelerator->getBitOrder() == Accelerator::BitOrder::LSB) {
+		        std::reverse(bitString.begin(), bitString.end());
+          }
+          auto index = std::stoi(count.first, nullptr, 2);
+          localBitStringIndices.push_back(index);
+          localCounts.push_back(count.second);
+        }
       }
     }
 
@@ -227,18 +308,57 @@ void HPCVirtDecorator::execute(
     }
 
     // gather all key chars
-    MPI_Allgatherv(localKeys.data(), localKeys.size(), MPI_CHAR,
-                   globalKeyChars.data(), commKeySize.data(),
-                   keySizeShift.data(), MPI_CHAR,
-                   zeroRanksComm->getMPICommProxy().getRef<MPI_Comm>());
+    zeroRanksComm->allGatherv(localKeys, globalKeyChars, commKeySize, keySizeShift);
+
+    if (!isVqeMode) {
+
+      // get number of bit strings in the communicator
+      std::vector<int> commNumberBitStrings(n_virtual_qpus);
+      shift = 0;
+      for (int i = 0; i < n_virtual_qpus; i++) {
+        auto it = globalNumberBitStrings.begin() + shift;
+        commNumberBitStrings[i] = std::accumulate(it, it + nLocalChildren[i], 0);
+        shift += nLocalChildren[i];
+      }
+
+      // shifts for bit strings
+      std::vector<int> bitStringShift(n_virtual_qpus);
+      for (int i = 1; i < n_virtual_qpus; i++) {
+        bitStringShift[i] =
+            std::accumulate(commNumberBitStrings.begin(), commNumberBitStrings.begin() + i, 0);
+      }
+
+      // gather all bit strings
+      zeroRanksComm->allGatherv(localBitStringIndices, globalBitStrings, commNumberBitStrings, bitStringShift);
+      // gather all counts
+      zeroRanksComm->allGatherv(localCounts, globalCounts, commNumberBitStrings, bitStringShift);
+    }
+
   }
 
   // broadcast all keys
-  MPI_Bcast(globalKeyChars.data(), globalKeyChars.size(), MPI_CHAR, 0,
-            qpuComm->getMPICommProxy().getRef<MPI_Comm>());
+  qpuComm->broadcast(globalKeyChars);
+
+  if (!isVqeMode) {
+   // broadcast indices
+    qpuComm->broadcast(globalBitStrings);
+    qpuComm->broadcast(globalCounts);
+  }
+
+  // get binary from decimal
+  const auto getBinary = [=](int n){
+    std::string s;
+    while (n != 0) {
+      s += (n % 2 == 0 ? "0" : "1" );
+      n /= 2;
+    }
+    //s += std::string(buffer->size() - s.size(), '0');
+    std::reverse(s.begin(), s.end());
+    return s;
+  };
 
   // now every process has everything to rebuild the buffer
-  int shift = 0;
+  int shift = 0, countShift = 0;
   for (int i = 0; i < nGlobalChildren; i++) {
 
     // get child name
@@ -248,7 +368,26 @@ void HPCVirtDecorator::execute(
     // create child buffer and append it to buffer
     auto child = xacc::qalloc(buffer->size());
     child->setName(name);
-    child->addExtraInfo("exp-val-z", globalExpVals[i]);
+
+    if (isVqeMode) {
+      child->addExtraInfo("exp-val-z", globalExpVals[i]);
+    } else {
+
+      auto nChildBitStrings = globalNumberBitStrings[i];
+      for (int b = 0; b < nChildBitStrings; b++) {
+
+        auto counts = globalCounts[b + countShift];
+        if (counts == 0) std::cout << "GOTCHA\n";
+        auto bitStringDecimal = globalBitStrings[b + countShift];
+        auto nBits = name.length() / 2;
+        auto bitString = getBinary(bitStringDecimal);
+        //auto bitString = getBinary(bitStringDecimal, nBits);
+        child->appendMeasurement(bitString, counts);
+
+      }
+      countShift += nChildBitStrings;
+    }
+
     buffer->appendChild(name, child);
     shift += globalKeySizes[i];
   }
@@ -260,6 +399,37 @@ void HPCVirtDecorator::execute(
 
   return;
 }
+
+void HPCVirtDecorator::finalize() {
+  if (qpuComm) {
+    // Make sure we explicitly release this so that MPICommProxy is destroyed
+    // before framework shutdown (MPI_Finalize if needed)
+    qpuComm.reset();
+  }
+}
+
+class HPCVirtTearDown : public xacc::TearDown {
+public:
+  virtual void tearDown() override {
+    auto c = xacc::getService<xacc::AcceleratorDecorator>("hpc-virtualization", false);
+    if (c) {
+      auto casted = std::dynamic_pointer_cast<xacc::quantum::HPCVirtDecorator>(c);
+      assert(casted);
+      casted->finalize();
+    }
+
+    int finalized, initialized;
+    MPI_Initialized(&initialized);
+    if (initialized) {
+      MPI_Finalized(&finalized);
+      if (!finalized && hpcVirtDecoratorInitializedMpi) {
+        MPI_Finalize();
+      }
+    }
+  }
+  virtual std::string name() const override { return "xacc-hpc-virt"; }
+};
+
 
 } // namespace quantum
 } // namespace xacc
@@ -282,6 +452,7 @@ public:
 
     context.RegisterService<xacc::AcceleratorDecorator>(c);
     context.RegisterService<xacc::Accelerator>(c);
+    context.RegisterService<xacc::TearDown>(std::make_shared<xacc::quantum::HPCVirtTearDown>());
   }
 
   /**

--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
@@ -14,7 +14,7 @@
 #ifndef XACC_HPC_VIRT_DECORATOR_HPP_
 #define XACC_HPC_VIRT_DECORATOR_HPP_
 
-#include "mpi.h"
+//#include "mpi.h"
 #include "xacc.hpp"
 #include "MPIProxy.hpp"
 #include "AcceleratorDecorator.hpp"
@@ -26,7 +26,8 @@ namespace quantum {
 class HPCVirtDecorator : public AcceleratorDecorator {
 protected:
 
-  int n_virtual_qpus = 1;
+  bool isVqeMode;
+  int n_virtual_qpus = 1, shots = -1;
   // The MPI communicator for each QPU
   std::shared_ptr<ProcessGroup> qpuComm;
 
@@ -45,31 +46,30 @@ public:
 
   const std::string name() const override { return "hpc-virtualization"; }
   const std::string description() const override { return ""; }
+  void finalize();
 
-  ~HPCVirtDecorator() override { }
+  ~HPCVirtDecorator() override { };
 
 private:
-  template <typename T>
-  std::vector<std::vector<T>> split_vector(const std::vector<T> &vec,
-                                           size_t n) {
-    std::vector<std::vector<T>> outVec;
 
-    size_t length = vec.size() / n;
-    size_t remain = vec.size() % n;
+template <typename T>
+std::vector<std::vector<T>> split_vector(const std::vector<T>& inputVector, size_t numSegments) {
+    std::vector<std::vector<T>> result;
 
-    size_t begin = 0;
-    size_t end = 0;
+    size_t inputSize = inputVector.size();
+    size_t segmentSize = (inputSize + numSegments - 1) / numSegments; // Ceiling division
 
-    for (size_t i = 0; i < std::min(n, vec.size()); ++i) {
-      end += (remain > 0) ? (length + !!(remain--)) : length;
+    auto begin = inputVector.begin();
+    auto end = inputVector.end();
 
-      outVec.push_back(std::vector<T>(vec.begin() + begin, vec.begin() + end));
-
-      begin = end;
+    for (size_t i = 0; i < numSegments; ++i) {
+        auto segmentEnd = std::next(begin, std::min(segmentSize, static_cast<size_t>(std::distance(begin, end))));
+        result.emplace_back(begin, segmentEnd);
+        begin = segmentEnd;
     }
 
-    return outVec;
-  }
+    return result;
+}
 };
 
 } // namespace quantum

--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
@@ -27,7 +27,7 @@ class HPCVirtDecorator : public AcceleratorDecorator {
 protected:
 
   bool isVqeMode;
-  int n_virtual_qpus = 1, shots = -1;
+  int n_virtual_qpus = 1, shots;
   // The MPI communicator for each QPU
   std::shared_ptr<ProcessGroup> qpuComm;
 

--- a/quantum/plugins/decorators/hpc-virtualization/tests/HpcVirtTester.cpp
+++ b/quantum/plugins/decorators/hpc-virtualization/tests/HpcVirtTester.cpp
@@ -173,13 +173,13 @@ std::shared_ptr<xacc::Observable> getH(const int nq) {
 TEST(HpcVirtTester, checkH2) {
   const int n_virt_qpus = 2;
   const int n_layers = 10;
-  const std::string acc = "qpp";
+  const std::string acc = "qsim";
   xacc::set_verbose(true);
   xacc::ScopeTimer timer("mpi_timing", false);
   auto accelerator = xacc::getAccelerator(acc);
   accelerator = xacc::getAcceleratorDecorator(
       "hpc-virtualization", accelerator,
-      {{"vqe-mode", false}, {"n-virtual-qpus", n_virt_qpus}});
+      {{"vqe-mode", true}, {"n-virtual-qpus", n_virt_qpus}});
   auto buffer = xacc::qalloc(2);
   auto observable = xacc::quantum::getObservable(
       "pauli", std::string("-0.349833 - 0.388748 Z0 - 0.388748 Z1 + 0.181771 "
@@ -222,7 +222,7 @@ TEST(HpcVirtTester, checkMcVQE) {
   auto accelerator = xacc::getAccelerator(acc);
   accelerator = xacc::getAcceleratorDecorator(
       "hpc-virtualization", accelerator,
-      {{"vqe-mode", false}, {"n-virtual-qpus", n_virt_qpus}});
+      {{"vqe-mode", true}, {"n-virtual-qpus", n_virt_qpus}});
   auto buffer = xacc::qalloc(nq);
 
   auto ansatz = getCircuit(nq);
@@ -255,7 +255,7 @@ TEST(HpcVirtTester, checkMcVQE) {
 }
 
 TEST(HpcVirtTester, checkGradients) {
-  auto accelerator = xacc::getAccelerator("qpp");
+  auto accelerator = xacc::getAccelerator("qsim");
   accelerator = xacc::getAcceleratorDecorator("hpc-virtualization", accelerator,
                                               {{"n-virtual-qpus", 2}});
   auto buffer = xacc::qalloc(3);

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -30,10 +30,6 @@
 #include <sys/stat.h>
 #include "TearDown.hpp"
 
-#ifdef MPI_ENABLED
-#include "mpi.h"
-#endif
-
 using namespace cxxopts;
 
 namespace xacc {
@@ -51,11 +47,6 @@ std::map<std::string, std::shared_ptr<CompositeInstruction>>
 std::map<std::string, std::shared_ptr<AcceleratorBuffer>> allocated_buffers{};
 
 std::string rootPathString = "";
-
-#ifdef MPI_ENABLED
-int isMPIInitialized;
-#endif
-
 void set_verbose(bool v) { verbose = v; }
 
 int getArgc() { return argc; }
@@ -116,18 +107,6 @@ void Initialize(int arc, char **arv) {
     XACCLogger::instance()->dumpQueue();
   }
 
-  // Initializing MPI here
-#ifdef MPI_ENABLED
-  int provided;
-  MPI_Initialized(&isMPIInitialized);
-  if (!isMPIInitialized) {
-    MPI_Init_thread(0, NULL, MPI_THREAD_MULTIPLE, &provided);
-    if (provided != MPI_THREAD_MULTIPLE) {
-      xacc::warning("MPI_THREAD_MULTIPLE not provided.");
-    }
-    isMPIInitialized = 1;
-  }
-#endif
 }
 
 void setIsPyApi() { isPyApi = true; }
@@ -869,12 +848,6 @@ void Finalize() {
     compilation_database.clear();
     allocated_buffers.clear();
     xacc::ServiceAPI_Finalize();
-    // This replaces the HPC virtualization TearDown
-#ifdef MPI_ENABLED
-    if (isMPIInitialized) {
-      MPI_Finalize();
-    }
-#endif
   }
 }
 


### PR DESCRIPTION
This PR incorporates the fixes suggested in #551 and:
 - Enables shot simulations
 - Provides wrappers to native MPI calls