### PR TITLE
Fix: XACC install failure with Qrack - error: conversion from ‘BigInteger’ to ‘bool’ is ambiguous

### DIFF
--- a/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
+++ b/quantum/plugins/qrack/accelerator/QrackVisitor.cpp
@@ -89,7 +89,7 @@ namespace quantum {
         for (auto it = measureDist.begin(); it != measureDist.end(); it++) {
             std::string bitString = "";
             for (int i = 0; i < m_measureBits.size(); i++) {
-                bitString.append((Qrack::pow2(i) & it->first) ? "1" : "0"); 
+                bitString.append(bi_compare_0((Qrack::pow2(i) & it->first)) ? "1" : "0"); 
             }
             for (int j = 0; j < it->second; j++) {
                 m_buffer->appendMeasurement(bitString);


### PR DESCRIPTION
Issue: #584 
This pull request addresses an issue encountered during the installation of XACC with the Qrack quantum computing framework. The problem arises from an ambiguous conversion error occurring in the codebase, specifically in the context of a conversion from BigInteger to bool.
 ```vebnet
 error: conversion from ‘BigInteger’ to ‘bool’ is ambiguous
 ```

This modification ensures that the result of the bitwise AND operation is explicitly compared to zero using bi_compare_0, providing a clear and unambiguous boolean result for the ternary conditional operator.





